### PR TITLE
Fix ESM support for `nodejs16.x` runtime

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -5,32 +5,71 @@
 process.env._HANDLER = process.env._ORIGIN_HANDLER;
 delete process.env._ORIGIN_HANDLER;
 
-if (!EvalError.$serverlessHandlerFunction) {
+if (!EvalError.$serverlessHandlerFunction && !EvalError.$serverlessHandlerDeferred) {
   const handlerError = EvalError.$serverlessHandlerModuleInitializationError;
   delete EvalError.$serverlessHandlerModuleInitializationError;
   throw handlerError;
 }
 
-const handlerFunction = EvalError.$serverlessHandlerFunction;
-delete EvalError.$serverlessHandlerFunction;
 const awsLambdaInstrumentation = EvalError.$serverlessAwsLambdaInstrumentation;
 delete EvalError.$serverlessAwsLambdaInstrumentation;
 
-let requestStartTime;
-let responseStartTime;
-let currentInvocationId = 0;
-const debugLog = (...args) => {
-  if (process.env.DEBUG_SLS_OTEL_LAYER) process._rawDebug(...args);
-};
+const wrapHandler = (handlerFunction) => {
+  let requestStartTime;
+  let responseStartTime;
+  let currentInvocationId = 0;
+  const debugLog = (...args) => {
+    if (process.env.DEBUG_SLS_OTEL_LAYER) process._rawDebug(...args);
+  };
 
-const wrappedHandler = awsLambdaInstrumentation._instance._getPatchHandler(
-  (event, context, callback) => {
-    const invocationId = currentInvocationId;
-    debugLog(
-      'Extension overhead duration: internal request:',
-      `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
-    );
+  const wrappedHandler = awsLambdaInstrumentation._instance._getPatchHandler(
+    (event, context, callback) => {
+      const invocationId = currentInvocationId;
+      debugLog(
+        'Extension overhead duration: internal request:',
+        `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
+      );
 
+      const wrapCallback =
+        (originalCallback) =>
+        (...args) => {
+          if (invocationId !== currentInvocationId) {
+            originalCallback(...args);
+            return;
+          }
+          if (!responseStartTime) responseStartTime = process.hrtime.bigint();
+          originalCallback(...args);
+        };
+      const done = wrapCallback(context.done);
+      context.done = done;
+      context.succeed = (result) => done(null, result);
+      context.fail = (err) => done(err == null ? 'handled' : err);
+      const result = handlerFunction(event, context, wrapCallback(callback));
+      if (!result) return result;
+      if (typeof result.then !== 'function') return result;
+      return Promise.resolve(result).finally(() => {
+        if (invocationId !== currentInvocationId) return;
+        if (!responseStartTime) responseStartTime = process.hrtime.bigint();
+      });
+    }
+  );
+
+  return (event, context, callback) => {
+    debugLog('Internal extension: Invocation');
+    const invocationId = ++currentInvocationId;
+    requestStartTime = process.hrtime.bigint();
+    const logResponseDuration = () => {
+      if (invocationId !== currentInvocationId) return;
+      delete EvalError.$serverlessRequestHandlerPromise;
+      delete EvalError.$serverlessResponseHandlerPromise;
+      if (responseStartTime) {
+        debugLog(
+          'Extension overhead duration: internal response:',
+          `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`
+        );
+        responseStartTime = null;
+      }
+    };
     const wrapCallback =
       (originalCallback) =>
       (...args) => {
@@ -38,66 +77,58 @@ const wrappedHandler = awsLambdaInstrumentation._instance._getPatchHandler(
           originalCallback(...args);
           return;
         }
-        if (!responseStartTime) responseStartTime = process.hrtime.bigint();
-        originalCallback(...args);
+        Promise.all([
+          EvalError.$serverlessRequestHandlerPromise,
+          EvalError.$serverlessResponseHandlerPromise,
+        ]).finally(() => {
+          process.nextTick(() => originalCallback(...args));
+          logResponseDuration();
+        });
       };
     const done = wrapCallback(context.done);
     context.done = done;
     context.succeed = (result) => done(null, result);
     context.fail = (err) => done(err == null ? 'handled' : err);
-    const result = handlerFunction(event, context, wrapCallback(callback));
+    const result = wrappedHandler(event, context, wrapCallback(callback));
     if (!result) return result;
     if (typeof result.then !== 'function') return result;
     return Promise.resolve(result).finally(() => {
-      if (invocationId !== currentInvocationId) return;
-      if (!responseStartTime) responseStartTime = process.hrtime.bigint();
-    });
-  }
-);
-
-module.exports.handler = (event, context, callback) => {
-  debugLog('Internal extension: Invocation');
-  const invocationId = ++currentInvocationId;
-  requestStartTime = process.hrtime.bigint();
-  const logResponseDuration = () => {
-    if (invocationId !== currentInvocationId) return;
-    delete EvalError.$serverlessRequestHandlerPromise;
-    delete EvalError.$serverlessResponseHandlerPromise;
-    if (responseStartTime) {
-      debugLog(
-        'Extension overhead duration: internal response:',
-        `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`
-      );
-      responseStartTime = null;
-    }
-  };
-  const wrapCallback =
-    (originalCallback) =>
-    (...args) => {
-      if (invocationId !== currentInvocationId) {
-        originalCallback(...args);
-        return;
-      }
-      Promise.all([
+      if (invocationId !== currentInvocationId) return null;
+      return Promise.all([
         EvalError.$serverlessRequestHandlerPromise,
         EvalError.$serverlessResponseHandlerPromise,
-      ]).finally(() => {
-        process.nextTick(() => originalCallback(...args));
-        logResponseDuration();
-      });
-    };
-  const done = wrapCallback(context.done);
-  context.done = done;
-  context.succeed = (result) => done(null, result);
-  context.fail = (err) => done(err == null ? 'handled' : err);
-  const result = wrappedHandler(event, context, wrapCallback(callback));
-  if (!result) return result;
-  if (typeof result.then !== 'function') return result;
-  return Promise.resolve(result).finally(() => {
-    if (invocationId !== currentInvocationId) return null;
-    return Promise.all([
-      EvalError.$serverlessRequestHandlerPromise,
-      EvalError.$serverlessResponseHandlerPromise,
-    ]).finally(logResponseDuration);
-  });
+      ]).finally(logResponseDuration);
+    });
+  };
 };
