### PR TITLE
Remove `node-fetch` dependency in external extension

### DIFF
--- a/.github/workflows/node-integrate.yml
+++ b/.github/workflows/node-integrate.yml
@@ -224,20 +224,6 @@ jobs:
         with:
           path: node/packages/aws-lambda-otel-extension/node_modules
           key: packages/aws-lambda-otel-extension/node-modules-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('node/packages/aws-lambda-otel-extension/package.json') }}
-      - name: Retrieve packages/aws-lambda-otel-extension/external/otel-extension-external/node_modules from cache
-        id: cacheAwsLambdaOtelExtensionExternalOtelExtensionExternalNodeModules
-        uses: actions/cache@v2
-        with:
-          path: node/packages/aws-lambda-otel-extension/external/otel-extension-external/node_modules
-          key: packages/aws-lambda-otel-extension/external/otel-extension-external/node-modules-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('node/packages/aws-lambda-otel-extension/external/otel-extension-external/package.json') }}
-          restore-keys: packages/aws-lambda-otel-extension/external/otel-extension-external/node-modules-v16-${{ runner.os }}-${{ github.ref }}-
-      - name: Retrieve packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node_modules from cache
-        id: cacheAwsLambdaOtelExtensionInternalOtelExtensionIntrernalNodeNodeModules
-        uses: actions/cache@v2
-        with:
-          path: node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node_modules
-          key: packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node-modules-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json') }}
-          restore-keys: packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node-modules-v16-${{ runner.os }}-${{ github.ref }}-
       - name: Retrieve packages/aws-lambda-otel-extension/test/fixtures/lambdas from cache
         id: cacheAwsLambdaOtelExtensionTestFixturesLambdasNodeModules
         uses: actions/cache@v2
@@ -250,8 +236,17 @@ jobs:
         with:
           node-version: 16.x
 
-      # Note: No need to install dependencies as we have retrieved cached `node_modules` for very
-      #       same `package.json` as stored with previous job
+      # Note: No need to install dependencies for main packgages as we have retrieved cached
+      #       `node_modules` for very  same `package.json` as stored with previous job
+
+      - name: Install packages/aws-lambda-otel-extension/external/otel-extension-external dependencies
+        run: |
+          cd node/packages/aws-lambda-otel-extension/external/otel-extension-external
+          npm install
+      - name: Install packages/aws-lambda-otel-extension/internal/otel-extension-internal-node dependencies
+        run: |
+          cd node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node
+          npm install
 
       - name: Integration tests
         run: |

--- a/.github/workflows/node-publish-aws-lambda-otel-extension.yml
+++ b/.github/workflows/node-publish-aws-lambda-otel-extension.yml
@@ -39,20 +39,6 @@ jobs:
           path: node/packages/aws-lambda-otel-extension/node_modules
           key: packages/aws-lambda-otel-extension/node-modules-v16-${{ runner.os }}-refs/heads/main-${{ hashFiles('node/packages/aws-lambda-otel-extension/package.json') }}
           restore-keys: packages/aws-lambda-otel-extension/node-modules-v16-${{ runner.os }}-refs/heads/main-
-      - name: Retrieve packages/aws-lambda-otel-extension/external/otel-extension-external/node_modules from cache
-        id: cacheAwsLambdaOtelExtensionExternalOtelExtensionExternalNodeModules
-        uses: actions/cache@v2
-        with:
-          path: node/packages/aws-lambda-otel-extension/external/otel-extension-external/node_modules
-          key: packages/aws-lambda-otel-extension/external/otel-extension-external/node-modules-v16-${{ runner.os }}-refs/heads/main-${{ hashFiles('node/packages/aws-lambda-otel-extension/external/otel-extension-external/package.json') }}
-          restore-keys: packages/aws-lambda-otel-extension/external/otel-extension-external/node-modules-v16-${{ runner.os }}-refs/heads/main-
-      - name: Retrieve packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node_modules from cache
-        id: cacheAwsLambdaOtelExtensionInternalOtelExtensionIntrernalNodeNodeModules
-        uses: actions/cache@v2
-        with:
-          path: node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node_modules
-          key: packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node-modules-v16-${{ runner.os }}-refs/heads/main-${{ hashFiles('node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json') }}
-          restore-keys: packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/node-modules-v16-${{ runner.os }}-refs/heads/main-
       - name: Retrieve packages/aws-lambda-otel-extension/test/fixtures/lambdas from cache
         id: cacheAwsLambdaOtelExtensionTestFixturesLambdasNodeModules
         uses: actions/cache@v2
@@ -90,15 +76,13 @@ jobs:
           npm update --no-save
           npm update --save-dev --no-save
       - name: Install packages/aws-lambda-otel-extension/external/otel-extension-external dependencies
