### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -195,7 +195,6 @@ jobs:
           npm run test:integration
 
       - name: Tag if new version
-        if: false # TODO: remove once packages/aws-lambda-otel-extension/package.json lands in master
         run: |
           NEW_VERSION=`git diff -U0 ${{ github.event.before }} packages/aws-lambda-otel-extension/package.json | grep '"version": "' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$NEW_VERSION" ];

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
This should now automatically release `0.1.0` of `@serverless/aws-lambda-otel-extension` and `@serverless/aws-lambda-otel-extension-dist` (ready artifact file to be used by the Framework)