### PR TITLE
Bundle internal and external extensions into a single file

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/prepare-wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/prepare-wrapper.js
@@ -88,6 +88,9 @@ module.exports = () => {
     if (typeof handlerFunction !== 'function') return result;
 
     EvalError.$serverlessHandlerFunction = handlerFunction;
+    // Exposed for Wrapper which is configured with no dependencies
+    // (it's to ensure no repeated code between distinct bundled files)
+    EvalError.$serverlessAwsLambdaInstrumentation = require('./aws-lambda-instrumentation');
   }
 
   process.env._ORIGIN_HANDLER = process.env._HANDLER;

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -1,3 +1,5 @@
+// Warning: This file must not require any dependencies
+
 'use strict';
 
 process.env._HANDLER = process.env._ORIGIN_HANDLER;
@@ -11,11 +13,13 @@ if (!EvalError.$serverlessHandlerFunction) {
 
 const handlerFunction = EvalError.$serverlessHandlerFunction;
 delete EvalError.$serverlessHandlerFunction;
+const awsLambdaInstrumentation = EvalError.$serverlessAwsLambdaInstrumentation;
+delete EvalError.$serverlessAwsLambdaInstrumentation;
 
 let requestStartTime;
 let responseStartTime;
 
-const wrappedHandler = require('./aws-lambda-instrumentation')._instance._getPatchHandler(
+const wrappedHandler = awsLambdaInstrumentation._instance._getPatchHandler(
   (event, context, callback) => {
     if (process.env.DEBUG_SLS_OTEL_LAYER) {
       process._rawDebug(

--- a/node/packages/aws-lambda-otel-extension/package.json
+++ b/node/packages/aws-lambda-otel-extension/package.json
@@ -5,6 +5,7 @@
   "author": "Serverless, Inc.",
   "dependencies": {
     "adm-zip": "^0.5.9",
+    "child-process-ext": "^2.1.1",
     "esbuild": "^0.14.39",
     "essentials": "^1.2.0",
     "fs2": "^0.3.9",


### PR DESCRIPTION
Bundle extensions but without minifying the source code, so eventual crashes can easily be debugged (I've also tested that minification doesn't give us a real gain in any area)

As I tested this cuts down ca 260ms from initialization time (30ms on external extension and 230ns on internal)

Additionally, it cuts down extension size from 8.7MB to 284KB