### PR TITLE
fix: Include spanId in req/res data

### DIFF
--- a/packages/aws-lambda-otel-extension/CHANGELOG.md
+++ b/packages/aws-lambda-otel-extension/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [0.2.12](https://github.com/serverless/runtime/compare/@serverless/aws-lambda-otel-extension@0.2.10...@serverless/aws-lambda-otel-extension@0.2.12) (2022-04-13)
+
+### Bug Fixes
+
+- Include spanId in req/res data ([1801503](https://github.com/serverless/runtime/commit/1801503557b09d97edbda16f94f990b6914c5bad))
+
+### Maintenance Improvements
+
+- Automate extension version resolution ([d1d8c12](https://github.com/serverless/runtime/commit/d1d8c124563b0481383c21b69e7f13576dafbab9))
+- Improve `faas.collector_version` format ([9ccbfa1](https://github.com/serverless/runtime/commit/9ccbfa10c301d1234d595ae5b242bd43a42b1ade))
+- Optimize instrumentations setup ([99b47fd](https://github.com/serverless/runtime/commit/99b47fd339f1a64312ef7c37baca54f6e9967ac1))
+- Prevent misleading "No modules.." warning ([85fbc39](https://github.com/serverless/runtime/commit/85fbc399ad61914104d7f86e60699042d7fe6f79))
+- Remove obsolete config configuration ([5b448ba](https://github.com/serverless/runtime/commit/5b448ba4c0bac1d9f6653151cad9d075916def3f))
+- Remove obsolete instrumentation registration ([014b6b3](https://github.com/serverless/runtime/commit/014b6b39647df54643aa18086183479810aaf79a))
+- Remove obsolete payload compression ([f5ceb3d](https://github.com/serverless/runtime/commit/f5ceb3d9151ad2183d3ebe5e1b079f4a7e788fea))

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/index.js
@@ -250,6 +250,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
         executionId,
         isTimeout,
         traceId: span ? span.spanContext().traceId : null,
+        spanId: span ? span.spanContext().spanId : null,
       },
       function: functionData,
       traces: {
@@ -354,6 +355,7 @@ registerInstrumentations({
             },
             requestEventPayload: {
               traceId: span.spanContext().traceId,
+              spanId: span.spanContext().spanId,
               requestData: event,
               executionId: context.awsRequestId,
             },

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Description
We ended up needing the spanId in the request/response payload so we can accurately match it to a specific trace span 👍 