### PR TITLE
CI: Fix release notes publications step

### DIFF
--- a/.github/workflows/publish-aws-lambda-otel-extension.yml
+++ b/.github/workflows/publish-aws-lambda-otel-extension.yml
@@ -120,6 +120,5 @@ jobs:
       - name: Publish release notes
         run: |
           cd packages/aws-lambda-otel-extension
-          TEMP_ARRAY=($(echo $GITHUB_REF | tr "/" "\n"))
-          TAG=${TEMP_ARRAY[@]: -1}
+          TAG=${GITHUB_REF:10}
           npx github-release-from-cc-changelog $TAG


### PR DESCRIPTION
CI fail exposed that resolution of Tag from Github ref did not work as expected. This patch fixes that