### PR TITLE
fix: Fixed function errors and trace overflow

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/helper.js
@@ -107,8 +107,8 @@ const resourceAttributes = [
   },
   {
     key: 'faas.collector_version',
-    value: '@serverless/aws-lambda-otel-extension-0.1.9',
-    source: '@serverless/aws-lambda-otel-extension-0.1.9',
+    value: '@serverless/aws-lambda-otel-extension-0.1.10',
+    source: '@serverless/aws-lambda-otel-extension-0.1.10',
     type: 'stringValue',
   },
 ];

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/report-otel-data.js
@@ -33,7 +33,6 @@ const processData = async (data, { url, s3Key, protobufPath, protobufType }) => 
 
                     const ServiceRequest = root.lookupType(protobufType);
                     resolve(ServiceRequest.encode(datum).finish());
-                    // const message = Buffer.from(encoded).toString('base64');
                   } catch (error) {
                     logMessage('Buffer error: ', error);
                     resolve(null);

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -113,7 +113,10 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     functionData.errorExceptionType = typeof err;
     functionData.errorExceptionMessage = err.message;
     functionData.errorExceptionStacktrace = err.stack;
-  } else if (pathData['http.status_code'] >= 500) {
+  } else if (
+    pathData['http.status_code'] >= 500 &&
+    ['aws.apigateway.http', 'aws.apigatewayv2.http'].includes(functionData.eventType)
+  ) {
     // This happens if we get a 500 status code set explicity within in the app
     functionData.error = true;
     functionData.errorCulprit = 'internal server error';
@@ -169,7 +172,9 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
         const endTime = val.endTime || [0, 0];
 
         let attributes = val.attributes;
-        if (firstThing.instrumentationLibrary.name === '@opentelemetry/instrumentation-aws-lambda') {
+        if (
+          firstThing.instrumentationLibrary.name === '@opentelemetry/instrumentation-aws-lambda'
+        ) {
           attributes = {
             ...val.attributes,
             ...pathData,

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/wrapper.js
@@ -167,6 +167,15 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
         const { traceId, spanId } = val.spanContext();
         const startTime = val.startTime || [0, 0];
         const endTime = val.endTime || [0, 0];
+
+        let attributes = val.attributes;
+        if (firstThing.instrumentationLibrary.name === '@opentelemetry/instrumentation-aws-lambda') {
+          attributes = {
+            ...val.attributes,
+            ...pathData,
+          };
+        }
+
         return {
           traceId,
           spanId,
@@ -180,10 +189,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
           kind: 'SPAN_KIND_SERVER',
           startTimeUnixNano: `${startTime[0] * 1000000000 + startTime[1]}`,
           endTimeUnixNano: `${endTime[0] * 1000000000 + endTime[1]}`,
-          attributes: {
-            ...val.attributes,
-            ...pathData,
-          },
+          attributes,
           status: {},
         };
       })

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Description
Fixed 3 issues we found when testing

- Only add the pathData on the top level @opentelemetry/instrumentation-aws-lambda span
- Mark execution as an error with status_code 500 only if the function was invoked with an API gateway event
- Break up the trace payloads into smaller chunks so that kinesis records are not too large (Probably only 100 spans per library)