### PR TITLE
Fix request and response hooks handling

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -44,6 +44,88 @@ const eventData = {};
 let timeoutHandler;
 let transactionCount = 0;
 
+const requestHandler = async (span, { event, context }) => {
+  handleTimeouts(context.getRemainingTimeInMillis());
+
+  const eventType = detectEventType(event);
+
+  eventData[context.awsRequestId] = {
+    ...tracerProvider.resource.attributes,
+    computeCustomArn: context.invokedFunctionArn,
+    functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+    computeRegion: process.env.AWS_REGION,
+    computeRuntime: `aws.lambda.nodejs.${process.versions.node}`,
+    computeCustomFunctionVersion: process.env.AWS_LAMBDA_FUNCTION_VERSION,
+    computeMemorySize: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
+    eventCustomXTraceId: process.env._X_AMZN_TRACE_ID,
+    computeCustomLogGroupName: process.env.AWS_LAMBDA_LOG_GROUP_NAME,
+    computeCustomLogStreamName: process.env.AWS_LAMBDA_LOG_STREAM_NAME,
+    computeCustomEnvArch: process.arch,
+    eventType,
+    eventCustomRequestId: context.awsRequestId,
+    computeIsColdStart: ++transactionCount === 1,
+    eventCustomDomain: null,
+    eventCustomRequestTimeEpoch: null,
+  };
+
+  if (eventType === 'aws.apigateway.http') {
+    eventData[context.awsRequestId].eventCustomApiId = event.requestContext.apiId;
+    eventData[context.awsRequestId].eventSource = 'aws.apigateway';
+    eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
+    eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
+    eventData[context.awsRequestId].rawHttpPath = event.path;
+    eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.httpMethod;
+    eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
+    eventData[context.awsRequestId].eventCustomRequestTimeEpoch =
+      event.requestContext.requestTimeEpoch;
+  } else if (eventType === 'aws.apigatewayv2.http') {
+    eventData[context.awsRequestId].eventCustomApiId = event.requestContext.apiId;
+    eventData[context.awsRequestId].eventSource = 'aws.apigateway';
+    eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
+    const routeKey = event.requestContext.routeKey;
+    eventData[context.awsRequestId].httpPath =
+      routeKey.split(' ')[1] || event.requestContext.routeKey;
+    eventData[context.awsRequestId].rawHttpPath = event.rawPath;
+    eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.http.method;
+    eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
+    eventData[context.awsRequestId].eventCustomRequestTimeEpoch = event.requestContext.timeEpoch;
+  }
+
+  const eventDataPayload = {
+    recordType: 'eventData',
+    record: {
+      eventData: { [context.awsRequestId]: eventData[context.awsRequestId] },
+      span: {
+        traceId: span.spanContext().traceId,
+        spanId: span.spanContext().spanId,
+      },
+    },
+  };
+  if (!userSettings.request.disabled) {
+    eventDataPayload.record.requestEventPayload = {
+      traceId: span.spanContext().traceId,
+      spanId: span.spanContext().spanId,
+      requestData: event,
+      executionId: context.awsRequestId,
+    };
+  }
+
+  if (process.env.TEST_DRY_LOG) {
+    process._rawDebug(
+      `${require('util').inspect(eventDataPayload, { depth: Infinity, colors: true })}\n`
+    );
+  } else {
+    // Send request data to external so that we can attach this data to logs
+    await fetch(`http://localhost:${OTEL_SERVER_PORT}`, {
+      method: 'post',
+      body: JSON.stringify(eventDataPayload),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+};
+
 const responseHandler = async (span, { res, err }, isTimeout) => {
   await tracerProvider.forceFlush();
   spanProcessor.finishAllSpans();
@@ -285,91 +367,12 @@ registerInstrumentations({
     }),
     new AwsLambdaInstrumentation({
       disableAwsContextPropagation: true,
-      requestHook: async (span, { event, context }) => {
-        handleTimeouts(context.getRemainingTimeInMillis());
-
-        const eventType = detectEventType(event);
-
-        eventData[context.awsRequestId] = {
-          ...tracerProvider.resource.attributes,
-          computeCustomArn: context.invokedFunctionArn,
-          functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
-          computeRegion: process.env.AWS_REGION,
-          computeRuntime: `aws.lambda.nodejs.${process.versions.node}`,
-          computeCustomFunctionVersion: process.env.AWS_LAMBDA_FUNCTION_VERSION,
-          computeMemorySize: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
-          eventCustomXTraceId: process.env._X_AMZN_TRACE_ID,
-          computeCustomLogGroupName: process.env.AWS_LAMBDA_LOG_GROUP_NAME,
-          computeCustomLogStreamName: process.env.AWS_LAMBDA_LOG_STREAM_NAME,
-          computeCustomEnvArch: process.arch,
-          eventType,
-          eventCustomRequestId: context.awsRequestId,
-          computeIsColdStart: ++transactionCount === 1,
-          eventCustomDomain: null,
-          eventCustomRequestTimeEpoch: null,
-        };
-
-        if (eventType === 'aws.apigateway.http') {
-          eventData[context.awsRequestId].eventCustomApiId = event.requestContext.apiId;
-          eventData[context.awsRequestId].eventSource = 'aws.apigateway';
-          eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
-          eventData[context.awsRequestId].httpPath = event.requestContext.resourcePath;
-          eventData[context.awsRequestId].rawHttpPath = event.path;
-          eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.httpMethod;
-          eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
-          eventData[context.awsRequestId].eventCustomRequestTimeEpoch =
-            event.requestContext.requestTimeEpoch;
-        } else if (eventType === 'aws.apigatewayv2.http') {
-          eventData[context.awsRequestId].eventCustomApiId = event.requestContext.apiId;
-          eventData[context.awsRequestId].eventSource = 'aws.apigateway';
-          eventData[context.awsRequestId].eventCustomAccountId = event.requestContext.accountId;
-          const routeKey = event.requestContext.routeKey;
-          eventData[context.awsRequestId].httpPath =
-            routeKey.split(' ')[1] || event.requestContext.routeKey;
-          eventData[context.awsRequestId].rawHttpPath = event.rawPath;
-          eventData[context.awsRequestId].eventCustomHttpMethod = event.requestContext.http.method;
-          eventData[context.awsRequestId].eventCustomDomain = event.requestContext.domainName;
-          eventData[context.awsRequestId].eventCustomRequestTimeEpoch =
-            event.requestContext.timeEpoch;
-        }
-
-        const eventDataPayload = {
-          recordType: 'eventData',
-          record: {
-            eventData: { [context.awsRequestId]: eventData[context.awsRequestId] },
-            span: {
-              traceId: span.spanContext().traceId,
-              spanId: span.spanContext().spanId,
-            },
-          },
-        };
-        if (!userSettings.request.disabled) {
-          eventDataPayload.record.requestEventPayload = {
-            traceId: span.spanContext().traceId,
-            spanId: span.spanContext().spanId,
-            requestData: event,
-            executionId: context.awsRequestId,
-          };
-        }
-
-        if (process.env.TEST_DRY_LOG) {
-          process._rawDebug(
-            `${require('util').inspect(eventDataPayload, { depth: Infinity, colors: true })}\n`
-          );
-        } else {
-          // Send request data to external so that we can attach this data to logs
-          await fetch(`http://localhost:${OTEL_SERVER_PORT}`, {
-            method: 'post',
-            body: JSON.stringify(eventDataPayload),
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          });
-        }
+      requestHook: (...args) => {
+        EvalError.$serverlessRequestHandlerPromise = requestHandler(...args);
       },
-      responseHook: async (span, { err, res }) => {
+      responseHook: (span, { err, res }) => {
         clearTimeout(timeoutHandler);
-        await (EvalError.$serverlessResponseHandlerPromise = responseHandler(span, { err, res }));
+        EvalError.$serverlessResponseHandlerPromise = responseHandler(span, { err, res });
       },
     }),
     new DnsInstrumentation(),

--- a/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
+++ b/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+// Triggers internal extension flow against provided handler (pass handler name via CLI arguments)
+// Useful for debugging issues locally with extra logs or Node.js debugger
+
+'use strict';
+
+const http = require('http');
+const path = require('path');
+const isThenable = require('type/thenable/is');
+const ensureNpmDependencies = require('../../scripts/lib/ensure-npm-dependencies');
+
+const fixturesDirname = path.resolve(__dirname, '../fixtures');
+
+const OTEL_SERVER_PORT = 2772;
+const handlerModuleName = process.argv[2];
+
+if (!handlerModuleName) throw new Error('Provide handler module name in argument');
+
+const payload = {};
+
+(async () => {
+  ensureNpmDependencies('internal/otel-extension-internal-node');
+  ensureNpmDependencies('test/fixtures/lambdas');
+  process.env.AWS_LAMBDA_FUNCTION_VERSION = '$LATEST';
+  process.env.AWS_REGION = 'us-east-1';
+  process.env.LAMBDA_TASK_ROOT = path.resolve(fixturesDirname, 'lambdas');
+  process.env.LAMBDA_RUNTIME_DIR = path.resolve(fixturesDirname, 'runtime');
+
+  process.env._HANDLER = `${handlerModuleName}.handler`;
+  const functionName = handlerModuleName.includes(path.sep)
+    ? path.dirname(handlerModuleName)
+    : handlerModuleName;
+  process.env.AWS_LAMBDA_FUNCTION_NAME = functionName;
+
+  const logsQueue = [];
+  let server;
+  const deferredResultProcessing = new Promise((resolve) => {
+    server = http.createServer((request, response) => {
+      if (request.method === 'POST') {
+        let body = '';
+        request.on('data', (data) => {
+          body += data;
+        });
+        request.on('end', () => {
+          response.writeHead(200, {});
+          response.end('OK');
+          const data = JSON.parse(body);
+          logsQueue.push(data);
+
+          if (logsQueue.length > 1) {
+            server.close();
+            resolve();
+          }
+        });
+      }
+    });
+  });
+
+  server.listen(OTEL_SERVER_PORT);
+
+  try {
+    await require('../../internal/otel-extension-internal-node');
+    await new Promise((resolve, reject) => {
+      const maybeThenable = require('../../internal/otel-extension-internal-node/wrapper').handler(
+        payload,
+        {
+          awsRequestId: '123',
+          functionName,
+          invokedFunctionArn: `arn:aws:lambda:us-east-1:123456789012:function:${functionName}`,
+          getRemainingTimeInMillis: () => 3000,
+        },
+        (error, result) => {
+          if (error) reject(error);
+          else resolve(result);
+        }
+      );
+      if (isThenable(maybeThenable)) resolve(maybeThenable);
+    });
+
+    await deferredResultProcessing;
+  } finally {
+    server.close();
+  }
+})();


### PR DESCRIPTION
_Reported internally by @Mmarzex_

It appears that AWS Lambda instrumentation supports only _sync_ request and response hooks, and eventual promises as returned by them are not awaited

It was not that problematic for lamdbas which resolved with a _callback_ and over there `context.callbackWaitsForEmptyEventLoop` is set to `true`, so AWS naturally waited for that hook to resolve before settling the invocation. Still when result of lambda is _thenable_ this setting is set to _false_ and AWS immediately settles the invocation.

With this PR I patched handling of responses so in all cases we wait for hooks to resolve. Additionally I've ensured we handle the right way the edge case of callback/thenable race (where given lambda is attempted to be resolved with both callback and thenable).

I've also added as simple test script that allows to invoke internal extension locally (for debugging purposes)

