### PR TITLE
chore: Fixed timestamp and add order property

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/helper.js
@@ -107,8 +107,8 @@ const resourceAttributes = [
   },
   {
     key: 'faas.collector_version',
-    value: '@serverless/aws-lambda-otel-extension-0.2.4',
-    source: '@serverless/aws-lambda-otel-extension-0.2.4',
+    value: '@serverless/aws-lambda-otel-extension-0.2.5',
+    source: '@serverless/aws-lambda-otel-extension-0.2.5',
     type: 'stringValue',
   },
 ];

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/index.js
@@ -253,7 +253,6 @@ module.exports = (async function main() {
   const { server } = listen({
     port: RECEIVER_PORT,
     address: receiverAddress(),
-    mainEventData,
     logsQueue,
     liveLogData,
     liveLogCallback: postLiveLogs,

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
@@ -177,7 +177,7 @@ const createLogPayload = (fun, logs) => {
       SeverityText: severityLevelNames.has(split[2]) ? split[2] : undefined,
       SeverityNumber: severityNumberMap[split[2]],
       Body: log.record || '',
-      ReceptionOrderId: process.hrtime.bigint().toString(),
+      ProcessingOrderId: process.hrtime.bigint().toString(),
     };
   });
 };

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
@@ -177,6 +177,7 @@ const createLogPayload = (fun, logs) => {
       SeverityText: severityLevelNames.has(split[2]) ? split[2] : undefined,
       SeverityNumber: severityNumberMap[split[2]],
       Body: log.record || '',
+      order: process.hrtime.bigint().toString(),
     };
   });
 };

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
@@ -177,7 +177,7 @@ const createLogPayload = (fun, logs) => {
       SeverityText: severityLevelNames.has(split[2]) ? split[2] : undefined,
       SeverityNumber: severityNumberMap[split[2]],
       Body: log.record || '',
-      order: process.hrtime.bigint().toString(),
+      ReceptionOrderId: process.hrtime.bigint().toString(),
     };
   });
 };

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/otel-payloads.js
@@ -169,7 +169,7 @@ const createLogPayload = (fun, logs) => {
   return logs.map((log) => {
     const split = (log.record || '').split('\t');
     return {
-      Timestamp: split[0] ? new Date(split[0]).getTime() : new Date().getTime(),
+      Timestamp: new Date(log.time).getTime(),
       Attributes: resourceAtt,
       Resource: metricsAtt,
       TraceId: spanData.traceId,

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Description
I am fixing the timestamp property to use the timestamp that is attached to the log api record and adding an order property to the log record that is sent to the API so we know what order the logs came in at.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202009458998787