### PR TITLE
Fix promise resolution handling

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -80,10 +80,7 @@ const wrapOriginalHandler = (orignalHandler) => {
       (someAwsCallback) =>
       (...args) => {
         // Callback invoked by Otel instrumentation after triggering response hook
-        if (invocationId !== currentInvocationId) {
-          someAwsCallback(...args);
-          return;
-        }
+        if (invocationId !== currentInvocationId) return;
         Promise.all([
           EvalError.$serverlessRequestHandlerPromise,
           EvalError.$serverlessResponseHandlerPromise,

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -14,7 +14,7 @@ if (!EvalError.$serverlessHandlerFunction && !EvalError.$serverlessHandlerDeferr
 const awsLambdaInstrumentation = EvalError.$serverlessAwsLambdaInstrumentation;
 delete EvalError.$serverlessAwsLambdaInstrumentation;
 
-const wrapOriginalHandler = (orignalHandler) => {
+const wrapOriginalHandler = (originalHandler) => {
   let requestStartTime;
   let responseStartTime;
   let currentInvocationId = 0;
@@ -46,7 +46,7 @@ const wrapOriginalHandler = (orignalHandler) => {
       context.done = done;
       context.succeed = (result) => done(null, result);
       context.fail = (err) => done(err == null ? 'handled' : err);
-      const result = orignalHandler(event, context, wrapOtelCallback(otelCallback));
+      const result = originalHandler(event, context, wrapOtelCallback(otelCallback));
       if (!result) return result;
       if (typeof result.then !== 'function') return result;
       return Promise.resolve(result).finally(() => {

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -173,6 +173,7 @@ describe('integration', function () {
       log.debug('instrumentationSpans %o', instrumentationSpans);
       if (testConfig.test) {
         testConfig.test({
+          invocationsData,
           metricsReport,
           tracesReport,
           resourceMetrics,

--- a/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/integration/index.test.js
@@ -83,10 +83,13 @@ describe('integration', function () {
           },
           isBase64Encoded: false,
         },
-        test: ({ instrumentationSpans }) => {
+        test: ({ instrumentationSpans, invocationsData }) => {
           expect(
             instrumentationSpans['@opentelemetry/instrumentation-express'].length
           ).to.be.at.least(4);
+          expect(
+            invocationsData.map(({ responsePayload }) => responsePayload.bodyJson)
+          ).to.deep.equal([{ message: 'Hello from /foo!' }, { message: 'Hello from /foo!' }]);
         },
       },
     ],


### PR DESCRIPTION
Fix for a bug reported internally.

In wrapper we're overriding `context` methods, to catch user resolutions, yet same methods are used internally by AWS in case of promise resolution. Additionally, we have dedicated logic to ensure correct resolution if lambda is attempted to be resolved with boith callback and promise, and that one broke those methods for internal AWS resolver.

This patch ensures that for internal AWS resolver those methods work as if not patched