### PR TITLE
Bug fixes and benchmark improvements

### DIFF
--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const http = require('http');
+const https = require('https');
+
 const isObject = (value) => value && typeof value === 'object';
 
 const extensionVersion = (() => {
@@ -246,4 +249,8 @@ module.exports = {
   resourceAttributes,
   measureAttributes,
   stripResponseBlobData,
+  keepAliveAgents: {
+    http: new http.Agent({ keepAlive: true }),
+    https: new https.Agent({ keepAlive: true }),
+  },
 };

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -20,7 +20,10 @@ module.exports = (async () => {
   const servers = new Set();
 
   const userSettings = require('./user-settings');
-  const { debugLog } = require('./helper');
+  const {
+    debugLog,
+    keepAliveAgents: { http: keepAliveAgent },
+  } = require('./helper');
   const reportOtelData = require('./report-otel-data');
   const {
     createMetricsPayload,
@@ -168,6 +171,7 @@ module.exports = (async () => {
       const request = http.request(
         `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-08-15/logs`,
         {
+          agent: keepAliveAgent,
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
@@ -212,6 +216,7 @@ module.exports = (async () => {
         const request = http.request(
           `${baseUrl}/event/next`,
           {
+            agent: keepAliveAgent,
             method: 'GET',
             headers: {
               'Content-Type': 'application/json',
@@ -334,6 +339,7 @@ module.exports = (async () => {
     const request = http.request(
       `${baseUrl}/register`,
       {
+        agent: keepAliveAgent,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -286,16 +286,29 @@ module.exports = (async () => {
                       createLogPayload(data.record, currentRequestContext.logsQueue)
                     );
                   }
+                  if (currentRequestContext.responseEventPayload) {
+                    sendReport(
+                      'response',
+                      createResponsePayload(currentRequestContext.responseEventPayload, data.record)
+                    );
+                  }
                 }
                 break;
               case 'telemetryData':
                 lastTelemetryData = data;
                 if (data.record.responseEventPayload) {
-                  const { requestData } = getCurrentRequestContext();
-                  sendReport(
-                    'response',
-                    createResponsePayload(data.record.responseEventPayload, requestData)
-                  );
+                  const currentRequestContext = getCurrentRequestContext();
+                  if (!currentRequestContext.requestData) {
+                    currentRequestContext.responseEventPayload = data.record.responseEventPayload;
+                  } else {
+                    sendReport(
+                      'response',
+                      createResponsePayload(
+                        data.record.responseEventPayload,
+                        currentRequestContext.requestData
+                      )
+                    );
+                  }
                 }
                 sendReport('metrics', createMetricsPayload(data.requestId, data.record.function));
                 for (const tracePayload of createTracePayload(

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -118,12 +118,10 @@ const requestHandler = async (span, { event, context }) => {
     };
   }
 
+  debugLog('Internal extension: Send event data');
   if (process.env.TEST_DRY_LOG) {
-    process._rawDebug(
-      `${require('util').inspect(eventDataPayload, { depth: Infinity, colors: true })}\n`
-    );
+    process.stdout.write(`⚡ eventData: ${JSON.stringify(eventDataPayload)}\n`);
   } else {
-    debugLog('Internal extension: Send event data');
     // Send request data to external so that we can attach this data to logs
     await fetch(`http://localhost:${OTEL_SERVER_PORT}`, {
       method: 'post',
@@ -339,12 +337,10 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
     };
   }
 
+  debugLog('Internal extension: Send telemetry data');
   if (process.env.TEST_DRY_LOG) {
-    process._rawDebug(
-      `${require('util').inspect(telemetryDataPayload, { depth: Infinity, colors: true })}\n`
-    );
+    process.stdout.write(`⚡ telemetryData: ${JSON.stringify(telemetryDataPayload)}\n`);
   } else {
-    debugLog('Internal extension: Send telemetry data');
     await fetch(`http://localhost:${OTEL_SERVER_PORT}`, {
       method: 'post',
       body: JSON.stringify(telemetryDataPayload),

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json
@@ -24,7 +24,6 @@
     "@opentelemetry/sdk-trace-base": "^1.3.1",
     "@opentelemetry/sdk-trace-node": "^1.3.1",
     "lodash.clone": "^4.5.0",
-    "lodash.get": "^4.4.2",
-    "node-fetch": "^2.6.7"
+    "lodash.get": "^4.4.2"
   }
 }

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/index.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/index.js
@@ -47,11 +47,13 @@ module.exports = async (options = {}) => {
   const coreConfig = {};
   await createCoreResources(coreConfig, { layerTypes: ['nodeAll', 'nodeInternal'] });
 
+  const memorySize = options.memorySize || 128;
   const allBenchmarkVariantsConfig = new Map([
     [
       'bare',
       {
         configuration: {
+          MemorySize: memorySize,
           Layers: [],
           Environment: { Variables: {} },
         },
@@ -61,6 +63,7 @@ module.exports = async (options = {}) => {
       'externalOnly',
       {
         configuration: {
+          MemorySize: memorySize,
           Environment: {
             Variables: {
               SLS_OTEL_USER_SETTINGS: JSON.stringify({ logs: { disabled: true } }),
@@ -74,6 +77,7 @@ module.exports = async (options = {}) => {
       'internalOnly',
       {
         configuration: {
+          MemorySize: memorySize,
           Layers: [coreConfig.layerInternalArn],
           Environment: {
             Variables: {
@@ -89,6 +93,7 @@ module.exports = async (options = {}) => {
       'jsonLog',
       {
         configuration: {
+          MemorySize: memorySize,
           Environment: {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
@@ -107,6 +112,7 @@ module.exports = async (options = {}) => {
       'protoLog',
       {
         configuration: {
+          MemorySize: memorySize,
           Environment: {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
@@ -125,6 +131,7 @@ module.exports = async (options = {}) => {
   if (token) {
     allBenchmarkVariantsConfig.set('protoConsole', {
       configuration: {
+        MemorySize: memorySize,
         Environment: {
           Variables: {
             AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -258,7 +258,7 @@ const retrieveReports = async (testConfig) => {
         currentInvocationData = null;
       }
     }
-  } while (invocationsData.length < 2);
+  } while (invocationsData.length < testConfig.invokeCount);
 
   if (processesData.length !== 1 && handledOutcomes.has(testConfig.expectedOutcome)) {
     throw new Error(

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -87,8 +87,13 @@ const invoke = async (testConfig) => {
       Payload: Buffer.from(JSON.stringify(invokePayload), 'utf8'),
     });
   } catch (error) {
-    if (error.message.includes('The role defined for the function cannot be assumed by Lambda')) {
+    if (
+      error.message.includes('The role defined for the function cannot be assumed by Lambda') ||
+      error.message.includes('Lambda was unable to decrypt the environment variables')
+    ) {
       // Occassional race condition issue on AWS side, retry
+      log.error('Approached error, retying ivocation: %o', error);
+      await wait(100);
       return invoke(testConfig);
     }
     error.message = `"${testConfig.configuration.FunctionName}" invocation failed: ${error.message}`;

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -104,7 +104,7 @@ const invoke = async (testConfig) => {
   }
   if (result.FunctionError) {
     if (expectedOutcome.startsWith('error')) return duration;
-    throw new Error(`Invocation errored: ${result.FunctionError}`);
+    throw new Error(`Invocation of ${testConfig.name} errored: ${result.FunctionError}`);
   }
   return duration;
 };

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -160,6 +160,7 @@ const retrieveReports = async (testConfig) => {
     let currentInvocationData;
     let currentProcessData;
     let startedMessage;
+    let isExternalExtensionLoaded = false;
     const getCurrentInvocationData = () => {
       if (!currentInvocationData) {
         log.error(
@@ -173,6 +174,7 @@ const retrieveReports = async (testConfig) => {
     };
     for (const { message } of events) {
       if (message.startsWith('Extension overhead duration: external initialization')) {
+        isExternalExtensionLoaded = true;
         processesData.push(
           (currentProcessData = {
             extensionOverheadDurations: {
@@ -180,6 +182,10 @@ const retrieveReports = async (testConfig) => {
             },
           })
         );
+        continue;
+      }
+      if (!isExternalExtensionLoaded && message.startsWith('Internal extension: Init')) {
+        processesData.push((currentProcessData = { extensionOverheadDurations: {} }));
         continue;
       }
       if (message.startsWith('Extension overhead duration: internal initialization')) {

--- a/node/packages/aws-lambda-otel-extension/test/scripts/benchmark.js
+++ b/node/packages/aws-lambda-otel-extension/test/scripts/benchmark.js
@@ -18,6 +18,7 @@ const resolveSet = (comaSeparatedValue) =>
 require('../benchmark')({
   benchmarkVariants: argv['benchmark-variants'] ? resolveSet(argv['benchmark-variants']) : null,
   useCases: argv['use-cases'] ? resolveSet(argv['use-cases']) : null,
+  memorySize: argv['memory-size'] ? Number(argv['memory-size']) : null,
 }).then((resultsMap) => {
   process.stdout.write(
     `${[


### PR DESCRIPTION
### Extension fixes and improvements
- Fix regression introduced with #80. In this PR dependency on `eventData` was added when handling `telemetryData`, yet there are scenarios observed when `telemetryData` arrives to the extension before `eventData`. Logic was not prepared for that. I've added a patch which ensures that in such case we wait for the `eventData` and propagate response data after we have it.
- Remove `node-fetch` dependency from internal extension
- Ensure to reuse HTTP(s) request sockets (enforce `keepAlive`)

### Benchmark fixes and improvements
- Add `internalOnly` benchmark variant case, where only overhead of internal extension is measured
- Add support for `--memory-size` param, through which we can test different memory size scenarios
- Improve benchmark internals