### PR TITLE
fix: Updated timeout error message

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -201,7 +201,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     functionData.errorExceptionType = 'TimeoutError';
     functionData.errorExceptionMessage = '';
     functionData.errorExceptionStacktrace =
-      'Function execution is going to exceeded configured timeout limit.';
+      'Function execution exceeded the configured timeout limit.';
   } else if (err) {
     functionData.error = true;
     functionData.errorCulprit = err.message;


### PR DESCRIPTION
## Description
The error message is a bit vague in that it sounds like the timeout has not happened yet even though it most likely has happened. So we decided to update the message to be a bit more definite given this error is showing up in the console UI. 