### PR TITLE
glossary, spelling, links

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "runtimes"
+    ]
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,12 +7,12 @@ menuOrder: 5
 
 # FAQ
 
-## Instrumenting apps and services
+## Configuring apps and services
 
 **How do I start using Serverless Console with my app?**
 
 The simplest way to get going with Serverless Console is to make sure your on
-the latest version of Serverless Framework and add the console enabled property
+the latest version of Serverless Framework and add the `console` property
 to your `serverless.yaml` file.
 
 ```yaml
@@ -23,6 +23,7 @@ frameworkVersion: '3'
 ```
 
 **Note:** The following example will disable the use of Serverless Dashboard. 
+
 **What Serverless.yaml fields effect console?**
 
 Several details of your serverless.yaml file will be relevant in Serverless
@@ -30,7 +31,7 @@ Console. This includes, your org (required), stage, service and function names.
 
 ```yaml
 
-# Orginization name (required)
+# Organization name (required)
 org: myorg
 
 # Console flag (required true)
@@ -55,11 +56,11 @@ functions:
 
 ```
 
-Additonally the stage parameter will be included as an environment filter within
+Additionally the stage parameter will be included as an environment filter within
 Serverless Console.
 
 ```text
-severless deploy --stage #included as environment
+serverless deploy --stage #included as environment
 ```
 
 ## Logging in and signing up
@@ -81,7 +82,7 @@ npm -g install serverless
 
 An organization is a unique tenant within the Serverless suite of products (including Serverless Dashboard, Serverless Cloud, and Serverless Console). This name must be unique, and we randomly assign a combination of words as your organization name if you're using Console for the first time. 
 
-**How does Serverless Console relate to Serveless Dashboard?**
+**How does Serverless Console relate to Serverless Dashboard?**
 
 Serverless Console is a new stand alone product, but can leverage functionality
 from Serverless Dashboard features for parameters and providers. To take
