### PR TITLE
Allow to run benchmark against separate external extension

### DIFF
--- a/node/packages/aws-lambda-otel-extension/test/benchmark/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/README.md
@@ -201,8 +201,16 @@ Generated benchmark results are output to the console in CSV format. To store th
 ./test/scripts/benchmark.js > benchmark.csv
 ```
 
-Benchmark run can additionally be configured with following CLI params
+### 4.1 Run customization
 
-- `--use-cases` Function use cases to test (e.g. `callback,express`)
-- `--benchmark-variants` Benchmark variants to test (e.g. `bare,externalOnly`)
+Benchmark run can additionally be customized with following CLI params
+
+- `--use-cases` Comma separated list of function use cases to test (e.g. `callback,express`)
+- `--benchmark-variants` Comma separated list of benchmark variants to test (e.g. `bare,externalOnly`)
 - `--memory-size` Memory size to provide to lambdas (by default it's 128MB).
+- `--extension-layers-mode` By default benchmark are run against single layer which contains Node.js external and internal extension. By setting `dual` value for this mode, benchmark will be run with those two extensions provided as separate layers (and external layer will come with Node.js binary bundled)
+
+Additionally extension layers that are used for testing can be overridden with following environment variables:
+
+- `TEST_LAYER_FILENAME` - Path to `.zip` file of a layer which contains both external and internal Node.js extensions. Ineffective with `--extension-layers-mode=dual`
+- `TEST_EXTERNAL_LAYER_FILENAME` - Path to `.zip` file of a layer which contains external (runtime agnostic) extension. Effective only with `--extension-layers-mode=dual`

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/README.md
@@ -214,3 +214,4 @@ Additionally extension layers that are used for testing can be overridden with f
 
 - `TEST_LAYER_FILENAME` - Path to `.zip` file of a layer which contains both external and internal Node.js extensions. Ineffective with `--extension-layers-mode=dual`
 - `TEST_EXTERNAL_LAYER_FILENAME` - Path to `.zip` file of a layer which contains external (runtime agnostic) extension. Effective only with `--extension-layers-mode=dual`
+- `TEST_INTERNAL_LAYER_FILENAME` - Path to `.zip` file of a layer which contains just internal Node.js extension. It's effective for `internalOnly` benchmark variant, and in other cases effective only with `--extension-layers-mode=dual`

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/index.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/index.js
@@ -7,7 +7,9 @@ const run = require('./lib/run');
 
 module.exports = async (options = {}) => {
   const coreConfig = {};
-  await createCoreResources(coreConfig, { layerTypes: ['nodeAll', 'nodeInternal'] });
+  await createCoreResources(coreConfig, {
+    layerTypes: [options.extensionLayersMode === 'dual' ? 'external' : 'nodeAll', 'nodeInternal'],
+  });
 
   const allBenchmarkVariantsConfig = await resolveCommonBenchmarkVariantsConfig(
     coreConfig,

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -58,6 +58,7 @@ module.exports = async (coreConfig, options) => {
               DEBUG_SLS_OTEL_LAYER: '1',
             },
           },
+          ...(coreConfig.layerExternalArn ? null : { Layers: [coreConfig.layerExternalArn] }),
         },
       },
     ],

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -35,7 +35,7 @@ const resolveIngestionData = async () => {
 };
 
 module.exports = async (coreConfig, options) => {
-  const memorySize = options.memorySize || 128;
+  const memorySize = options.memorySize || 1024;
   const allBenchmarkVariantsConfig = new Map([
     [
       'bare',

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/performance.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/performance.test.js
@@ -20,14 +20,14 @@ describe('performance', function () {
 
   // TODO: Reduce acceptable durations once improvements are made
   it('should introduce reasonable initialization overhead', () => {
-    expect(results.initialization.total.median).to.be.below(500);
+    expect(results.initialization.total.median).to.be.below(400);
   });
 
   it('should introduce reasonable first invocation overhead', () => {
-    expect(results.invocation.first.total.median).to.be.below(2500);
+    expect(results.invocation.first.total.median).to.be.below(200);
   });
 
   it('should introduce reasonable following invocation overhead', () => {
-    expect(results.invocation.following.total.median).to.be.below(1500);
+    expect(results.invocation.following.total.median).to.be.below(150);
   });
 });

--- a/node/packages/aws-lambda-otel-extension/test/lib/cleanup.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/cleanup.js
@@ -57,7 +57,11 @@ const deleteLayers = async (layerName) => {
 };
 
 const deleteAllLayers = () =>
-  Promise.all([deleteLayers(basename), deleteLayers(`${basename}-internal`)]);
+  Promise.all([
+    deleteLayers(basename),
+    deleteLayers(`${basename}-internal`),
+    deleteLayers(`${basename}-external`),
+  ]);
 
 const deleteRole = async () => {
   const policyArn = `arn:aws:iam::${

--- a/node/packages/aws-lambda-otel-extension/test/lib/cleanup.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/cleanup.js
@@ -56,9 +56,8 @@ const deleteLayers = async (layerName) => {
   );
 };
 
