### PR TITLE
fix: Fixed waitFor bug

### DIFF
--- a/packages/aws-lambda-otel-extension/CHANGELOG.md
+++ b/packages/aws-lambda-otel-extension/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.13](https://github.com/serverless/runtime/compare/@serverless/aws-lambda-otel-extension@0.2.12...@serverless/aws-lambda-otel-extension@0.2.13) (2022-04-13)
+
+### Bug Fixes
+
+- Fixed waitFor bug ([aa0658c](https://github.com/serverless/runtime/commit/aa0658cc8c3ab87708ec33c00f21dc93c1dc76e7))
+
 ### [0.2.12](https://github.com/serverless/runtime/compare/@serverless/aws-lambda-otel-extension@0.2.10...@serverless/aws-lambda-otel-extension@0.2.12) (2022-04-13)
 
 ### Bug Fixes

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/index.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/index.js
@@ -276,9 +276,9 @@ module.exports = (async function main() {
     liveLogCallback: postLiveLogs,
     callback: async (...args) => {
       await uploadLogs(...args);
-      receivedData = true;
     },
     requestResponseCallback: async (data) => {
+      receivedData = true;
       await reportOtelData.requestResponse(data);
     },
   });

--- a/packages/aws-lambda-otel-extension/opt/otel-extension/external/initialize-telemetry-listener.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/external/initialize-telemetry-listener.js
@@ -36,7 +36,7 @@ function initializeTelemetryListener({
             writeFileSync(SAVE_FILE, JSON.stringify(logsQueue));
           }
 
-          if (callback && data.recordType === 'telemetryData') {
+          if (callback && data.recordType === 'telemetryData' && typeof data.record === 'string') {
             const reportIds = [data.record.split('\t')[1]];
             callback(logsQueue, reportIds);
           }

--- a/packages/aws-lambda-otel-extension/package.json
+++ b/packages/aws-lambda-otel-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-otel-extension",
   "repository": "serverless/runtime",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Description
Fixed a bug that was causing lambda functions to run until they timed out. I am not sure when this bug was introduced but I think it has something to do when we switched the logging callback in the telemetry server.

I will do some more investigation and clean up once we get the fix out there 😎 