@@ -96,7 +97,7 @@ service: myservice
 frameworkVersion: '3'
 ```
 
-Serverles Console also share your orginization and users from Serverless
+Serverless Console also share your organization and users from Serverless
 Dashboard and/or Serverless Cloud. 
 
 ## Metrics and Use Cases
@@ -104,7 +105,7 @@ Dashboard and/or Serverless Cloud.
 **I am not seeing all my details from API-Gateway?**
 At this time some details from API gateway are not collected. This means
 some errors are not recorded in a Trace. We recommend using a framework
-like [Express](../guide/esbuild.md) to assist with capturing a errors.
+like [Express](platform/frameworks.md) to assist with capturing a errors.
 
 **What languages and runtimes are supported?**
 
@@ -112,18 +113,18 @@ Currently Serverless Console only supports Node.js on AWS Lambda.
 
 **How can I use console to find API Errors?**
 
-Trouble shooting and finding API errors is a valuable way to use Serveless
+Trouble shooting and finding API errors is a valuable way to use Serverless
 Console. To identify API Errors, select the HTTP status codes and filter for
 500 or other status codes you are interested in visualizing. We recommend 
 [saving a custom view](using/metrics.md)of your non 200 status code across 
-in your production envorionments across your org. 
+in your production environments across your org. 
 
-You can use this view to quickly identify anomolies, and then locate the
+You can use this view to quickly identify anomalies, and then locate the
 underlying [Trace](using/traces.md) that caused the problem.
 
 **How can I use console to find slow API Endpoints?**
 
-Slow API responses can negatively impact users and cost your orginization money.
+Slow API responses can negatively impact users and cost your organization money.
 Our metrics and trace explorer allow you to filter on specific endpoints and
 environment. From there the p95 metric shows you the worst 5% of API
 performance, and the p90 metric shows you the worst 10%. Filtering the traces
@@ -152,7 +153,7 @@ Overages only apply when a Trace has
 We display a cost metric based on the duration and memory used by your Lambda 
 function and is based on a x86 price of `$0.0000166667` per Gigabyte second.
 Using our cost figure, along wit our filters allows you to understand your
-Serveless compute costs across AWS accounts in ways it can be hard to accomplish
+Serverless compute costs across AWS accounts in ways it can be hard to accomplish
 otherwise. 
 
 ## Data Retention

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,38 +15,25 @@ The following definitions provide context on how these terms are used
 in the documentation and serves as a starting point for learning
 about the Serverless Console.
 
-# Serverless
+## Serverless
 Serverless Console is optimized for use in Function as a Service (FAAS) platforms, specifically
 [AWS Lambda](#aws-lambda). That said, we define Serverless as any pay-for-usage
 managed service and plan to offer more platforms and services in the near future. [Contact Sales](https://www.serverless.com/sales) if you'd like to learn more about our Road Map.
 
+<!--
 # Logs
 [Logs](product/logs.md) are collected directly from your application and
-are avialble both streaming and in [Traces](product/traces.md) within Serverless
+are available both streaming and in [Traces](product/traces.md) within Serverless
 Console. All logs include a set of [Tags](product/tags.md) for searching and filtering
 within the [Explorer](product/explorer.md) but are ingested and 
-stored seperate from Traces and Metrics.
+stored separate from Traces and Metrics.
 
 # Metrics
 [Metrics](product/metrics.md) are numerical data about the 
 performance of your applications or its underlying infrastructure.
 These metrics are collected by the [Serverless Console Extension](platform/extension.md)
-during an invocation but are ingested and store seperately from a Traces,
+during an invocation but are ingested and store separately from a Traces,
 and Logs. For more details about Metrics see the [product/metrics.md] section.
-
-# Traces
-All the observability details about your apps and services are
-captured as [Traces](products/traces.md). The Trace brings together
-the Metrics, Tags, and Spans associated to an event within your system.
-Traces can be used to identify slowness, pinpoint errors, and understand
-the interaction between different systems. 
-
-There are several durations asscociated with a single Trace
-which segemented as Initialization, Invocation and Shutdown. Not
-all of these affect the end-user experience or your bill.
-
-A more detailed description of what is incldued for each duration is included
-in our [duration guide](product/duration.md).
 
 # Tags
 All Traces, Logs and Metrics share a specific set of [Semantic Tags](tags.md)
@@ -58,28 +45,41 @@ A [Scope](product/scopes.md) is a set of tags used to identify patterns as use-c
 are handled by Serverless Console. All metrics, logs, and traces must
 match a recognized scope to be ingested into Serverless Console.
 
-# Serverless Console Extension
-The [Serverless Console Extension](platform/extension.md) is a AWS Lambda extension
-for collecting logs, metrics, and trace data from your AWS Lambda functions. 
-
 # Organization
 An organization is a unique tenant within the Serverless suite of 
 products (including Serverless Dashboard, Serverless Cloud, and 
 Serverless Console). 
 
-# AWS Lambda
-The following are AWS specific terms which are helpful in understanding how 
-Serevrless Console applies specific AWS Lambda Functionality.
+-->
 
-## Handler
+## Tracing
+All the observability details about your apps and services are
+captured as [Traces](product/traces.md). The Trace brings together
+the [Metrics](product/metrics.md), [Tags](product/tags.md), and [Spans](product/traces.md#spans) associated to an event within your system.
+Traces can be used to identify slowness, pinpoint errors, and understand
+the interaction between different systems. 
+
+There are several durations associated with a single Trace
+which segmented as Initialization, Invocation and Shutdown. Not
+all of these affect the end-user experience or your bill.
+
+A more detailed description of what is included for each duration is included
+in our [duration guide](product/duration.md).
+
+## Function Handler
 The handler of an AWS Lambda function is where your business logic resides.
 Fore more details about what duration accounted for in the Handler see the
 [duration guide](product/duration.md#extensions-and-the-invocation-phase)
 
+## Lambda Extension
+A Lambda extension is a way for tools to deeply integrate with Lambda 
+functionality and is used to collect metrics, logs, and traces from your
+Lambda function. See more details about the Serverless Console Extension.
+
 ## Initialization
-The initilization phase of a Trace includes any setup time associated
-with the event. This will include one time occurences like an
-[AWS Cold-Start](#cold-start), as well as initatlizing runtime requirements. 
+The initialization phase of a Trace includes any setup time associated
+with the event. This will include one time occurrences like an
+[AWS Cold-Start](#cold-start), as well as initializing runtime requirements. 
 Poor Initialization performance will directly affect the experience of your 
 users and customers as well as affect cost.
 
@@ -87,20 +87,20 @@ More details about optimizing initialization performance are in the
 [Duration Guide](product/duration.md#optimizing-initlization-in-aws).
 
 ## Invocation 
-An invocation referes to the execution of a function in a Serverless
+An invocation refers to the execution of a function in a Serverless
 FAAS such as AWS Lambda. This only includes the specific execution
-of your bussines logic and code you control directly. Because it does
-not include all of the initlization time, it does not represent the
+of your business logic and code you control directly. Because it does
+not include all of the initialization time, it does not represent the
 duration end users experience, or used to calculate cost. 
 
 ## Shutdown
 Most FAAS platforms utilize some sort of shutdown process that can
-impact [Initilization](#initialization) behavior and timeouts. These
+impact [Initialization](#initialization) behavior and timeouts. These
 details are not collected or represented in Serverless Console and
 does not usually affect cost or end user experience directly.
 
 ## Cold-Start
-When an AWS Lambda function recieves a request, and it has not been used before, or for several minutes, its environment and code must first be Initialized.  This process is known as an AWS Lambda Cold-Start.  This process adds latency to the overall invocation duration.
+When an AWS Lambda function receives a request, and it has not been used before, or for several minutes, its environment and code must first be Initialized.  This process is known as an AWS Lambda Cold-Start.  This process adds latency to the overall invocation duration.
 
 After the execution completes, the execution environment is frozen. To improve resource management and performance, the Lambda service retains the execution environment for a non-deterministic period of time. During this time, if another request arrives for the same function, the service may reuse the environment. This second request typically finishes more quickly, since the execution environment already exists and it’s not necessary to download the code and run the initialization code. This is called a Warm-Start.
 

--- a/docs/platform/extension.md
+++ b/docs/platform/extension.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Console Lambda Extension
 menuText: Lambda Extension
-description: An overview of the Serverles Runtime
+description: An overview of the Serverless Runtime
 menuOrder: 6
 -->
 
@@ -17,7 +17,7 @@ a set of Node.js modules is used. This is referred to as the Internal Instrument
 Additional language support will require language specific Open Telemetry Libraries.
 
 ## External Extension
-In additional to runtime libraries installed by the Severless Extension, an extrnal
+In additional to runtime libraries installed by the Serverless Extension, an external
 Lambda Extension is used to forward logs, metrics, and traces to
 Serverless Console. This component is independent from the language runtime.
 
@@ -25,5 +25,5 @@ Serverless Console. This component is independent from the language runtime.
 [Serverless Framework](../index.md) is the easiest way to instrument your app or
 service with the Serverless Console Extension. Additionally, 
 it is possible to configure the Serverless Console Extension without 
-Serverless Framework. Details about configuring the environemnt variables can
-be found in [AWS OTEL Lambda Extension](../../node/packages/aws-lambda-otel-extension/README.md)
+Serverless Framework. Details about configuring the environment variables can
+be found in [AWS OTEL Lambda Extension](https://github.com/serverless/console/tree/main/node/packages/aws-lambda-otel-extension)

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -10,7 +10,7 @@ menuOrder: 3
 
 Serverless Console is optimized to work with AWS Lambda, and has planned integration
 for further AWS Service integration. This guide provides instructions
-for, [configuring credentials](setting-up-creds.md), [instrumentating AWS Lambda functions](extension.md) 
+for, [configuring credentials](setting-up-creds.md), [instrumenting AWS Lambda functions](extension.md) 
 and [supported frameworks](frameworks.md).
 
 ## Runtime Support
@@ -21,4 +21,4 @@ On AWS Lambda we currently only support Node.js.
 Node.js is the only supported runtime for instrumenting with Serverless Console.
 
 ### Python
-Pyhton support is coming soon!
+Python support is coming soon!

--- a/docs/product/create-org.md
+++ b/docs/product/create-org.md
@@ -42,8 +42,8 @@ so your desired organization name may not be available.
 ## Using Serverless Dashboard Orgs
 If you have an existing Serverless Dashboard org and you log into 
 Serverless Console you will automatically start using your existing 
-organization. Additionally if you are a member of a Serevrless Dashboard
-orginization you will automatically made a member of that org in 
+organization. Additionally if you are a member of a Serverless Dashboard
+organization you will automatically made a member of that org in 
 Serverless Console.  
 
 **Note:** if you change your org name in Console, you’ll need to specify the dashboard name separately to take advantage of dashboard features like Parameters and Providers. This can be done by including the console specific name in the console section of your configuration, as in the example below.

--- a/docs/product/duration.md
+++ b/docs/product/duration.md
@@ -14,24 +14,24 @@ values in Serverless Console charts and interfaces.
 
 ## Understanding Duration Across Console
 Applying these definitions, you can expect the following behavior and details
-are incldued across Console. 
+are included across Console. 
 
 **On the Metrics View**
 The red number and dots represent the slowest 5% of transactions that occurred 
 during the time frame selected. This does not include Cold Starts. 
 
-The black number and line describe the average Duration for the selected timeframe. 
+The black number and line describe the average Duration for the selected time frame. 
 This does not include Cold Starts.
 
 **On the Explorer** 
 When the Trace is first received the value shown, is the Trace Duration of *your* function
 and does not yet include Extension Duration. A few seconds after the Trace is received we receive
-the full duration details and show the full duration with any Cold Starts duration. The max value progress bar is calculated based on the 5% slowest duration during the timeframe to help show relative performance of the trace. 
+the full duration details and show the full duration with any Cold Starts duration. The max value progress bar is calculated based on the 5% slowest duration during the time frame to help show relative performance of the trace. 
 
 **On Trace Detail View**
 The Duration shown in the header represents the execution time
 of your function plus the duration of any execution time of any Lambda Extensions 
-including the Serveless Runtime OTEL Extension.
+including the Serverless Console Extension.
 
 The span chart is based on the start and end times collected from the 
 Open Telemetry trace, plus the recorded Cold Start if one occurred. 
@@ -39,12 +39,12 @@ It does not include Lambda Extension Execution Times and is therefore not \direc
 
 **When Filtering**
 Filtering is based on the Duration of your function, pluse the duration 
-of any Lambda Extensions including the Serveless Runtime OTEL Extension.
+of any Lambda Extensions including the Serverless Runtime OTEL Extension.
 
 **When Calculating Cost**
 Cost is calculated based on Billed Duration. 
 
-## Optimizing Initlization in AWS Lambda
+## Optimizing Initialization in AWS Lambda
 Initialization includes the following:
 
 * Initializing all External AWS Lambda Extensions configured

--- a/docs/product/index.md
+++ b/docs/product/index.md
@@ -18,8 +18,8 @@ getting started.
 ## Follow our Getting Started Guide for Serverless Framework
 The easiest way to get started is using our [Serverless Framework Guide](../index.md).
 
-## Signup or log in at console.serverless.com
-[Create your orginization](create-org.md) and learn how to deploy by logging into [Console](https://console.serverless.com?utm_campaign=Console%20Signup&utm_source=docs&utm_content=console%20docs%20login%20link)
+## Sign up or log in at console.serverless.com
+[Create your organization](create-org.md) and learn how to deploy by logging into [Console](https://console.serverless.com?utm_campaign=Console%20Signup&utm_source=docs&utm_content=console%20docs%20login%20link)
 
 ## Find or Submit a Question to our FAQ
 If your looking for an answer to a specific question find it on our [../faq.md]

--- a/docs/product/logs.md
+++ b/docs/product/logs.md
@@ -25,7 +25,7 @@ in order to stream logs.
 ## Trace Logs
 Logs are also especially useful when troubleshooting specific
 errors. When you find an invocation that results in an error
-and click on the Trace, you can find details about the exection
+and click on the Trace, you can find details about the execution
 under the Logs section of the Trace Detail view. 
 
 ## Disabling log collection

--- a/docs/product/tags.md
+++ b/docs/product/tags.md
@@ -25,7 +25,7 @@ Should be set to `lambda`.
 **Deployment** - Deployment tags identify details about your specific
 deployment.
 - `deployment.environment` This is the environment an app is deployed to. It can
-be defined as `stage` in `serverlss.yaml` file `prod`.
+be defined as `stage` in `serverless.yaml` file `prod`.
 
 **FAAS Tags** - FAAS tags identify details function as a service platforms like
 AWS Lambda.
@@ -38,7 +38,7 @@ with `aws.sqs`
 - `faas.name` - This the name of the single function that was invoked. 
 `console-node-http-api-hello`
 - `faas.error_message` The error message if one is captured.
-`Exception occured`
+`Exception occurred`
 
 **HTTP Tags** - HTTP tags identify details for HTTP based API's
 - `http.path` - This is the http path with the path that includes path param
@@ -50,11 +50,11 @@ place holders `/test/{id}`
 **Service Tags** - Service tags identify naming details about the underlying
 resources of your service. 
 - `service.name` This a resource name for the service that your function or
-container is running in. For Serverless Framwork users this will combine your
+container is running in. For Serverless Framework users this will combine your
 stage, service name, and function name. `console-node-http-api`
 - `service.namespace` The serverless organization app service name assigned to
 this code. This can be specified as the service name in the `serverless.yaml`
-file or will be inherited based in your compute envirionment.
+file or will be inherited based in your compute environment.
 `console-node-http-api`
 
 ## Filters

--- a/docs/product/traces.md
+++ b/docs/product/traces.md
@@ -15,8 +15,8 @@ To do this we provided a set of tools for analyzing Traces
 
 ## Spans
 
-A Trace contains a set of Spans associated with and displated in the style of a 
-Gant Chart. This chartprovides you with context for when, and 
+A Trace contains a set of Spans associated with and displayed in the style of a 
+Gant Chart. This chart provides you with context for when, and 
 how long various subsequent interactions took. 
 
 For more details about Spans see our [Example Trace](#example-trace).
@@ -31,9 +31,9 @@ Detail view.
 ## Explorer View
 
 Similar to our [Metrics View](metrics.md) the Trace Explorer provides you a
-starting point for discovering errors, or slowness across your Orginization.
+starting point for discovering errors, or slowness across your Organization.
 Similar to metrics views you can apply filters to narrow in on errors, slowness
-or usage patterns across your orginization. 
+or usage patterns across your organization. 
 
 Traces share the same set of filters from our [Metrics View](metrics.md) but are
 not saved.


### PR DESCRIPTION
This PR has several docs changes.

* Glossary Trimming - removes (comments out) some likely known terms likes logs, metrics
* Glossary formatting - changes some formatting away from h1, to h2. 
* Spelling changes throughout
* Fixes more links and adds ref to main README

@ac360 tagging you because this undoes a bit of some changes you made a few days ago but should look better IMO. Will merge later without your review but wanted to give you a heads up. 