-const deleteDefaultLayers = () => deleteLayers(basename);
-const deleteInternalLayers = () => deleteLayers(`${basename}-internal`);
-const deleteAllLayers = () => Promise.all([deleteDefaultLayers(), deleteInternalLayers()]);
+const deleteAllLayers = () =>
+  Promise.all([deleteLayers(basename), deleteLayers(`${basename}-internal`)]);
 
 const deleteRole = async () => {
   const policyArn = `arn:aws:iam::${

--- a/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
@@ -10,7 +10,7 @@ const buildLayer = require('../../scripts/lib/build');
 const awsRequest = require('../utils/aws-request');
 const basename = require('./basename');
 
-const createLayer = async (config, { layerName, filename, skipBuild, buildConfig }) => {
+const createLayer = async ({ layerName, filename, skipBuild, buildConfig }) => {
   if (!skipBuild) {
     log.info('Building layer');
     await buildLayer(filename, buildConfig);
@@ -35,35 +35,35 @@ const createLayers = async (config, layerTypes) => {
       switch (layerType) {
         case 'nodeAll':
           if (process.env.TEST_LAYER_FILENAME) {
-            config.layerArn = await createLayer(config, {
+            config.layerArn = await createLayer({
               layerName: basename,
               filename: process.env.TEST_LAYER_FILENAME,
               skipBuild: true,
             });
             return;
           }
-          config.layerArn = await createLayer(config, {
+          config.layerArn = await createLayer({
             layerName: basename,
             filename: path.resolve(__dirname, '../../dist/extension.zip'),
           });
           return;
         case 'external':
           if (process.env.TEST_EXTERNAL_LAYER_FILENAME) {
-            config.layerExternalArn = await createLayer(config, {
+            config.layerExternalArn = await createLayer({
               layerName: `${basename}-external`,
               filename: process.env.TEST_EXTERNAL_LAYER_FILENAME,
               skipBuild: true,
             });
             return;
           }
-          config.layerExternalArn = await createLayer(config, {
+          config.layerExternalArn = await createLayer({
             layerName: `${basename}-external`,
             filename: path.resolve(__dirname, '../../dist/extension.external.zip'),
             buildConfig: { mode: 2 },
           });
           return;
         case 'nodeInternal':
-          config.layerInternalArn = await createLayer(config, {
+          config.layerInternalArn = await createLayer({
             layerName: `${basename}-internal`,
             filename: path.resolve(__dirname, '../../dist/extension.internal.zip'),
             buildConfig: { mode: 1 },

--- a/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
@@ -17,14 +17,12 @@ const createLayer = async ({ layerName, filename, skipBuild, buildConfig }) => {
   }
 
   log.info('Publishing layer (%s) to AWS', filename);
-  await awsRequest(Lambda, 'publishLayerVersion', {
-    LayerName: layerName,
-    Content: { ZipFile: await fsp.readFile(filename) },
-  });
-  log.info('Resolving layer ARN');
   const arn = (
-    await awsRequest(Lambda, 'listLayerVersions', { LayerName: layerName })
-  ).LayerVersions.shift().LayerVersionArn;
+    await awsRequest(Lambda, 'publishLayerVersion', {
+      LayerName: layerName,
+      Content: { ZipFile: await fsp.readFile(filename) },
+    })
+  ).LayerVersionArn;
   log.info('Layer ready %s', arn);
   return arn;
 };

--- a/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
@@ -47,6 +47,21 @@ const createLayers = async (config, layerTypes) => {
             filename: path.resolve(__dirname, '../../dist/extension.zip'),
           });
           return;
+        case 'external':
+          if (process.env.TEST_EXTERNAL_LAYER_FILENAME) {
+            config.layerExternalArn = await createLayer(config, {
+              layerName: `${basename}-external`,
+              filename: process.env.TEST_EXTERNAL_LAYER_FILENAME,
+              skipBuild: true,
+            });
+            return;
+          }
+          config.layerExternalArn = await createLayer(config, {
+            layerName: `${basename}-external`,
+            filename: path.resolve(__dirname, '../../dist/extension.external.zip'),
+            buildConfig: { mode: 2 },
+          });
+          return;
         case 'nodeInternal':
           config.layerInternalArn = await createLayer(config, {
             layerName: `${basename}-internal`,

--- a/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/create-core-resources.js
@@ -63,6 +63,14 @@ const createLayers = async (config, layerTypes) => {
           });
           return;
         case 'nodeInternal':
+          if (process.env.TEST_INTERNAL_LAYER_FILENAME) {
+            config.layerExternalArn = await createLayer({
+              layerName: `${basename}-internal`,
+              filename: process.env.TEST_INTERNAL_LAYER_FILENAME,
+              skipBuild: true,
+            });
+            return;
+          }
           config.layerInternalArn = await createLayer({
             layerName: `${basename}-internal`,
             filename: path.resolve(__dirname, '../../dist/extension.internal.zip'),

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -31,7 +31,9 @@ const create = async (testConfig, coreConfig) => {
       Code: {
         ZipFile: await resolveDirZipBuffer(fixturesDirname),
       },
-      Layers: [coreConfig.layerArn],
+      Layers: coreConfig.layerArn
+        ? [coreConfig.layerArn]
+        : [coreConfig.layerExternalArn, coreConfig.layerInternalArn],
       Environment: {
         Variables: {
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -28,6 +28,7 @@ const create = async (testConfig, coreConfig) => {
     await awsRequest(Lambda, 'createFunction', {
       Role: coreConfig.roleArn,
       Runtime: 'nodejs16.x',
+      MemorySize: 1024,
       Code: {
         ZipFile: await resolveDirZipBuffer(fixturesDirname),
       },

--- a/node/packages/aws-lambda-otel-extension/test/scripts/benchmark.js
+++ b/node/packages/aws-lambda-otel-extension/test/scripts/benchmark.js
@@ -19,6 +19,7 @@ require('../benchmark')({
   benchmarkVariants: argv['benchmark-variants'] ? resolveSet(argv['benchmark-variants']) : null,
   useCases: argv['use-cases'] ? resolveSet(argv['use-cases']) : null,
   memorySize: argv['memory-size'] ? Number(argv['memory-size']) : null,
+  extensionLayersMode: argv['extension-layers-mode'] || null,
 }).then((resultsMap) => {
   process.stdout.write(
     `${[


### PR DESCRIPTION
Introduce `--extension-layers-mode` which allow to run benchmarks against separate layers hosting internal and external extension. Additionally path to custom external layer can be passed through `TEST_EXTERNAL_LAYER_FILENAME` environment variable.

Additionally:
- Set memory size default to 1024. That's also the default in the Framework, and it's probably closest value to reflect real world usage