### PR TITLE
Unify debug log handling

### DIFF
--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
@@ -237,7 +237,7 @@ const measureAttributes = [
 
 const debugLog = (...args) => {
   if (process.env.DEBUG_SLS_OTEL_LAYER) {
-    console.log(...args);
+    process._rawDebug(...args);
   }
 };
 

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -187,14 +187,12 @@ module.exports = (async () => {
       const event = await new Promise((resolve, reject) => {
         if (isInitializing) {
           isInitializing = false;
-          if (process.env.DEBUG_SLS_OTEL_LAYER) {
-            process._rawDebug(
-              'Extension overhead duration: external initialization:',
-              `${Math.round(Number(process.hrtime.bigint() - processStartTime) / 1000000)}ms`
-            );
-          }
-        } else if (process.env.DEBUG_SLS_OTEL_LAYER) {
-          process._rawDebug(
+          debugLog(
+            'Extension overhead duration: external initialization:',
+            `${Math.round(Number(process.hrtime.bigint() - processStartTime) / 1000000)}ms`
+          );
+        } else {
+          debugLog(
             'Extension overhead duration: external invocation:',
             `${Math.round(Number(process.hrtime.bigint() - invocationStartTime) / 1000000)}ms`
           );
@@ -329,12 +327,10 @@ module.exports = (async () => {
   });
 
   for (const server of servers) server.close();
-  if (process.env.DEBUG_SLS_OTEL_LAYER) {
-    process._rawDebug(
-      'Extension overhead duration: external shutdown:',
-      `${Math.round(Number(process.hrtime.bigint() - shutdownStartTime) / 1000000)}ms`
-    );
-  }
+  debugLog(
+    'Extension overhead duration: external shutdown:',
+    `${Math.round(Number(process.hrtime.bigint() - shutdownStartTime) / 1000000)}ms`
+  );
   if (!process.env.SLS_TEST_RUN) process.exit();
 })().catch((error) => {
   // Ensure to crash extension process on unhandled rejection


### PR DESCRIPTION
In context of extension, no `console.log`'s are prefixed with timestamp and request id, also `console.log` may interfere with `stdout` of the lambda logic which we may confirm on in tests. Therefore changed `debugLog` so it writes to `stderr` via `_rawDebug` (this method is not susceptible to some third party patches).

Having that I've reconfigured current logs which we wrote with `_rawDebug` to use `debugLog` function