+
+if (EvalError.$serverlessHandlerDeferred) {
+  const handlerDeferred = EvalError.$serverlessHandlerDeferred;
+  delete EvalError.$serverlessHandlerDeferred;
+  module.exports = handlerDeferred.then((handlerModule) => {
+    if (handlerModule == null) return handlerModule;
+
+    const path = require('path');
+    const handlerBasename = path.basename(process.env._HANDLER);
+    const handlerModuleBasename = handlerBasename.slice(0, handlerBasename.indexOf('.'));
+
+    const handlerPropertyPathTokens = handlerBasename
+      .slice(handlerModuleBasename.length + 1)
+      .split('.');
+    const handlerFunctionName = handlerPropertyPathTokens.pop();
+    let handlerContext = handlerModule;
+    while (handlerPropertyPathTokens.length) {
+      handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
+      if (handlerContext == null) return handlerModule;
+    }
+    const handlerFunction = handlerContext[handlerFunctionName];
+    if (typeof handlerFunction !== 'function') return handlerModule;
+
+    return { handler: wrapHandler(handlerFunction) };
+  });
+  return;
+}
+
+const handlerFunction = EvalError.$serverlessHandlerFunction;
+delete EvalError.$serverlessHandlerFunction;
+module.exports.handler = wrapHandler(handlerFunction);

--- a/node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/success-callback-express.js
+++ b/node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/success-callback-express.js
@@ -10,6 +10,10 @@ app.get('/', (req, res) => {
   return res.status(200).json({ message: 'Hello from root!' });
 });
 
