### PR TITLE
Improve debug logs and log extension overhead durations

### DIFF
--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
@@ -235,14 +235,14 @@ const measureAttributes = [
   },
 ];
 
-const logMessage = (...args) => {
+const debugLog = (...args) => {
   if (process.env.DEBUG_SLS_OTEL_LAYER) {
     console.log(...args);
   }
 };
 
 module.exports = {
-  logMessage,
+  debugLog,
   resourceAttributes,
   measureAttributes,
   stripResponseBlobData,

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -15,7 +15,7 @@ module.exports = (async () => {
   const servers = new Set();
 
   const userSettings = require('./user-settings');
-  const { stripResponseBlobData, logMessage } = require('./helper');
+  const { stripResponseBlobData, debugLog } = require('./helper');
   const reportOtelData = require('./report-otel-data');
   const { createMetricsPayload, createTracePayload, createLogPayload } = require('./otel-payloads');
 
@@ -24,11 +24,11 @@ module.exports = (async () => {
   const sendReport = (method, payload) => {
     const startTime = Date.now();
     const requestId = ++reportRequestIdTracker;
-    logMessage(`[${requestId}] send "${method}"`);
+    debugLog(`[${requestId}] send "${method}"`);
     const promise = reportOtelData[method](payload);
     pendingReports.add(promise);
     promise.finally(() => {
-      logMessage(`[${requestId}] "${method}" sent in`, Date.now() - startTime);
+      debugLog(`[${requestId}] "${method}" sent in`, Date.now() - startTime);
       pendingReports.delete(promise);
     });
   };
@@ -234,7 +234,7 @@ module.exports = (async () => {
           });
           request.on('end', async () => {
             const data = JSON.parse(body);
-            logMessage('BATCH FROM CUSTOM HTTP SERVER: ', body, JSON.stringify(data));
+            debugLog('BATCH FROM CUSTOM HTTP SERVER: ', body, JSON.stringify(data));
             switch (data.recordType) {
               case 'eventData':
                 {

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -248,7 +248,7 @@ module.exports = (async () => {
           });
           request.on('end', async () => {
             const data = JSON.parse(body);
-            debugLog('BATCH FROM CUSTOM HTTP SERVER: ', body, JSON.stringify(data));
+            debugLog('Internal telemetry payload', JSON.stringify(data));
             switch (data.recordType) {
               case 'eventData':
                 {

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -70,7 +70,12 @@ module.exports = (async () => {
             response.writeHead(200, {});
             response.end('OK');
             const data = JSON.parse(body);
-            const functionLogEvents = data.filter((event) => event.type === 'function');
+            let functionLogEvents = data.filter((event) => event.type === 'function');
+            if (process.env.DEBUG_SLS_OTEL_LAYER) {
+              functionLogEvents = functionLogEvents.filter(
+                (event) => !event.record.startsWith('Extension duration: ')
+              );
+            }
             if (functionLogEvents.length) {
               const currentRequestData = getCurrentRequestData();
               if (!currentRequestData.eventData) {

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -24,18 +24,11 @@ module.exports = (async () => {
   const reportOtelData = require('./report-otel-data');
   const { createMetricsPayload, createTracePayload, createLogPayload } = require('./otel-payloads');
 
-  let reportRequestIdTracker = 0;
   const pendingReports = new Set();
   const sendReport = (method, payload) => {
-    const startTime = Date.now();
-    const requestId = ++reportRequestIdTracker;
-    debugLog(`[${requestId}] send "${method}"`);
     const promise = reportOtelData[method](payload);
     pendingReports.add(promise);
-    promise.finally(() => {
-      debugLog(`[${requestId}] "${method}" sent in`, Date.now() - startTime);
-      pendingReports.delete(promise);
-    });
+    promise.finally(() => pendingReports.delete(promise));
   };
 
   // Rotate current request data

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/report-otel-data.js
@@ -2,7 +2,7 @@
 
 const createHttpRequest = require('http').request;
 const createHttpsRequest = require('https').request;
-const { logMessage } = require('./helper');
+const { debugLog } = require('./helper');
 
 const reportModes = new Set(['json', 'proto']);
 const REPORT_TYPE = reportModes.has(process.env.SLS_OTEL_REPORT_TYPE)
@@ -38,12 +38,12 @@ const processData = async (data, { url, s3Key, protobufPath, protobufType }) => 
                     const ServiceRequest = root.lookupType(protobufType);
                     resolve(ServiceRequest.encode(datum).finish());
                   } catch (error) {
-                    logMessage('Buffer error: ', error);
+                    debugLog('Buffer error: ', error);
                     resolve(null);
                   }
                 });
               } catch (error) {
-                logMessage('Could not convert to proto buff: ', error);
+                debugLog('Could not convert to proto buff: ', error);
                 resolve(null);
               }
             })

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -28,7 +28,7 @@ const SlsSpanProcessor = require('./span-processor');
 const { detectEventType } = require('./event-detection');
 const userSettings = require('./user-settings');
 
-const logMessage = (...args) => {
+const debugLog = (...args) => {
   if (process.env.DEBUG_SLS_OTEL_LAYER) {
     console.log(...args);
   }
@@ -228,7 +228,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     };
   });
 
-  logMessage(
+  debugLog(
     'Wrapper trace data: ',
     JSON.stringify(
       {

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -82,11 +82,11 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
   const { startTime: st, endTime: et } = spans.reduce(
     (obj, val) => {
       if (val.instrumentationLibrary.name === '@opentelemetry/instrumentation-aws-lambda') {
-        const startTime = val.startTime || [0, 0];
-        const endTime = val.endTime || [0, 0];
+        const spanStartTime = val.startTime || [0, 0];
+        const spanEndTime = val.endTime || [0, 0];
         return {
-          startTime: new Date((startTime[0] * 1000000000 + startTime[1]) / 1000000),
-          endTime: new Date((endTime[0] * 1000000000 + endTime[1]) / 1000000),
+          startTime: new Date((spanStartTime[0] * 1000000000 + spanStartTime[1]) / 1000000),
+          endTime: new Date((spanEndTime[0] * 1000000000 + spanEndTime[1]) / 1000000),
         };
       }
       return obj;
@@ -179,8 +179,8 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     const spanObj = spanList
       .map((val) => {
         const { traceId, spanId } = val.spanContext();
-        const startTime = val.startTime || [0, 0];
-        const endTime = val.endTime || [0, 0];
+        const spanStartTime = val.startTime || [0, 0];
+        const spanEndTime = val.endTime || [0, 0];
 
         let attributes = {
           ...val.attributes,
@@ -208,8 +208,8 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
               ? `request handler - ${pathData['http.path']}`
               : val.name,
           kind: 'SPAN_KIND_SERVER',
-          startTimeUnixNano: `${startTime[0] * 1000000000 + startTime[1]}`,
-          endTimeUnixNano: `${endTime[0] * 1000000000 + endTime[1]}`,
+          startTimeUnixNano: `${spanStartTime[0] * 1000000000 + spanStartTime[1]}`,
+          endTimeUnixNano: `${spanEndTime[0] * 1000000000 + spanEndTime[1]}`,
           attributes,
           status: {},
         };

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -30,12 +30,6 @@ const SlsSpanProcessor = require('./span-processor');
 const { detectEventType } = require('./event-detection');
 const userSettings = require('./user-settings');
 
-const debugLog = (...args) => {
-  if (process.env.DEBUG_SLS_OTEL_LAYER) {
-    console.log(...args);
-  }
-};
-
 const OTEL_SERVER_PORT = 2772;
 const logLevel = getEnv().OTEL_LOG_LEVEL;
 diag.setLogger(new DiagConsoleLogger(), logLevel);
@@ -229,25 +223,6 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
       spans: Object.values(spanObj),
     };
   });
-
-  debugLog(
-    'Wrapper trace data: ',
-    JSON.stringify(
-      {
-        function: functionData,
-        traces: {
-          resourceSpans: [
-            {
-              resource: tracerProvider.resource.attributes,
-              instrumentationLibrarySpans: data,
-            },
-          ],
-        },
-      },
-      null,
-      2
-    )
-  );
 
   const telemetryDataPayload = {
     recordType: 'telemetryData',

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/prepare-wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/prepare-wrapper.js
@@ -2,7 +2,7 @@
 
 module.exports = () => {
   if (!process.env._HANDLER.includes('.') || process.env._HANDLER.includes('..')) {
-    return false; // Bad handler, let error naturally surface
+    return; // Bad handler, let error naturally surface
   }
 
   const path = require('path');
@@ -76,19 +76,17 @@ module.exports = () => {
       .split('.');
     const handlerFunctionName = handlerPropertyPathTokens.pop();
     let handlerContext = handlerModule;
-    if (handlerContext == null) return false;
+    if (handlerContext == null) return;
     while (handlerPropertyPathTokens.length) {
       handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
-      if (handlerContext == null) return false;
+      if (handlerContext == null) return;
     }
     const handlerFunction = handlerContext[handlerFunctionName];
-    if (typeof handlerFunction !== 'function') return false;
+    if (typeof handlerFunction !== 'function') return;
 
     EvalError.$serverlessHandlerFunction = handlerFunction;
   }
 
   process.env._ORIGIN_HANDLER = process.env._HANDLER;
   process.env._HANDLER = '/opt/otel-extension-internal-node/wrapper.handler';
-
-  return true;
 };

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -12,6 +12,86 @@ if (!EvalError.$serverlessHandlerFunction) {
 const handlerFunction = EvalError.$serverlessHandlerFunction;
 delete EvalError.$serverlessHandlerFunction;
 
-module.exports.handler = require('./aws-lambda-instrumentation')._instance._getPatchHandler(
-  handlerFunction
+let requestStartTime;
+let responseStartTime;
+
+const wrappedHandler = require('./aws-lambda-instrumentation')._instance._getPatchHandler(
+  (event, context, callback) => {
+    if (process.env.DEBUG_SLS_OTEL_LAYER) {
+      process._rawDebug(
+        'Extension duration: internal request:',
+        `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
+      );
+    }
+    let isPromiseResult = false;
+    const originalDone = context.done;
+    const done = (...args) => {
+      if (!isPromiseResult && !responseStartTime) responseStartTime = process.hrtime.bigint();
+      return originalDone(...args);
+    };
+    context.done = done;
+    context.succeed = (result) => done(null, result);
+    context.fail = (err) => done(err == null ? 'handled' : err);
+    const result = handlerFunction(event, context, (...args) => {
+      if (!isPromiseResult && !responseStartTime) responseStartTime = process.hrtime.bigint();
+      return callback(...args);
+    });
+    if (!result) return result;
+    if (typeof result.then !== 'function') return result;
+    isPromiseResult = true;
+    return result.then(
+      (asyncResult) => {
+        if (!responseStartTime) responseStartTime = process.hrtime.bigint();
+        return asyncResult;
+      },
+      (error) => {
+        if (!responseStartTime) responseStartTime = process.hrtime.bigint();
+        throw error;
+      }
+    );
+  }
 );
+
+module.exports.handler = (event, context, callback) => {
+  requestStartTime = process.hrtime.bigint();
+  const logResponseDuration = () => {
+    delete EvalError.$serverlessResponseHandlerPromise;
+    if (process.env.DEBUG_SLS_OTEL_LAYER && responseStartTime) {
+      process._rawDebug(
+        'Extension duration: internal response:',
+        `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`
+      );
+      responseStartTime = null;
+    }
+  };
+  let isPromiseResult = false;
+  const originalDone = context.done;
+  const done = (...args) => {
+    if (!isPromiseResult && EvalError.$serverlessResponseHandlerPromise) {
+      EvalError.$serverlessResponseHandlerPromise.finally(logResponseDuration);
+    }
+    return originalDone(...args);
+  };
+  context.done = done;
+  context.succeed = (result) => done(null, result);
+  context.fail = (err) => done(err == null ? 'handled' : err);
+  const result = wrappedHandler(event, context, (...args) => {
+    if (!isPromiseResult && EvalError.$serverlessResponseHandlerPromise) {
+      EvalError.$serverlessResponseHandlerPromise.finally(logResponseDuration);
+    }
+    return callback(...args);
+  });
+  if (!result) return result;
+  if (typeof result.then !== 'function') return result;
+  isPromiseResult = true;
+  return result.then(
+    (asyncResult) => {
+      logResponseDuration();
+      return asyncResult;
+    },
+    (error) => {
+      logResponseDuration();
+      throw error;
+    }
+  );
+};


### PR DESCRIPTION
- Provide debug logs for all the extension durations overhead
- Improve ingestion server request and failed response logging (no longer log failures unconditionally as that's confusing for users)
- Log duration of all ingestion server requests
-  Improve logging of incoming telemetry requests.

New logs will layout in CloudWatch as follows (for better insight I've expanded one request log):

<img width="1247" alt="Screenshot 2022-05-24 at 16 48 26" src="https://user-images.githubusercontent.com/122434/170065075-a32cdece-1f88-495d-82b7-42e632c506c6.png">

