### PR TITLE
Fix dependencies configuration

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -25,6 +25,7 @@
     "chai": "^4.3.6",
     "chalk": "^4.1.2",
     "child-process-ext": "^2.1.1",
+    "deasync": "^0.1.26",
     "eslint": "^8.16.0",
     "eslint-plugin-import": "^2.26.0",
     "essentials": "^1.2.0",
@@ -42,8 +43,8 @@
     "standard-version": "^9.5.0",
     "stream-promise": "^3.2.0",
     "timers-ext": "^0.1.7",
-    "uuid": "^8.3.2",
-    "yargs-parser": "^21.0.1"
+    "type": "^2.6.0",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "lint": "eslint .",

--- a/node/packages/aws-lambda-otel-extension/package.json
+++ b/node/packages/aws-lambda-otel-extension/package.json
@@ -8,11 +8,8 @@
     "esbuild": "^0.14.39",
     "essentials": "^1.2.0",
     "fs2": "^0.3.9",
-    "semver": "^7.3.7"
-  },
-  "devDependencies": {
-    "deasync": "^0.1.26",
-    "type": "^2.6.0"
+    "semver": "^7.3.7",
+    "yargs-parser": "^21.0.1"
   },
   "standard-version": {
     "tagPrefix": "@serverless/aws-lambda-otel-extension@",


### PR DESCRIPTION
_Addressing issue reported internally by @whardier (observed `Error: Cannot find module 'yargs-parser'`)_

Current conventions are the following:
- All _dev_ dependencies that are used for testing, linting etc. (operations that should not be done on the package when it's npm installed) at the root package
- All `aws-lambda-otel-extension` build script dependencies are treated as _prod_ (not _dev_) dependencies (as users should be able to build the extension binaries after installing this package).

This PR fixes issues in dependencies layout