### PR TITLE
 Improve extension overhead logs tag line

### DIFF
--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -73,7 +73,7 @@ module.exports = (async () => {
             let functionLogEvents = data.filter((event) => event.type === 'function');
             if (process.env.DEBUG_SLS_OTEL_LAYER) {
               functionLogEvents = functionLogEvents.filter(
-                (event) => !event.record.startsWith('Extension duration: ')
+                (event) => !event.record.startsWith('Extension overhead duration: ')
               );
             }
             if (functionLogEvents.length) {
@@ -184,13 +184,13 @@ module.exports = (async () => {
           isInitializing = false;
           if (process.env.DEBUG_SLS_OTEL_LAYER) {
             process._rawDebug(
-              'Extension duration: external initialization:',
+              'Extension overhead duration: external initialization:',
               `${Math.round(Number(process.hrtime.bigint() - processStartTime) / 1000000)}ms`
             );
           }
         } else if (process.env.DEBUG_SLS_OTEL_LAYER) {
           process._rawDebug(
-            'Extension duration: external invocation:',
+            'Extension overhead duration: external invocation:',
             `${Math.round(Number(process.hrtime.bigint() - invocationStartTime) / 1000000)}ms`
           );
         }
@@ -326,7 +326,7 @@ module.exports = (async () => {
   for (const server of servers) server.close();
   if (process.env.DEBUG_SLS_OTEL_LAYER) {
     process._rawDebug(
-      'Extension duration: external shutdown:',
+      'Extension overhead duration: external shutdown:',
       `${Math.round(Number(process.hrtime.bigint() - shutdownStartTime) / 1000000)}ms`
     );
   }

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -397,7 +397,7 @@ const { handlerLoadDuration } = require('./prepare-wrapper')();
 
 if (process.env.DEBUG_SLS_OTEL_LAYER) {
   process._rawDebug(
-    'Extension duration: internal initialization:',
+    'Extension overhead duration: internal initialization:',
     `${Math.round(
       Number(process.hrtime.bigint() - processStartTime - handlerLoadDuration) / 1000000
     )}ms`

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -19,7 +19,7 @@ const wrappedHandler = require('./aws-lambda-instrumentation')._instance._getPat
   (event, context, callback) => {
     if (process.env.DEBUG_SLS_OTEL_LAYER) {
       process._rawDebug(
-        'Extension duration: internal request:',
+        'Extension overhead duration: internal request:',
         `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
       );
     }
@@ -58,7 +58,7 @@ module.exports.handler = (event, context, callback) => {
     delete EvalError.$serverlessResponseHandlerPromise;
     if (process.env.DEBUG_SLS_OTEL_LAYER && responseStartTime) {
       process._rawDebug(
-        'Extension duration: internal response:',
+        'Extension overhead duration: internal response:',
         `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`
       );
       responseStartTime = null;


### PR DESCRIPTION
`Extension duration` suggested that it's a total time that extension took, while it reports only the overhead of what extension adds to the execution time. Updated log message to reflect that