-        if: steps.cacheAwsLambdaOtelExtensionExternalOtelExtensionExternalNodeModules.outputs.cache-hit != 'true'
         run: |
           cd node/packages/aws-lambda-otel-extension/external/otel-extension-external
-          npm update --no-save
+          npm install
       - name: Install packages/aws-lambda-otel-extension/internal/otel-extension-internal-node dependencies
-        if: steps.cacheAwsLambdaOtelExtensionInternalOtelExtensionInternalNodeNodeModules.outputs.cache-hit != 'true'
         run: |
           cd node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node
-          npm update --no-save
+          npm install
       - name: Install packages/aws-lambda-otel-extension/test/fixtures/lambdas dependencies
         if: steps.cacheAwsLambdaOtelExtensionTestFixturesLambdasNodeModules.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/node-publish-aws-lambda-otel-extension.yml
+++ b/.github/workflows/node-publish-aws-lambda-otel-extension.yml
@@ -39,13 +39,6 @@ jobs:
           path: node/packages/aws-lambda-otel-extension/node_modules
           key: packages/aws-lambda-otel-extension/node-modules-v16-${{ runner.os }}-refs/heads/main-${{ hashFiles('node/packages/aws-lambda-otel-extension/package.json') }}
           restore-keys: packages/aws-lambda-otel-extension/node-modules-v16-${{ runner.os }}-refs/heads/main-
-      - name: Retrieve packages/aws-lambda-otel-extension/test/fixtures/lambdas from cache
-        id: cacheAwsLambdaOtelExtensionTestFixturesLambdasNodeModules
-        uses: actions/cache@v2
-        with:
-          path: node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/node_modules
-          key: packages/aws-lambda-otel-extension/test/fixtures/lambdas/node-modules-v16-${{ runner.os }}-refs/heads/main-${{ hashFiles('node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/package.json') }}
-          restore-keys: packages/aws-lambda-otel-extension/test/fixtures/lambdas/node-modules-v16-${{ runner.os }}-refs/heads/main-
       - name: Retrieve packages/aws-lambda-otel-extension-dist/node_modules from cache
         id: cacheAwsLambdaOtelExtensionDistNodeModules
         uses: actions/cache@v2
@@ -83,11 +76,6 @@ jobs:
         run: |
           cd node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node
           npm install
-      - name: Install packages/aws-lambda-otel-extension/test/fixtures/lambdas dependencies
-        if: steps.cacheAwsLambdaOtelExtensionTestFixturesLambdasNodeModules.outputs.cache-hit != 'true'
-        run: |
-          cd node/packages/aws-lambda-otel-extension/test/fixtures/lambdas
-          npm update --no-save
       - name: Install packages/aws-lambda-otel-extension-dist dependencies
         if: steps.cacheAwsLambdaOtelExtensionDistNodeModules.outputs.cache-hit != 'true'
         run: |

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/package.json
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "node-fetch": "^2.6.7",
     "protobufjs": "^6.11.2"
   }
 }

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
@@ -58,6 +58,7 @@ const processData = async (data, { url, s3Key, protobufPath, protobufType }) => 
           'content-type': REPORT_TYPE === 'proto' ? 'application/x-protobuf' : 'application/json',
           ...EXTRA_REQUEST_HEADERS,
         };
+        if (REPORT_TYPE !== 'proto') datum = JSON.stringify(datum);
         const options = {
           method: 'post',
           body: datum,

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fetch = require('node-fetch');
+const { logMessage } = require('./helper');
+
 const reportModes = new Set(['json', 'proto']);
 const REPORT_TYPE = reportModes.has(process.env.SLS_OTEL_REPORT_TYPE)
   ? process.env.SLS_OTEL_REPORT_TYPE
@@ -18,8 +21,6 @@ const protobuf = REPORT_TYPE === 'proto' ? require('protobufjs') : null;
 // aws-sdk is provided in Lambda runtime
 // eslint-disable-next-line import/no-unresolved
 const s3Client = S3_BUCKET ? new (require('/var/runtime/node_modules/aws-sdk').S3)() : null;
-const fetch = require('node-fetch');
-const { logMessage } = require('./helper');
 
 const processData = async (data, { url, s3Key, protobufPath, protobufType }) => {
   if (REPORT_TYPE === 'proto') {


### PR DESCRIPTION
So it's lighter and has better initialization time (less external requires), I've tested it by deploying and confirming that all requests work as expected (as this is not really covered by integration tests at this point)

Additionally improved CI setup:
- So far we were updating `node_modules` with `npm update` which won't clean dependencies that were removed from `package.json`. For internal and external extensions I've ensured we have a clean install
- Remove obsolete installation of dependencies in test fixtures for publish job