### PR TITLE
Parse Http Route for Fastify

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/helper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/helper.js
@@ -107,8 +107,8 @@ const resourceAttributes = [
   },
   {
     key: 'faas.collector_version',
-    value: '@serverless/aws-lambda-otel-extension-0.2.10',
-    source: '@serverless/aws-lambda-otel-extension-0.2.10',
+    value: '@serverless/aws-lambda-otel-extension-0.2.11',
+    source: '@serverless/aws-lambda-otel-extension-0.2.11',
     type: 'stringValue',
   },
 ];

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -141,6 +141,8 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
       (val.instrumentationLibrary.name === '@opentelemetry/instrumentation-express' &&
         val.name === 'middleware - bound ') ||
       (val.instrumentationLibrary.name === '@opentelemetry/instrumentation-express' &&
+        /request handler - /i.test(val.name)) ||
+      (val.instrumentationLibrary.name === '@opentelemetry/instrumentation-fastify' &&
         /request handler - /i.test(val.name))
     ) {
       return val.attributes['http.route'];

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
This makes fastify routes parse correctly into `http.path`