### PR TITLE
Added changes when handling 500 and path

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -101,7 +101,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     functionData.errorExceptionType = typeof err;
     functionData.errorExceptionMessage = err.message;
     functionData.errorExceptionStacktrace = err.stack;
-  } else if (pathData['http.status_code']) {
+  } else if (pathData['http.status_code'] >= 500) {
     // This happens if we get a 500 status code set explicity within in the app
     functionData.error = true;
     functionData.errorCulprit = 'internal server error';

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -278,7 +278,6 @@ const instrumentations = [
         } else {
           eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
         }
-        eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
         eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.httpMethod;
         eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
         eventData[context.awsRequestId].eventCustomRequestTimeEpoch =

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -76,6 +76,16 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
   functionData.startTime = st.getTime();
   functionData.endTime = et.getTime();
 
+  if (!err && !res) {
+    pathData['http.status_code'] = 500;
+  } else if (pathData) {
+    let statusCode = (res || {}).statusCode || 200;
+    if (err && !(res || {}).statusCode) {
+      statusCode = 500;
+    }
+    pathData['http.status_code'] = statusCode;
+  }
+
   functionData.error = false;
   functionData.timeout = isTimeout;
   if (isTimeout) {
@@ -91,16 +101,13 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     functionData.errorExceptionType = typeof err;
     functionData.errorExceptionMessage = err.message;
     functionData.errorExceptionStacktrace = err.stack;
-  }
-
-  if (!err && !res) {
-    pathData['http.status_code'] = 500;
-  } else if (pathData) {
-    let statusCode = (res || {}).statusCode || 200;
-    if (err && !(res || {}).statusCode) {
-      statusCode = 500;
-    }
-    pathData['http.status_code'] = statusCode;
+  } else if (pathData['http.status_code']) {
+    // This happens if we get a 500 status code set explicity within in the app
+    functionData.error = true;
+    functionData.errorCulprit = 'internal server error';
+    functionData.errorExceptionType = typeof new Error();
+    functionData.errorExceptionMessage = 'internal server error';
+    functionData.errorExceptionStacktrace = 'internal server error';
   }
 
   const grouped = spans.reduce((obj, val) => {
@@ -265,6 +272,12 @@ const instrumentations = [
         eventData[context.awsRequestId].eventCustomApiId = event.requestContext.apiId;
         eventData[context.awsRequestId].eventSource = 'aws.apigateway';
         eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
+        if (/{proxy\+}/.test(event.requestContext.resourcePath)) {
+          // Raw path from the requests instead of proxy
+          eventData[context.awsRequestId].httpPath = event.path;
+        } else {
+          eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
+        }
         eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
         eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.httpMethod;
         eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
@@ -276,7 +289,12 @@ const instrumentations = [
         eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
         const routeKey = event.requestContext.routeKey;
         const path = routeKey.split(' ')[1];
-        eventData[context.awsRequestId].httpPath = path;
+        if (/{proxy\+}/.test(path)) {
+          // Raw path from the requests instead of proxy
+          eventData[context.awsRequestId].httpPath = event.rawPath;
+        } else {
+          eventData[context.awsRequestId].httpPath = path;
+        }
         eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.http.method;
         eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
         eventData[context.awsRequestId].eventCustomRequestTimeEpoch =


### PR DESCRIPTION
## Description
I made a small change to also mark any requests as an error request that respond with a status code of 500 or greater.

I also made a change to not save the `/{proxy+}` as the `httpPath` and instead save the full path. This change was made so if we are using an express/koa app and we try and request a route that doesn't exist we will send the full path rather than the `/{proxy+}` path to our telemetry backend 👍 