### PR TITLE
bug: fixed logs on timeout and express root path

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
@@ -199,6 +199,8 @@ const receiverAddress = () => {
   return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 };
 
+const SAVE_FILE = '/tmp/sls-save-log.json';
+
 const RECEIVER_PORT = 4243;
 const TIMEOUT_MS = 25; // Maximum time (in milliseconds) that a batch is buffered.
 const MAX_BYTES = 262144; // Maximum size in bytes that the logs are buffered in memory.
@@ -219,6 +221,7 @@ const SUBSCRIPTION_BODY = {
 };
 
 module.exports = {
+  SAVE_FILE,
   logMessage,
   receiverAddress,
   RECEIVER_PORT,

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
@@ -4,6 +4,7 @@
 
 const { unzip: unzipWtithCallback } = require('zlib');
 const { promisify } = require('util');
+const { writeFileSync } = require('fs');
 const get = require('lodash.get');
 const { register, next } = require('./lambda-apis/extensions-api');
 const { subscribe } = require('./lambda-apis/logs-api');
@@ -15,6 +16,7 @@ const {
   receiverAddress,
   RECEIVER_PORT,
   SUBSCRIPTION_BODY,
+  SAVE_FILE,
 } = require('./helper');
 const { createMetricsPayload, createTracePayload } = require('./otel-payloads');
 
@@ -212,6 +214,7 @@ module.exports = (async function main() {
       await uploadLogs(logsQueue);
 
       logMessage('DONE...', JSON.stringify(logsQueue));
+      writeFileSync(SAVE_FILE, JSON.stringify(logsQueue));
       server.close();
       break;
     } else if (event.eventType === EventType.INVOKE) {
@@ -235,6 +238,7 @@ module.exports = (async function main() {
       if (logLength < logsQueue.length) {
         await uploadLogs(logsQueue);
       }
+      writeFileSync(SAVE_FILE, JSON.stringify(logsQueue));
     } else {
       throw new Error(`unknown event: ${event.eventType}`);
     }

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
@@ -1,10 +1,19 @@
 'use strict';
 
 const http = require('http');
-const { logMessage } = require('./../helper');
+const { readFileSync, existsSync } = require('fs');
+const { logMessage, SAVE_FILE } = require('./../helper');
 
 function listen(address, port) {
-  const logsQueue = [];
+  let logsQueue = [];
+
+  if (existsSync(SAVE_FILE)) {
+    try {
+      logsQueue = JSON.parse(readFileSync(SAVE_FILE, { encoding: 'utf-8' }));
+    } catch (error) {
+      logMessage('Failed to parse logs queue file');
+    }
+  }
 
   // init HTTP server for the Logs API subscription
   const server = http.createServer((request, response) => {

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -15,7 +15,7 @@ const S3_BUCKET = process.env.SLS_OTEL_REPORT_S3_BUCKET;
 const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // aws-sdk is provided in Lambda runtime
 // eslint-disable-next-line import/no-unresolved
-const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
+const s3Client = null; // S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
 const fetch = require('node-fetch');
 
 const processData = async (data, { url, s3Key, protobufPath, protobufType }) => {

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -15,7 +15,7 @@ const S3_BUCKET = process.env.SLS_OTEL_REPORT_S3_BUCKET;
 const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // aws-sdk is provided in Lambda runtime
 // eslint-disable-next-line import/no-unresolved
-const s3Client = null; // S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
+const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
 const fetch = require('node-fetch');
 
 const processData = async (data, { url, s3Key, protobufPath, protobufType }) => {

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Description
This was an issue I had brought up a while back and it seems like if you have a lambda function that times out on every request the `logQueue` variable is reset after each invocation.

Also I adjusted the express path detection to also include paths that are able to be resolved normally via express. (So far I have only seen this happen at the base path but there could be others so it is probably be we do this anyway 🤷)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201895027212527