### PR TITLE
Fix reliability of integration tests

### DIFF
--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -155,7 +155,7 @@ describe('integration', function () {
       objects = ((await awsRequest(S3, 'listObjectsV2', { Bucket: basename })).Contents || [])
         .map((object) => object.Key)
         .filter((key) => key.startsWith(`${functionName}/`));
-    } while (!objects.length);
+    } while (objects.length < 3);
 
     log.info('Delete function %s', functionBasename);
     await deleteFunction();

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -161,8 +161,8 @@ describe('integration', function () {
     await deleteFunction();
     log.info('Retrieve body of generated S3 objects %s', functionBasename);
     return Promise.all(
-      objects.map(async (objectKey) =>
-        JSON.parse(
+      objects.map(async (objectKey) => {
+        const result = JSON.parse(
           String(
             await streamToPromise(
               (
@@ -170,8 +170,10 @@ describe('integration', function () {
               ).Body
             )
           )
-        )
-      )
+        );
+        log.info('Report for %s: %o', objectKey, result);
+        return result;
+      })
     );
   };
 
@@ -316,7 +318,6 @@ describe('integration', function () {
       let reports;
       before(async () => {
         reports = await processFunction(handlerModuleName, invocationOptions);
-        log.debug('resolved reports %o', reports);
       });
       it('test', () => {
         const metricsReport = reports.find((report) => report[0].resourceMetrics)[0];


### PR DESCRIPTION
Addresses two recent fails:

- https://github.com/serverless/runtime/actions/runs/2391380978
- https://github.com/serverless/runtime/actions/runs/2391391575

Fails happened because we started to process reports when just _metrics_ report was read from S3 bucket. 

This patch ensures we do not move to processing until there's also _traces_ and final _metrics_ report
