### PR TITLE
Otel instrumentation optimizations

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/aws-lambda-instrumentation.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/aws-lambda-instrumentation.js
@@ -9,6 +9,17 @@ AwsLambdaInstrumentation.prototype.init = function () {
   }
   // Expose instance for our custom wrapping needs
   AwsLambdaInstrumentation._instance = this;
+  // First part of a patch to prevent "No modules instrumentation has been defined" warning
+  // It is reverted in temporarily overriden `enable()` method invoked right after `init()`
+  return Array(1);
+};
+
+// Second part of patch to prevent "No modules instrumentation has been defined" warning
+AwsLambdaInstrumentation.prototype.enable = function () {
+  // Revert temporary patch (result of dummy response from `init()`)
+  this._modules = [];
+  delete AwsLambdaInstrumentation.prototype.enable;
+  return this.enable();
 };
 
 module.exports = AwsLambdaInstrumentation;

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -391,11 +391,6 @@ const instrumentations = [
   new FastifyInstrumentation(),
 ];
 
-// Register instrumentations synchronously to ensure code is patched even before provider is ready.
-registerInstrumentations({
-  instrumentations,
-});
-
 async function initializeProvider() {
   const resource = await detectResources({
     detectors: [awsLambdaDetector, envDetector, processDetector],

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -403,8 +403,7 @@ async function initializeProvider() {
   spanProcessor = new SlsSpanProcessor(memoryExporter);
   tracerProvider.addSpanProcessor(spanProcessor);
 
-  const sdkRegistrationConfig = {};
-  tracerProvider.register(sdkRegistrationConfig);
+  tracerProvider.register();
 
   // Re-register instrumentation with initialized provider. Patched code will see the update.
   registerInstrumentations({


### PR DESCRIPTION
When learning more about how instrumentation internals work, I've come up with few improvements:

- Register initialized instrumentations once (it's fine to extend _resource_ of tracer after it's initialized)
- Introduce patch that will prevent misleading `No modules instrumentation has been defined, nothing will be patched` warning as produced by AWS Lambda instrumentation (we replaced its patcher with ours, so indeed otel internally sees no modules to patch)