### PR TITLE
refactor: Send trace and reports async

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
@@ -211,7 +211,7 @@ const SUBSCRIPTION_BODY = {
     protocol: 'HTTP',
     URI: `http://${RECEIVER_NAME}:${RECEIVER_PORT}`,
   },
-  types: ['platform', 'function'],
+  types: ['platform'],
   buffering: {
     timeoutMs: TIMEOUT_MS,
     maxBytes: MAX_BYTES,

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
@@ -200,7 +200,10 @@ const receiverAddress = () => {
 };
 
 const SAVE_FILE = '/tmp/sls-save-log.json';
+const SENT_FILE = '/tmp/sent-requests.json';
 
+const OTEL_SERVER_PORT = 2772;
+const OTEL_SERVER_HOST = 'localhost';
 const RECEIVER_PORT = 4243;
 const TIMEOUT_MS = 25; // Maximum time (in milliseconds) that a batch is buffered.
 const MAX_BYTES = 262144; // Maximum size in bytes that the logs are buffered in memory.
@@ -222,6 +225,9 @@ const SUBSCRIPTION_BODY = {
 
 module.exports = {
   SAVE_FILE,
+  SENT_FILE,
+  OTEL_SERVER_PORT,
+  OTEL_SERVER_HOST,
   logMessage,
   receiverAddress,
   RECEIVER_PORT,

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
@@ -17,6 +17,8 @@ const {
   RECEIVER_PORT,
   SUBSCRIPTION_BODY,
   SAVE_FILE,
+  SENT_FILE,
+  OTEL_SERVER_PORT,
 } = require('./helper');
 const { createMetricsPayload, createTracePayload } = require('./otel-payloads');
 
@@ -36,7 +38,6 @@ if (existsSync(SAVE_FILE)) {
     logMessage('Failed to parse logs queue file');
   }
 }
-const SENT_FILE = '/tmp/sent-requests.json';
 if (existsSync(SENT_FILE)) {
   try {
     sentRequests = JSON.parse(readFileSync(SENT_FILE, { encoding: 'utf-8' }));
@@ -222,7 +223,7 @@ module.exports = (async function main() {
 
   const { server: otelServer } = listen({
     logsQueue,
-    port: 2772,
+    port: OTEL_SERVER_PORT,
     callback: async (...args) => {
       await uploadLogs(...args);
       receivedData = true;

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/index.js
@@ -104,7 +104,7 @@ module.exports = (async function main() {
   };
 
   // function for processing collected logs
-  async function uploadLogs(logList, focusIds) {
+  async function uploadLogs(logList, focusIds = []) {
     const currentIndex = logList.length;
     const groupedByRequestId = await groupLogs(logList);
 
@@ -298,7 +298,9 @@ module.exports = (async function main() {
           }, 50);
         });
       /* eslint-enable no-loop-func */
-      await waitRecursive();
+      if (!process.env.DO_NOT_WAIT) {
+        await waitRecursive();
+      }
       writeFileSync(SENT_FILE, JSON.stringify(sentRequests));
       writeFileSync(SAVE_FILE, JSON.stringify(logsQueue));
       receivedData = false; // Reset received event

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
@@ -1,20 +1,10 @@
 'use strict';
 
 const http = require('http');
-const { readFileSync, existsSync } = require('fs');
 const { logMessage, SAVE_FILE } = require('./../helper');
+const { writeFileSync } = require('fs');
 
-function listen(address, port) {
-  let logsQueue = [];
-
-  if (existsSync(SAVE_FILE)) {
-    try {
-      logsQueue = JSON.parse(readFileSync(SAVE_FILE, { encoding: 'utf-8' }));
-    } catch (error) {
-      logMessage('Failed to parse logs queue file');
-    }
-  }
-
+function listen({ port, address, logsQueue, callback }) {
   // init HTTP server for the Logs API subscription
   const server = http.createServer((request, response) => {
     if (request.method === 'POST') {
@@ -25,18 +15,32 @@ function listen(address, port) {
       request.on('end', () => {
         try {
           const batch = JSON.parse(body);
-          logMessage('Current data before write: ', JSON.stringify(logsQueue));
+          if (address) {
+            logMessage('Current data before write: ', JSON.stringify(logsQueue));
+          } else {
+            logMessage('BATCH FROM CUSTOM HTTP SERVER: ', body, JSON.stringify(batch));
+          }
           if (batch.length > 0) {
-            logsQueue.push(
-              batch.filter((log) => {
-                if (log.type === 'platform.report') {
-                  return true;
-                } else if (log.type === 'function' && log.record.includes('⚡.')) {
-                  return true;
-                }
-                return false;
-              })
-            );
+            const logBatch = batch.filter((log) => {
+              if (log.type === 'platform.report') {
+                return true;
+              } else if (log.type === 'function' && log.record.includes('⚡.')) {
+                return true;
+              }
+              return false;
+            });
+            logsQueue.push(logBatch);
+            writeFileSync(SAVE_FILE, JSON.stringify(logsQueue));
+
+            if (callback && logBatch.length > 0) {
+              const reportIds = logBatch.map(
+                (log) => log.record.requestId || log.record.split('\t')[1]
+              );
+              callback(logsQueue, reportIds);
+            }
+          }
+          if (!address) {
+            logMessage('FROM CUSTOM HTTP SERVER: ', JSON.stringify(logsQueue));
           }
         } catch (e) {
           logMessage('failed to parse logs', e);

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/lambda-apis/http-listener.js
@@ -39,7 +39,7 @@ function listen(address, port) {
             );
           }
         } catch (e) {
-          console.log('failed to parse logs');
+          logMessage('failed to parse logs', e);
         }
         response.writeHead(200, {});
         response.end('OK');

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -15,7 +15,7 @@ const S3_BUCKET = process.env.SLS_OTEL_REPORT_S3_BUCKET;
 const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // aws-sdk is provided in Lambda runtime
 // eslint-disable-next-line import/no-unresolved
-const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
+const s3Client = null; // S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
 const fetch = require('node-fetch');
 const { logMessage } = require('./helper');
 

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -15,7 +15,7 @@ const S3_BUCKET = process.env.SLS_OTEL_REPORT_S3_BUCKET;
 const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // aws-sdk is provided in Lambda runtime
 // eslint-disable-next-line import/no-unresolved
-const s3Client = null; // S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
+const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
 const fetch = require('node-fetch');
 const { logMessage } = require('./helper');
 

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -17,6 +17,7 @@ const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // eslint-disable-next-line import/no-unresolved
 const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
 const fetch = require('node-fetch');
+const { logMessage } = require('./helper');
 
 const processData = async (data, { url, s3Key, protobufPath, protobufType }) => {
   if (REPORT_TYPE === 'proto') {
@@ -34,12 +35,12 @@ const processData = async (data, { url, s3Key, protobufPath, protobufType }) => 
                     resolve(ServiceRequest.encode(datum).finish());
                     // const message = Buffer.from(encoded).toString('base64');
                   } catch (error) {
-                    console.log('Buffer error: ', error);
+                    logMessage('Buffer error: ', error);
                     resolve(null);
                   }
                 });
               } catch (error) {
-                console.log('Could not convert to proto buff', error);
+                logMessage('Could not convert to proto buff: ', error);
                 resolve(null);
               }
             })

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -248,9 +248,6 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     },
   });
 
-  // TODO: Replace with process.stdout.write once extension does not depend on requestId being in logs
-  // console.log(logString);
-
   // Reset the exporter so we don't see duplicates
   memoryExporter.reset();
 };

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -24,7 +24,7 @@ const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
 const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
 const { diag, DiagConsoleLogger } = require('@opentelemetry/api');
 const fetch = require('node-fetch');
-const { logMessage } = require('./helper');
+const { logMessage, OTEL_SERVER_PORT, OTEL_SERVER_HOST } = require('./helper');
 const SlsSpanProcessor = require('./span.processor');
 const { detectEventType } = require('./eventDetection');
 
@@ -234,7 +234,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     })
   ).toString('base64')}`;
 
-  await fetch('http://localhost:2772', {
+  await fetch(`http://${OTEL_SERVER_HOST}:${OTEL_SERVER_PORT}`, {
     method: 'post',
     body: JSON.stringify([
       {

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -234,7 +234,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     })
   ).toString('base64')}`;
 
-  await fetch(`http://${OTEL_SERVER_HOST}:${OTEL_SERVER_PORT}`, {
+  await fetch(`http://${OTEL_SERVER_HOST}:${process.env.MOCK_PORT || OTEL_SERVER_PORT}`, {
     method: 'post',
     body: JSON.stringify([
       {

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",

--- a/packages/aws-lambda-otel-extension/test/unit/extension.test.js
+++ b/packages/aws-lambda-otel-extension/test/unit/extension.test.js
@@ -19,6 +19,7 @@ describe('extension', () => {
   });
 
   it('should handle plain success invocation', async () => {
+    process.env.DO_NOT_WAIT = true;
     const emitter = new EventEmitter();
     const { server, listenerEmitter } = getExtensionServerMock(emitter);
 
@@ -93,6 +94,7 @@ describe('extension', () => {
     ]);
 
     await extensionProcess;
+    delete process.env.DO_NOT_WAIT;
     server.close();
     log.debug('report string %s', stdoutData);
     const [[metricsReport], [tracesReport]] = stdoutData

--- a/packages/aws-lambda-otel-extension/test/unit/wrapper.test.js
+++ b/packages/aws-lambda-otel-extension/test/unit/wrapper.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const http = require('http');
 const path = require('path');
 const { promisify } = require('util');
 const unzip = promisify(require('zlib').unzip);
@@ -17,11 +18,44 @@ describe('wrapper', () => {
     process.env.LAMBDA_TASK_ROOT = lambdaFixturesDirname;
   });
 
-  it('should handle plain success invocation', async () => {
+  it('should handle plain success invocation', (done) => {
     process.env._HANDLER = 'callback-success.handler';
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'callback-success';
     let stdoutData = '';
-    await overwriteStdoutWrite(
+
+    let logsQueue = [];
+    const server = http.createServer((request, response) => {
+      if (request.method === 'POST') {
+        let body = '';
+        request.on('data', (data) => {
+          body += data;
+        });
+        request.on('end', async () => {
+          response.writeHead(200, {});
+          response.end('OK');
+          server.close();
+          const batch = JSON.parse(body);
+          logsQueue = batch;
+
+          expect(logsQueue.length).to.equal(1);
+          const reportLog = logsQueue[0].record.split('\t')[2];
+
+          const reportCompressed = reportLog.slice(reportLog.indexOf('⚡.') + 2);
+          const report = JSON.parse(String(await unzip(Buffer.from(reportCompressed, 'base64'))));
+          log.debug('result report: %o', report);
+          expect(report.function['telemetry.sdk.language']).to.equal('nodejs');
+          expect(report.function['telemetry.sdk.name']).to.equal('opentelemetry');
+          expect(report.function['faas.name']).to.equal('callback-success');
+          expect(report.function.error).to.equal(false);
+          done();
+        });
+      }
+    });
+
+    process.env.MOCK_PORT = 4123;
+    server.listen(process.env.MOCK_PORT);
+
+    overwriteStdoutWrite(
       (data) => (stdoutData += data),
       async () =>
         requireUncached(async () => {
@@ -39,13 +73,5 @@ describe('wrapper', () => {
           });
         })
     );
-    const reportLog = stdoutData.split('\n').find((logLine) => logLine.includes('⚡.'));
-    const reportCompressed = reportLog.slice(reportLog.indexOf('⚡.') + 2);
-    const report = JSON.parse(String(await unzip(Buffer.from(reportCompressed, 'base64'))));
-    log.debug('result report: %o', report);
-    expect(report.function['telemetry.sdk.language']).to.equal('nodejs');
-    expect(report.function['telemetry.sdk.name']).to.equal('opentelemetry');
-    expect(report.function['faas.name']).to.equal('callback-success');
-    expect(report.function.error).to.equal(false);
   });
 });

--- a/packages/aws-lambda-otel-extension/test/utils/get-extension-server-mock.js
+++ b/packages/aws-lambda-otel-extension/test/utils/get-extension-server-mock.js
@@ -85,7 +85,7 @@ module.exports = (emitter) => {
         request.on('data', (data) => (body += data));
         request.on('end', () => {
           const data = JSON.parse(body);
-          expect(data.types).to.deep.equal(['platform', 'function']);
+          expect(data.types).to.deep.equal(['platform']);
           expect(data.destination).to.have.property('URI');
           logsUrl = data.destination.URI;
           const statusCode = 200;


### PR DESCRIPTION
## Description
This PR is changing the way we send traces and metrics to our backend service.

Previously we were sending traces and all of our metrics in once we received them from the logs API. This caused a pretty severe delay in when we would receive data because we would have to wait for the `platform.report` to be posted to the logs API.

To solve this problem we are now just going to send data to the backend services the moment we have it available. This will result in the following

The following will be sent immediately after each invocation

- Traces
- `faas.invocation` metric

This set of metrics will be sent once we receive the `platform.report` log message

- `faas.memory` metric
- `faas.duration` metric

There are still some cases (like in a lambda timeout scenario) where it is possible the traces and `faas.invocation` will be sent at a later invocation or shutdown but this will prevent us from having to wait for these metrics in most cases.