+app.get('/foo', (req, res) => {
+  return res.status(200).json({ message: 'Hello from /foo!' });
+});
+
 app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
 
 module.exports.handler = serverless(app);

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -21,7 +21,7 @@ describe('integration', function () {
     [
       'success-callback-express',
       {
-        i: {
+        invokeOptions: {
           payload: {
             version: '2.0',
             routeKey: '$default',

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -25,7 +25,7 @@ describe('integration', function () {
           payload: {
             version: '2.0',
             routeKey: '$default',
-            rawPath: '/',
+            rawPath: '/foo',
             rawQueryString: '',
             headers: {
               'accept':
@@ -54,7 +54,7 @@ describe('integration', function () {
               domainPrefix: '1hqnqp4a70',
               http: {
                 method: 'GET',
-                path: '/',
+                path: '/foo',
                 protocol: 'HTTP/1.1',
                 sourceIp: '80.55.87.22',
                 userAgent:

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -103,9 +103,11 @@ describe('integration', function () {
       : handlerModuleName;
 
     testScenariosConfig.push({
-      handlerModuleName,
+      functionConfig: {
+        handlerModuleName,
+        basename: functionBasename,
+      },
       testConfig,
-      functionBasename,
     });
   }
 
@@ -113,7 +115,7 @@ describe('integration', function () {
     await createCoreResources(coreConfig);
     for (const testScenarioConfig of testScenariosConfig) {
       testScenarioConfig.deferredResult = processFunction(
-        testScenarioConfig.handlerModuleName,
+        testScenarioConfig.functionConfig,
         testScenarioConfig.testConfig,
         coreConfig
       ).catch((error) => ({
@@ -127,7 +129,7 @@ describe('integration', function () {
 
   for (const testScenarioConfig of testScenariosConfig) {
     const {
-      functionBasename,
+      functionConfig: { basename: functionBasename },
       testConfig: { invokeOptions = {}, test },
     } = testScenarioConfig;
 

--- a/node/packages/aws-lambda-otel-extension/test/integration/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/process-function.js
@@ -63,8 +63,6 @@ const ensureIsActive = async (fnConfig) => {
 };
 
 const invoke = async (fnConfig, testConfig) => {
-  // Local computer time might a bit out of sync. Relax time range by 3 seconds
-  fnConfig.invokeStartTime = Date.now() - 3000;
   const { invokeOptions = {} } = testConfig;
 
   const payload = invokeOptions.payload || {};

--- a/node/packages/aws-lambda-otel-extension/test/integration/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/process-function.js
@@ -67,14 +67,16 @@ const invoke = async (fnConfig, testConfig) => {
   fnConfig.invokeStartTime = Date.now() - 3000;
   const { invokeOptions = {} } = testConfig;
 
+  const payload = invokeOptions.payload || {};
+  log.debug('invoke request payload %O', payload);
   const result = await awsRequest(Lambda, 'invoke', {
     FunctionName: fnConfig.name,
-    Payload: Buffer.from(JSON.stringify(invokeOptions.payload || {}), 'utf8'),
+    Payload: Buffer.from(JSON.stringify(payload), 'utf8'),
   });
   try {
     const responsePayload = JSON.parse(Buffer.from(result.Payload));
-    log.debug('invoke payload %O', responsePayload);
-    log.debug('invoke parsed payload %O', JSON.parse(responsePayload.body));
+    log.debug('invoke response payload %O', responsePayload);
+    log.debug('invoke response parsed payload %O', JSON.parse(responsePayload.body));
   } catch {
     /* ignore */
   }

--- a/node/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
@@ -69,21 +69,21 @@ const handleSuccess = async (handlerModuleName, payload = {}) => {
   try {
     await requireUncached(async () => {
       await require('../../../internal/otel-extension-internal-node');
+      const handlerModule = await require('../../../internal/otel-extension-internal-node/wrapper');
       await new Promise((resolve, reject) => {
-        const maybeThenable =
-          require('../../../internal/otel-extension-internal-node/wrapper').handler(
-            payload,
-            {
-              awsRequestId: '123',
-              functionName,
-              invokedFunctionArn: `arn:aws:lambda:us-east-1:123456789012:function:${functionName}`,
-              getRemainingTimeInMillis: () => 3000,
-            },
-            (error, result) => {
-              if (error) reject(error);
-              else resolve(result);
-            }
-          );
+        const maybeThenable = handlerModule.handler(
+          payload,
+          {
+            awsRequestId: '123',
+            functionName,
+            invokedFunctionArn: `arn:aws:lambda:us-east-1:123456789012:function:${functionName}`,
+            getRemainingTimeInMillis: () => 3000,
+          },
+          (error, result) => {
+            if (error) reject(error);
+            else resolve(result);
+          }
+        );
         if (isThenable(maybeThenable)) resolve(maybeThenable);
       });
     });


### PR DESCRIPTION
AWS apparently uses a different internal module loader in v14 than in v16, and our wrapper patch does not work for ESM in the context of node16.x runtime.

This PR fixes that and ensures we run tests against all supported runtimes.

Additionally:
- Ensure to handle well scenarios where the report is split among multiple CloudWatch logs (observed such situation locally)
- Improve debug logs for lambda invocation
- Fix express app test setup (after recent refactor, it didn't receive API Gateway payload - ensure that also test crashes if we have regression on that - we just tested that express instrumentation loaded and not that it generated spans specific to request, it was improved)
- Fix time range configuration for CW logs retrieval (by mistake, we've used start time recorded before the last invocation and not before the first one - I've observed one test locally due to that - otherwise, it usually worked as start time was intentionally subtracted by additional 3s)
- Handle eventual race conditions on AWS side in the context of `Lambda.invoke` (in response to failure observed locally)
- Refactor tests setup, so different testing scenarios can be set for each handler (so far, it was one scenario per handler)