### PR TITLE
Replace otel internal Lambda wrapper

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/.eslintrc.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/.eslintrc.js
@@ -16,4 +16,10 @@ module.exports = {
     ],
     'no-console': 'off',
   },
+  overrides: [
+    {
+      files: ['internal/prepare-wrapper.js'],
+      parserOptions: { ecmaVersion: 2020 },
+    },
+  ],
 };

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/aws-lambda-instrumentation.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/aws-lambda-instrumentation.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { AwsLambdaInstrumentation } = require('@opentelemetry/instrumentation-aws-lambda');
+
+AwsLambdaInstrumentation.prototype.init = function () {
+  // Turn off lambda wrapping as introduced by this class due to its limitations
+  if (AwsLambdaInstrumentation._instance) {
+    throw new Error('Unexpected doubled initialization');
+  }
+  // Expose instance for our custom wrapping needs
+  AwsLambdaInstrumentation._instance = this;
+};
+
+module.exports = AwsLambdaInstrumentation;

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (!process.env._HANDLER.includes('.')) return; // Bad handler, let error naturally surface
+if (!require('./prepare-wrapper')()) return; // Bad handler, let error naturally surface
 
 const { gzipSync } = require('zlib');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
@@ -10,7 +10,6 @@ const { detectResources, envDetector, processDetector } = require('@opentelemetr
 const { AwsInstrumentation } = require('@opentelemetry/instrumentation-aws-sdk');
 const { getEnv } = require('@opentelemetry/core');
 const { awsLambdaDetector } = require('@opentelemetry/resource-detector-aws');
-const { AwsLambdaInstrumentation } = require('@opentelemetry/instrumentation-aws-lambda');
 const { DnsInstrumentation } = require('@opentelemetry/instrumentation-dns');
 const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
 const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');
@@ -25,6 +24,7 @@ const { NetInstrumentation } = require('@opentelemetry/instrumentation-net');
 const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
 const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
 const { FastifyInstrumentation } = require('@opentelemetry/instrumentation-fastify');
+const AwsLambdaInstrumentation = require('./aws-lambda-instrumentation');
 const { diag, DiagConsoleLogger } = require('@opentelemetry/api');
 const fetch = require('node-fetch');
 const { logMessage, OTEL_SERVER_PORT } = require('../lib/helper');

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -321,8 +321,8 @@ const instrumentations = [
         eventData[context.awsRequestId].eventSource = 'aws.apigateway';
         eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
         const routeKey = event.requestContext.routeKey;
-        const path = routeKey.split(' ')[1] || event.requestContext.routeKey;
-        eventData[context.awsRequestId].httpPath = path;
+        eventData[context.awsRequestId].httpPath =
+          routeKey.split(' ')[1] || event.requestContext.routeKey;
         eventData[context.awsRequestId].rawHttpPath = event.rawPath;
         eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.http.method;
         eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!process.env._HANDLER.includes('.')) return; // Bad handler, let error naturally surface
+
 const { gzipSync } = require('zlib');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { InMemorySpanExporter } = require('@opentelemetry/sdk-trace-base');

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/prepare-wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/prepare-wrapper.js
@@ -1,0 +1,83 @@
+'use strict';
+
+module.exports = () => {
+  if (!process.env._HANDLER.includes('.') || process.env._HANDLER.includes('..')) {
+    return false; // Bad handler, let error naturally surface
+  }
+
+  const path = require('path');
+  const handlerDirname = path.dirname(process.env._HANDLER);
+  const handlerBasename = path.basename(process.env._HANDLER);
+  const handlerModuleBasename = handlerBasename.slice(0, handlerBasename.indexOf('.'));
+  const handlerModuleDirname = path.resolve(process.env.LAMBDA_TASK_ROOT, handlerDirname);
+  const handlerModuleName = path.resolve(handlerModuleDirname, handlerModuleBasename);
+
+  const importEsm = (() => {
+    try {
+      // eslint-disable-next-line import/no-unresolved
+      return require(path.resolve(process.env.LAMBDA_RUNTIME_DIR, 'deasync')).deasyncify(
+        async (p) => {
+          return await import(p);
+        }
+      );
+    } catch (error) {
+      // No ESM support (Node.js v12)
+      return null;
+    }
+  })();
+
+  const doesModuleExist = (filename) => {
+    try {
+      require.resolve(filename);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const handlerModule = (() => {
+    if (importEsm) {
+      // Handle eventual ESM handler modules
+      if (doesModuleExist(`${handlerModuleName}.mjs`)) {
+        return importEsm(`${handlerModuleName}.mjs`);
+      }
+      if (doesModuleExist(`${handlerModuleName}.js`)) {
+        if (
+          !handlerModuleDirname.endsWith('/node_modules') &&
+          (() => {
+            try {
+              return require(path.resolve(handlerModuleDirname, 'package.json')).type === 'module';
+            } catch {
+              return false;
+            }
+          })()
+        ) {
+          return importEsm(`${handlerModuleName}.js`);
+        }
+      }
+    }
+
+    if (doesModuleExist(handlerModuleName)) return require(handlerModuleName);
+    return require('module').createRequire(handlerModuleName)(handlerModuleBasename);
+  })();
+
+  const handlerPropertyPathTokens = handlerBasename
+    .slice(handlerModuleBasename.length + 1)
+    .split('.');
+  const handlerFunctionName = handlerPropertyPathTokens.pop();
+  let handlerContext = handlerModule;
+  if (handlerContext == null) return false;
+  while (handlerPropertyPathTokens.length) {
+    handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
+    if (handlerContext == null) return false;
+  }
+  const handlerFunction = handlerContext[handlerFunctionName];
+  if (typeof handlerFunction !== 'function') return false;
+
+  process.env._ORIGIN_HANDLER = process.env._HANDLER;
+  process.env._HANDLER = '/opt/otel-extension/internal/wrapper.handler';
+
+  EvalError.$serverlessHandlerFunction = handlerFunction;
+
+  return true;
+};

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/wrapper.js
@@ -1,0 +1,11 @@
+'use strict';
+
+process.env._HANDLER = process.env._ORIGIN_HANDLER;
+delete process.env._ORIGIN_HANDLER;
+
+const handlerFunction = EvalError.$serverlessHandlerFunction;
+delete EvalError.$serverlessHandlerFunction;
+
+module.exports.handler = require('./aws-lambda-instrumentation')._instance._getPatchHandler(
+  handlerFunction
+);

--- a/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
+++ b/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
@@ -68,7 +68,7 @@ describe('internal', () => {
         requireUncached(async () => {
           await require('../../../opt/otel-extension/internal');
           await new Promise((resolve) => {
-            require(path.resolve(lambdaFixturesDirname, 'callback-success.js')).handler(
+            require('../../../opt/otel-extension/internal/wrapper').handler(
               {},
               {
                 awsRequestId: '123',

--- a/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
+++ b/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
@@ -72,6 +72,7 @@ describe('internal', () => {
               {},
               {
                 awsRequestId: '123',
+                functionName: 'callback-success',
                 invokedFunctionArn:
                   'arn:aws:lambda:us-east-1:123456789012:function:callback-success',
                 getRemainingTimeInMillis: () => 3000,


### PR DESCRIPTION
It's to fix discovered issues as:
- Broken wrapping when esbuild bundling of ESM modules is involed
- Lack of support for ESM modules
