### PR TITLE
Fix handling of initialization errors

### DIFF
--- a/packages/aws-lambda-otel-extension/opt/otel-extension/internal/wrapper.js
+++ b/packages/aws-lambda-otel-extension/opt/otel-extension/internal/wrapper.js
@@ -3,6 +3,12 @@
 process.env._HANDLER = process.env._ORIGIN_HANDLER;
 delete process.env._ORIGIN_HANDLER;
 
+if (!EvalError.$serverlessHandlerFunction) {
+  const handlerError = EvalError.$serverlessHandlerModuleInitializationError;
+  delete EvalError.$serverlessHandlerModuleInitializationError;
+  throw handlerError;
+}
+
 const handlerFunction = EvalError.$serverlessHandlerFunction;
 delete EvalError.$serverlessHandlerFunction;
 


### PR DESCRIPTION
I've discovered that initialization errors, when thrown from pre-required preparation module are exposed as Runtime errors to users.

This patch ensures the error is cached and thrown from patched handler instead. Having that user faces same effect, no matter whether lambda function is instrumented or not