### PR TITLE
Convert extension to be Serverless Console specific

### DIFF
--- a/node/packages/aws-lambda-otel-extension/README.md
+++ b/node/packages/aws-lambda-otel-extension/README.md
@@ -79,6 +79,18 @@ Monitoring settings are expected to be provided in JSON format at `SLS_OTEL_USER
 
 ##### Required settings:
 
+###### `orgId`
+
+Serverless Console organization id
+
+###### `namespace`
+
+Namespace at which reports should be grouped (Serverless Framework sets it with _service name_)
+
+###### `environment`
+
+Application environment (Serverless Framework sets with _stage_ value)
+
 ###### `ingestToken`
 
 Serverless Console ingestion token, to be obtained via Serverless Console API. At this point it's resolved automatically in context of the Serverless Framework (manual resolution instructions will be provided in a near future)

--- a/node/packages/aws-lambda-otel-extension/README.md
+++ b/node/packages/aws-lambda-otel-extension/README.md
@@ -93,7 +93,6 @@ logs:
   # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
   destination: https://some-url/ | s3://bucketname[/rootkey]
 metrics:
-  outputType: protobuf | json # Output type (defaults to protobuf)
   # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
   destination: https://some-url/ | s3://bucketname[/rootkey]
 request:
@@ -107,7 +106,6 @@ response:
   # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
   destination: https://some-url/ | s3://bucketname[/rootkey
 traces:
-  outputType: protobuf | json # Output type (defaults to protobuf)
   # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
   destination: https://some-url/ | s3://bucketname[/rootkey]
 ```

--- a/node/packages/aws-lambda-otel-extension/README.md
+++ b/node/packages/aws-lambda-otel-extension/README.md
@@ -1,6 +1,6 @@
 # @serverless/aws-lambda-otel-extension
 
-## AWS Lambda extension that gathers [OpenTelemetry](https://opentelemetry.io/) data and sends it to the designated destination
+## AWS Lambda extension that gathers [OpenTelemetry](https://opentelemetry.io/) data and sends it to the Serverless Console ingestion servers
 
 _Package is still in an experimental stage and subject to major changes._
 
@@ -10,7 +10,7 @@ _At this point, only Node.js runtime is supported, but this support will be exte
 
 The extension is a lambda layer with a source maintained in [opt](opt) folder. There are two extensions configured within a layer:
 
-1. External, placed in [opt/otel-extension/external](opt/otel-extension/external) folder, which gathers information (from (1) execution environment (2) AWS Lambdas APIs (3) Data provided via internal extension) and sends the compliant [OpenTelemetry](https://opentelemetry.io/) payload to designated destination (see [Configure destination endpoints of telemetry payloads](#configure-destination-endpoints-of-telemetry-payloads))
+1. External, placed in [opt/otel-extension/external](opt/otel-extension/external) folder, which gathers information (from (1) execution environment (2) AWS Lambdas APIs (3) Data provided via internal extension) and sends the compliant [OpenTelemetry](https://opentelemetry.io/) payload to Serverless Console ingestion servers
 2. Internal, placed in [opt/otel-extension/internal](opt/otel-extension/internal) folder, which is pre-run in the same process as Node.js Lambda handler, and through pre-setup instrumentation gathers additional data about invocations, which is sent to external extension
 
 ### What telemetry payload does it generate?
@@ -73,42 +73,35 @@ Ensure that layer version ARN is listed in Lambda layers.
 
 Ensure that internal extension of a layer is pre-loaded by configuring `AWS_LAMBDA_EXEC_WRAPPER` environment variable with `/opt/otel-extension-internal-node/exec-wrapper.sh`
 
-##### 4. Configure monitoring settings
+#### 4. Configure monitoring settings
 
 Monitoring settings are expected to be provided in JSON format at `SLS_OTEL_USER_SETTINGS` environment variable.
 
-All settings are optional, still if no settings are provided, the generated telemetry reports will be just logged into process output.
+##### Required settings:
 
-Supported settings:
+###### `ingestToken`
 
-```yaml
-common:
-  # Settings common to all reports
-  destination:
-    # Request headers for server (url) destinations
-    requestHeaders: param1=value&param2=value # search params string of headers to be added to each request
-logs:
-  # Log report settings
-  disabled: true # Disable logs monitoring
-  # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
-  destination: https://some-url/ | s3://bucketname[/rootkey]
-metrics:
-  # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
-  destination: https://some-url/ | s3://bucketname[/rootkey]
-request:
-  # Request report settings
-  disabled: true # Disable request reporting
-  # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
-  destination: https://some-url/ | s3://bucketname[/rootkey]
-response:
-  # Response report settings
-  disabled: true # Disable response reporting
-  # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
-  destination: https://some-url/ | s3://bucketname[/rootkey
-traces:
-  # Destination can be HTTP/HTTPS url, or S3 bucket. If not provided reports are written to the console
-  destination: https://some-url/ | s3://bucketname[/rootkey]
-```
+Serverless Console ingestion token, to be obtained via Serverless Console API. At this point it's resolved automatically in context of the Serverless Framework (manual resolution instructions will be provided in a near future)
+
+##### Optional settings:
+
+##### `logs`
+
+Settings that affect log monitoring. Supported options:
+
+- `logs.disabled` - Set to true to disable logs monitoring
+
+##### `request`
+
+Settings that affect requests monitoring. Supported options:
+
+- `request.disabled` - Set to true to disable requests monitoring
+
+##### `response`
+
+Settings that affect response monitoring. Supported options:
+
+- `response.disabled` - Set to true to disable response monitoring
 
 ### Generated reports structure
 

--- a/node/packages/aws-lambda-otel-extension/README.md
+++ b/node/packages/aws-lambda-otel-extension/README.md
@@ -75,7 +75,7 @@ Ensure that internal extension of a layer is pre-loaded by configuring `AWS_LAMB
 
 #### 4. Configure monitoring settings
 
-Monitoring settings are expected to be provided in JSON format at `SLS_OTEL_USER_SETTINGS` environment variable.
+Monitoring settings are expected to be provided in JSON format at `SLS_EXTENSION` environment variable.
 
 ##### Required settings:
 

--- a/node/packages/aws-lambda-otel-extension/README.md
+++ b/node/packages/aws-lambda-otel-extension/README.md
@@ -148,32 +148,6 @@ _HTTP Responses with a non JSON body will be ignored_
 
 ### Tests
 
-To run tests ensure to additionaly run `npm install` in following folders:
+Tests can only be run in context of package repository (they're not included with npm package).
 
-- `external/otel-extension-external`
-- `internal/otel-extension-internal-node`
-- `test/fixtures/lambdas`
-
-#### Unit tests
-
-Unit tests are configured to be independent of any external infrastructure (AWS Lambda environment is emulated).
-
-```bash
-npm test
-```
-
-#### Integration tests
-
-AWS account is needed to run integration tests, and AWS credentials need to be configured.
-
-In tests, the home folder is mocked, therefore AWS access cannot be reliably set up via the `AWS_PROFILE` variable or any other means that rely on configuration placed in the home folder.
-
-Easiest is to run tests is by setting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` environment variables.
-
-Tests create a temporary layer and Lambda resources and remove them after the test is finalized.
-
-All created resourced are named or prefixed with `test-otel-extension-<testUid>` string, where `testUid` is four characters taken from [local machine id](https://www.npmjs.com/package/node-machine-id) or in case of CI runs a random string. `testUid` string can also be overriden via environment variable `TEST_UID`
-
-```bash
-npm run test:integration
-```
+See [Tests documentation](./test/README.md)

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/helper.js
@@ -239,7 +239,7 @@ const measureAttributes = [
 ];
 
 const debugLog = (...args) => {
-  if (process.env.DEBUG_SLS_OTEL_LAYER) {
+  if (process.env.SLS_DEBUG_EXTENSION) {
     process._rawDebug(...args);
   }
 };

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -371,7 +371,7 @@ module.exports = (async () => {
     'Extension overhead duration: external shutdown:',
     `${Math.round(Number(process.hrtime.bigint() - shutdownStartTime) / 1000000)}ms`
   );
-  if (!process.env.SLS_TEST_RUN) process.exit();
+  if (!process.env.SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT) process.exit();
 })().catch((error) => {
   // Ensure to crash extension process on unhandled rejection
   process.nextTick(() => {

--- a/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
+++ b/node/packages/aws-lambda-otel-extension/external/otel-extension-external/index.js
@@ -85,7 +85,7 @@ module.exports = (async () => {
                 // TODO: Remove after Dashboard is turned off
                 !event.record.includes('SERVERLESS_ENTERPRISE')
             );
-            if (process.env.DEBUG_SLS_OTEL_LAYER) {
+            if (process.env.SLS_DEBUG_EXTENSION) {
               functionLogEvents = functionLogEvents.filter(
                 (event) => !event.record.startsWith('Extension overhead duration: ')
               );

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -122,7 +122,7 @@ const requestHandler = async (span, { event, context }) => {
 
   const requestBody = JSON.stringify(eventDataPayload);
   debugLog('Internal extension: Send event data');
-  if (process.env.TEST_DRY_LOG) {
+  if (process.env.SLS_TEST_EXTENSION_INTERNAL_LOG) {
     process.stdout.write(`⚡ eventData: ${requestBody}\n`);
   } else {
     // Send request data to external so that we can attach this data to logs
@@ -370,7 +370,7 @@ const responseHandler = async (span, { res, err }, isTimeout) => {
 
   const requestBody = JSON.stringify(telemetryDataPayload);
   debugLog('Internal extension: Send telemetry data');
-  if (process.env.TEST_DRY_LOG) {
+  if (process.env.SLS_TEST_EXTENSION_INTERNAL_LOG) {
     process.stdout.write(`⚡ telemetryData: ${requestBody}\n`);
   } else {
     const requestStartTime = process.hrtime.bigint();

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -9,6 +9,10 @@ const debugLog = (...args) => {
 };
 debugLog('Internal extension: Init');
 
+// Bundled user settings may involve environment variables adjustments
+// therefore needs to be loaded first
+const userSettings = require('./user-settings');
+
 const http = require('http');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { InMemorySpanExporter } = require('@opentelemetry/sdk-trace-base');
@@ -35,7 +39,6 @@ const AwsLambdaInstrumentation = require('./aws-lambda-instrumentation');
 const { diag, DiagConsoleLogger } = require('@opentelemetry/api');
 const SlsSpanProcessor = require('./span-processor');
 const { detectEventType } = require('./event-detection');
-const userSettings = require('./user-settings');
 
 const OTEL_SERVER_PORT = 2772;
 const logLevel = getEnv().OTEL_LOG_LEVEL;

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -11,7 +11,18 @@ debugLog('Internal extension: Init');
 
 // Bundled user settings may involve environment variables adjustments
 // therefore needs to be loaded first
-const userSettings = require('./user-settings');
+const userSettings = (() => {
+  try {
+    return require('./user-settings');
+  } catch (error) {
+    process.stdout.write(
+      `Error: Extension user settings resolution crashed with: ${error.stack}\n`
+    );
+    process.stdout.write('Extension will operate in no-op mode\n');
+    return null;
+  }
+})();
+if (!userSettings) return;
 
 const http = require('http');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -3,7 +3,7 @@
 const processStartTime = process.hrtime.bigint();
 
 const debugLog = (...args) => {
-  if (process.env.DEBUG_SLS_OTEL_LAYER) {
+  if (process.env.SLS_DEBUG_EXTENSION) {
     process._rawDebug(...args);
   }
 };
@@ -459,7 +459,7 @@ module.exports = detectResources({
 
 const { handlerLoadDuration } = require('./prepare-wrapper')();
 
-if (process.env.DEBUG_SLS_OTEL_LAYER) {
+if (process.env.SLS_DEBUG_EXTENSION) {
   process._rawDebug(
     'Extension overhead duration: internal initialization:',
     `${Math.round(

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/wrapper.js
@@ -21,7 +21,7 @@ const wrapOriginalHandler = (originalHandler) => {
   let isResolved = false;
   const unresolvedPromise = new Promise(() => {});
   const debugLog = (...args) => {
-    if (process.env.DEBUG_SLS_OTEL_LAYER) process._rawDebug(...args);
+    if (process.env.SLS_DEBUG_EXTENSION) process._rawDebug(...args);
   };
   let contextDone;
 

--- a/node/packages/aws-lambda-otel-extension/lib/user-settings.js
+++ b/node/packages/aws-lambda-otel-extension/lib/user-settings.js
@@ -33,7 +33,7 @@ const bundledSettings = (() => {
 
 if (bundledSettings) merge(userSettings, bundledSettings);
 
-const envSettingsText = process.env.SLS_OTEL_USER_SETTINGS;
+const envSettingsText = process.env.SLS_EXTENSION;
 if (envSettingsText) merge(userSettings, JSON.parse(envSettingsText));
 
 const altDestination = (() => {

--- a/node/packages/aws-lambda-otel-extension/lib/user-settings.js
+++ b/node/packages/aws-lambda-otel-extension/lib/user-settings.js
@@ -3,12 +3,9 @@
 'use strict';
 
 const userSettings = (module.exports = {
-  common: { destination: {} },
   logs: {},
-  metrics: {},
   request: {},
   response: {},
-  traces: {},
 });
 
 const isObject = (value) => Boolean(value && typeof value === 'object');
@@ -38,3 +35,16 @@ if (bundledSettings) merge(userSettings, bundledSettings);
 
 const envSettingsText = process.env.SLS_OTEL_USER_SETTINGS;
 if (envSettingsText) merge(userSettings, JSON.parse(envSettingsText));
+
+const altDestination = (() => {
+  const setting = process.env.SLS_TEST_EXTENSION_REPORT_DESTINATION || '';
+  if (setting.startsWith('s3://')) return setting;
+  if (setting === 'log') return setting;
+  return null;
+})();
+
+if (altDestination) {
+  userSettings._altDestination = altDestination;
+} else if (!userSettings.ingestToken) {
+  throw new Error('Missing required "ingestToken" setting');
+}

--- a/node/packages/aws-lambda-otel-extension/lib/user-settings.js
+++ b/node/packages/aws-lambda-otel-extension/lib/user-settings.js
@@ -45,6 +45,24 @@ const altDestination = (() => {
 
 if (altDestination) {
   userSettings._altDestination = altDestination;
-} else if (!userSettings.ingestToken) {
-  throw new Error('Missing required "ingestToken" setting');
+} else {
+  if (!userSettings.ingestToken) throw new Error('Missing required "ingestToken" setting');
+  if (!userSettings.orgId) throw new Error('Missing required "orgId" setting');
+  if (!userSettings.namespace) throw new Error('Missing required "namespace" setting');
+  if (!userSettings.environment) throw new Error('Missing required "environment" setting');
+}
+
+const otelResourceAtrributes = [];
+if (userSettings.namespace) {
+  otelResourceAtrributes.push(`sls_service_name=${userSettings.namespace}`);
+}
+if (userSettings.environment) otelResourceAtrributes.push(`sls_stage=${userSettings.environment}`);
+if (userSettings.orgId) otelResourceAtrributes.push(`sls_org_id=${userSettings.orgId}`);
+
+if (otelResourceAtrributes.length) {
+  if (process.env.OTEL_RESOURCE_ATTRIBUTES) {
+    process.env.OTEL_RESOURCE_ATTRIBUTES += `,${otelResourceAtrributes.join(',')}`;
+  } else {
+    process.env.OTEL_RESOURCE_ATTRIBUTES = otelResourceAtrributes.join(',');
+  }
 }

--- a/node/packages/aws-lambda-otel-extension/lib/user-settings.js
+++ b/node/packages/aws-lambda-otel-extension/lib/user-settings.js
@@ -26,25 +26,15 @@ const merge = (target, source) => {
 
 const bundledSettings = (() => {
   try {
-    // eslint-disable-next-line import/no-unresolved
-    return require('./.user-settings');
+    require.resolve('./.user-settings');
   } catch {
     return null;
   }
+  // eslint-disable-next-line import/no-unresolved
+  return require('./.user-settings');
 })();
 
 if (bundledSettings) merge(userSettings, bundledSettings);
 
-const envSettings = (() => {
-  const envSettingsText = process.env.SLS_OTEL_USER_SETTINGS;
-
-  if (!envSettingsText) return null;
-  try {
-    return JSON.parse(envSettingsText);
-  } catch (error) {
-    process._rawDebug(`Resolution of user settings failed with: ${error.message}`);
-    return null;
-  }
-})();
-
-if (envSettings) merge(userSettings, envSettings);
+const envSettingsText = process.env.SLS_OTEL_USER_SETTINGS;
+if (envSettingsText) merge(userSettings, JSON.parse(envSettingsText));

--- a/node/packages/aws-lambda-otel-extension/lib/user-settings.js
+++ b/node/packages/aws-lambda-otel-extension/lib/user-settings.js
@@ -5,10 +5,10 @@
 const userSettings = (module.exports = {
   common: { destination: {} },
   logs: {},
-  metrics: { outputType: 'protobuf' },
+  metrics: {},
   request: {},
   response: {},
-  traces: { outputType: 'protobuf' },
+  traces: {},
 });
 
 const isObject = (value) => Boolean(value && typeof value === 'object');

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -47,6 +47,7 @@ npm run test:performance
 
 How extensions behave, for various testing purposes, can be tweaked with following environment variables:
 
+- `SERVERLESS_PLATFORM_STAGE` - Ingestion server stage to which reports should be propagated (default is `prod`, with this setting it can be overriden to `dev`)
 - `SLS_DEBUG_EXTENSION` - Log debug messages, of which scope is to:
   - Mark certain processing points
   - Log payloads which are send between extensions and to the external ingestion server

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -53,3 +53,4 @@ How extensions behave, for various testing purposes, can be tweaked with followi
   - Report durations overhead that extension introduces
 - `SLS_TEST_EXTENSION_INTERNAL_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
 - `SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT` - In context of the external extension, do not exit the process after shutdown phase
+- `SLS_TEST_EXTENSION_REPORT_TYPE` - Set to `json` to pass reports in direct JSON format instead of Protobuf

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -54,3 +54,6 @@ How extensions behave, for various testing purposes, can be tweaked with followi
 - `SLS_TEST_EXTENSION_INTERNAL_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
 - `SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT` - In context of the external extension, do not exit the process after shutdown phase
 - `SLS_TEST_EXTENSION_REPORT_TYPE` - Set to `json` to pass reports in direct JSON format instead of Protobuf
+- `SLS_TEST_EXTENSION_REPORT_DESTINATION` - Telemetry reports normally are sent to the Console ingestion servers, with this variable this can be overriden:
+  - Set to `s3://<bucket>//<root-key>` to send reports to S3 bucket
+  - Set to `log` to just log reports into process stdout

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -18,7 +18,7 @@ Easiest is to run tests is by setting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KE
 
 Tests create a temporary layer and Lambda resources and remove them after the test is finalized.
 
-All created resourced are named or prefixed with `test-otel-extension-<testUid>` string, where `testUid` is four characters taken from [local machine id](https://www.npmjs.com/package/node-machine-id) or in case of CI runs a random string. `testUid` string can also be overriden via environment variable `TEST_UID`
+All created resourced are named or prefixed with `test-otel-extension-<testUid>` string, where `testUid` is four characters taken from [local machine id](https://www.npmjs.com/package/node-machine-id) or in case of CI runs a random string. `testUid` string can also be overridden via environment variable `TEST_UID`
 
 ```bash
 npm run test:integration
@@ -47,7 +47,7 @@ npm run test:performance
 
 How extensions behave, for various testing purposes, can be tweaked with following environment variables:
 
-- `SERVERLESS_PLATFORM_STAGE` - Ingestion server stage to which reports should be propagated (default is `prod`, with this setting it can be overriden to `dev`)
+- `SERVERLESS_PLATFORM_STAGE` - Ingestion server stage to which reports should be propagated (default is `prod`, with this setting it can be overridden to `dev`)
 - `SLS_DEBUG_EXTENSION` - Log debug messages, of which scope is to:
   - Mark certain processing points
   - Log payloads which are send between extensions and to the external ingestion server
@@ -55,6 +55,6 @@ How extensions behave, for various testing purposes, can be tweaked with followi
 - `SLS_TEST_EXTENSION_INTERNAL_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
 - `SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT` - In context of the external extension, do not exit the process after shutdown phase
 - `SLS_TEST_EXTENSION_REPORT_TYPE` - Set to `json` to pass reports in direct JSON format instead of Protobuf
-- `SLS_TEST_EXTENSION_REPORT_DESTINATION` - Telemetry reports normally are sent to the Console ingestion servers, with this variable this can be overriden:
+- `SLS_TEST_EXTENSION_REPORT_DESTINATION` - Telemetry reports normally are sent to the Console ingestion servers, with this variable this can be overridden:
   - Set to `s3://<bucket>//<root-key>` to send reports to S3 bucket
   - Set to `log` to just log reports into process stdout

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -24,6 +24,25 @@ All created resourced are named or prefixed with `test-otel-extension-<testUid>`
 npm run test:integration
 ```
 
+## Performance tests
+
+Both AWS credentials Serverless Console credentials are needed to run performance test.
+
+Test confirms on performance of the extension instrumentation. Specifically they validate whether introduced initialization and invocation duration overhead doesn't go beyond agreed threshold.
+
+Same as in case of integration tests, home folder is mocked, so AWS credentials cannot be set via `AWS_PROFILE` (easiest it to provide them via `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`).
+
+Console credentials need to be provided with following environment variables:
+
+- `SLS_ORG_NAME` - Name of the organization
+- `SLS_ORG_TOKEN` - Authentication org token, which can be obtained for given organization in Console UI
+
+Otherwise characteristic of test is very same as in case of integration tests (please follow it's documentation)
+
+```bash
+npm run test:performance
+```
+
 ## Environment variables
 
 How extensions behave, for various testing purposes, can be tweaked with following environment variables:

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -1,0 +1,25 @@
+# Tests
+
+## Unit tests
+
+Unit tests are configured to be independent of any external infrastructure (AWS Lambda environment is emulated), and can be run offline
+
+```bash
+npm test
+```
+
+## Integration tests
+
+AWS account is needed to run integration tests, and AWS credentials need to be configured.
+
+In tests, the home folder is mocked, therefore AWS access cannot be reliably set up via the `AWS_PROFILE` variable or any other means that rely on configuration placed in the home folder.
+
+Easiest is to run tests is by setting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` environment variables.
+
+Tests create a temporary layer and Lambda resources and remove them after the test is finalized.
+
+All created resourced are named or prefixed with `test-otel-extension-<testUid>` string, where `testUid` is four characters taken from [local machine id](https://www.npmjs.com/package/node-machine-id) or in case of CI runs a random string. `testUid` string can also be overriden via environment variable `TEST_UID`
+
+```bash
+npm run test:integration
+```

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -51,5 +51,5 @@ How extensions behave, for various testing purposes, can be tweaked with followi
   - Mark certain processing points
   - Log payloads which are send between extensions and to the external ingestion server
   - Report durations overhead that extension introduces
-- `TEST_DRY_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
+- `SLS_TEST_EXTENSION_INTERNAL_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
 - `SLS_TEST_RUN` - In context of the external extension, do not exit the process after shutdown phase

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -47,7 +47,7 @@ npm run test:performance
 
 How extensions behave, for various testing purposes, can be tweaked with following environment variables:
 
-- `DEBUG_SLS_OTEL_LAYER` - Log debug messages, of which scope is to:
+- `SLS_DEBUG_EXTENSION` - Log debug messages, of which scope is to:
   - Mark certain processing points
   - Log payloads which are send between extensions and to the external ingestion server
   - Report durations overhead that extension introduces

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -52,4 +52,4 @@ How extensions behave, for various testing purposes, can be tweaked with followi
   - Log payloads which are send between extensions and to the external ingestion server
   - Report durations overhead that extension introduces
 - `SLS_TEST_EXTENSION_INTERNAL_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
-- `SLS_TEST_RUN` - In context of the external extension, do not exit the process after shutdown phase
+- `SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT` - In context of the external extension, do not exit the process after shutdown phase

--- a/node/packages/aws-lambda-otel-extension/test/README.md
+++ b/node/packages/aws-lambda-otel-extension/test/README.md
@@ -23,3 +23,14 @@ All created resourced are named or prefixed with `test-otel-extension-<testUid>`
 ```bash
 npm run test:integration
 ```
+
+## Environment variables
+
+How extensions behave, for various testing purposes, can be tweaked with following environment variables:
+
+- `DEBUG_SLS_OTEL_LAYER` - Log debug messages, of which scope is to:
+  - Mark certain processing points
+  - Log payloads which are send between extensions and to the external ingestion server
+  - Report durations overhead that extension introduces
+- `TEST_DRY_LOG` - In context of the internal extension, log payloads instead of sending them to the external extension
+- `SLS_TEST_RUN` - In context of the external extension, do not exit the process after shutdown phase

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -72,7 +72,7 @@ module.exports = async (coreConfig, options) => {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
-              TEST_DRY_LOG: '1',
+              SLS_TEST_EXTENSION_INTERNAL_LOG: '1',
             },
           },
         },

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -55,7 +55,7 @@ module.exports = async (coreConfig, options) => {
           Environment: {
             Variables: {
               SLS_OTEL_USER_SETTINGS: JSON.stringify({ logs: { disabled: true } }),
-              DEBUG_SLS_OTEL_LAYER: '1',
+              SLS_DEBUG_EXTENSION: '1',
             },
           },
           ...(coreConfig.layerExternalArn ? null : { Layers: [coreConfig.layerExternalArn] }),
@@ -71,7 +71,7 @@ module.exports = async (coreConfig, options) => {
           Environment: {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-              DEBUG_SLS_OTEL_LAYER: '1',
+              SLS_DEBUG_EXTENSION: '1',
               TEST_DRY_LOG: '1',
             },
           },
@@ -86,7 +86,7 @@ module.exports = async (coreConfig, options) => {
           Environment: {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-              DEBUG_SLS_OTEL_LAYER: '1',
+              SLS_DEBUG_EXTENSION: '1',
               SLS_OTEL_USER_SETTINGS: JSON.stringify({
                 logs: { disabled: true },
                 metrics: { outputType: 'json' },
@@ -105,7 +105,7 @@ module.exports = async (coreConfig, options) => {
           Environment: {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-              DEBUG_SLS_OTEL_LAYER: '1',
+              SLS_DEBUG_EXTENSION: '1',
               SLS_OTEL_USER_SETTINGS: JSON.stringify({
                 logs: { disabled: true },
               }),
@@ -124,7 +124,7 @@ module.exports = async (coreConfig, options) => {
         Environment: {
           Variables: {
             AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-            DEBUG_SLS_OTEL_LAYER: '1',
+            SLS_DEBUG_EXTENSION: '1',
             OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${service},sls_stage=${stage},sls_org_id=${orgId}`,
             SLS_OTEL_USER_SETTINGS: JSON.stringify({
               common: { destination: { requestHeaders: `serverless_token=${token}` } },

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const apiRequest = require('@serverless/utils/api-request');
-const backendUrl = require('@serverless/utils/lib/auth/urls').backend;
 const log = require('log').get('test');
 
-const ingestionServerUrl = `${backendUrl}/ingestion/kinesis`;
 const service = 'benchmark';
 const stage = 'test';
 
@@ -73,6 +71,7 @@ module.exports = async (coreConfig, options) => {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
               SLS_TEST_EXTENSION_INTERNAL_LOG: '1',
+              SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
             },
           },
         },
@@ -88,6 +87,7 @@ module.exports = async (coreConfig, options) => {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
               SLS_TEST_EXTENSION_REPORT_TYPE: 'json',
+              SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
               SLS_OTEL_USER_SETTINGS: JSON.stringify({
                 logs: { disabled: true },
               }),
@@ -105,6 +105,7 @@ module.exports = async (coreConfig, options) => {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
+              SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
               SLS_OTEL_USER_SETTINGS: JSON.stringify({
                 logs: { disabled: true },
               }),
@@ -126,12 +127,8 @@ module.exports = async (coreConfig, options) => {
             SLS_DEBUG_EXTENSION: '1',
             OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${service},sls_stage=${stage},sls_org_id=${orgId}`,
             SLS_OTEL_USER_SETTINGS: JSON.stringify({
-              common: { destination: { requestHeaders: `serverless_token=${token}` } },
+              ingestToken: token,
               logs: { disabled: true },
-              metrics: { destination: `${ingestionServerUrl}/v1/metrics` },
-              request: { destination: `${ingestionServerUrl}/v1/request-response` },
-              response: { destination: `${ingestionServerUrl}/v1/request-response` },
-              traces: { destination: `${ingestionServerUrl}/v1/traces` },
             }),
           },
         },

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -87,10 +87,9 @@ module.exports = async (coreConfig, options) => {
             Variables: {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
+              SLS_TEST_EXTENSION_REPORT_TYPE: 'json',
               SLS_OTEL_USER_SETTINGS: JSON.stringify({
                 logs: { disabled: true },
-                metrics: { outputType: 'json' },
-                traces: { outputType: 'json' },
               }),
             },
           },

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -125,9 +125,11 @@ module.exports = async (coreConfig, options) => {
           Variables: {
             AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
             SLS_DEBUG_EXTENSION: '1',
-            OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${service},sls_stage=${stage},sls_org_id=${orgId}`,
             SLS_OTEL_USER_SETTINGS: JSON.stringify({
+              orgId,
               ingestToken: token,
+              namespace: service,
+              environment: stage,
               logs: { disabled: true },
             }),
           },

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -52,7 +52,7 @@ module.exports = async (coreConfig, options) => {
           MemorySize: memorySize,
           Environment: {
             Variables: {
-              SLS_OTEL_USER_SETTINGS: JSON.stringify({ logs: { disabled: true } }),
+              SLS_EXTENSION: JSON.stringify({ logs: { disabled: true } }),
               SLS_DEBUG_EXTENSION: '1',
             },
           },
@@ -88,7 +88,7 @@ module.exports = async (coreConfig, options) => {
               SLS_DEBUG_EXTENSION: '1',
               SLS_TEST_EXTENSION_REPORT_TYPE: 'json',
               SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
-              SLS_OTEL_USER_SETTINGS: JSON.stringify({
+              SLS_EXTENSION: JSON.stringify({
                 logs: { disabled: true },
               }),
             },
@@ -106,7 +106,7 @@ module.exports = async (coreConfig, options) => {
               AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
               SLS_DEBUG_EXTENSION: '1',
               SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
-              SLS_OTEL_USER_SETTINGS: JSON.stringify({
+              SLS_EXTENSION: JSON.stringify({
                 logs: { disabled: true },
               }),
             },
@@ -125,7 +125,7 @@ module.exports = async (coreConfig, options) => {
           Variables: {
             AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
             SLS_DEBUG_EXTENSION: '1',
-            SLS_OTEL_USER_SETTINGS: JSON.stringify({
+            SLS_EXTENSION: JSON.stringify({
               orgId,
               ingestToken: token,
               namespace: service,

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
@@ -2,11 +2,9 @@
 
 const _ = require('lodash');
 const path = require('path');
-const backendUrl = require('@serverless/utils/lib/auth/urls').backend;
 const resolveFileZipBuffer = require('../../utils/resolve-file-zip-buffer');
 
 const fixturesDirname = path.resolve(__dirname, '../../fixtures/lambdas');
-const ingestionServerUrl = `${backendUrl}/ingestion/kinesis`;
 
 const cloneMap = (map) => new Map(Array.from(map, ([key, value]) => [key, _.merge({}, value)]));
 
@@ -121,29 +119,12 @@ module.exports = (benchmarkVariantsConfig, options) => {
             Array.from(benchmarkVariantsConfig, ([name, caseConfig]) => {
               switch (name) {
                 case 'jsonLog':
-                case 'protoLog': {
-                  const userSettings = JSON.parse(
-                    caseConfig.configuration.Environment.Variables.SLS_OTEL_USER_SETTINGS
-                  );
-                  delete userSettings.logs;
-                  return [
-                    name,
-                    _.merge({}, caseConfig, {
-                      configuration: {
-                        Environment: {
-                          Variables: {
-                            SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
-                          },
-                        },
-                      },
-                    }),
-                  ];
-                }
+                case 'protoLog':
                 case 'console': {
                   const userSettings = JSON.parse(
                     caseConfig.configuration.Environment.Variables.SLS_OTEL_USER_SETTINGS
                   );
-                  userSettings.logs = { destination: `${ingestionServerUrl}/v1/logs` };
+                  delete userSettings.logs;
                   return [
                     name,
                     _.merge({}, caseConfig, {

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
@@ -122,7 +122,7 @@ module.exports = (benchmarkVariantsConfig, options) => {
                 case 'protoLog':
                 case 'console': {
                   const userSettings = JSON.parse(
-                    caseConfig.configuration.Environment.Variables.SLS_OTEL_USER_SETTINGS
+                    caseConfig.configuration.Environment.Variables.SLS_EXTENSION
                   );
                   delete userSettings.logs;
                   return [
@@ -131,7 +131,7 @@ module.exports = (benchmarkVariantsConfig, options) => {
                       configuration: {
                         Environment: {
                           Variables: {
-                            SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
+                            SLS_EXTENSION: JSON.stringify(userSettings),
                           },
                         },
                       },

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -40,6 +40,7 @@ const create = async (testConfig, coreConfig) => {
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
           SLS_DEBUG_EXTENSION: '1',
           SLS_TEST_EXTENSION_REPORT_TYPE: 'json',
+          SLS_TEST_EXTENSION_REPORT_DESTINATION: 'log',
         },
       },
       ...configuration,

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -39,10 +39,7 @@ const create = async (testConfig, coreConfig) => {
         Variables: {
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
           SLS_DEBUG_EXTENSION: '1',
-          SLS_OTEL_USER_SETTINGS: JSON.stringify({
-            metrics: { outputType: 'json' },
-            traces: { outputType: 'json' },
-          }),
+          SLS_TEST_EXTENSION_REPORT_TYPE: 'json',
         },
       },
       ...configuration,

--- a/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
+++ b/node/packages/aws-lambda-otel-extension/test/lib/process-function.js
@@ -38,7 +38,7 @@ const create = async (testConfig, coreConfig) => {
       Environment: {
         Variables: {
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-          DEBUG_SLS_OTEL_LAYER: '1',
+          SLS_DEBUG_EXTENSION: '1',
           SLS_OTEL_USER_SETTINGS: JSON.stringify({
             metrics: { outputType: 'json' },
             traces: { outputType: 'json' },

--- a/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
@@ -23,7 +23,7 @@ describe('external', () => {
       metrics: { outputType: 'json' },
       traces: { outputType: 'json' },
     });
-    process.env.SLS_TEST_RUN = '1';
+    process.env.SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT = '1';
   });
 
   it('should handle plain success invocation', async () => {

--- a/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
@@ -21,6 +21,7 @@ describe('external', () => {
     process.env.AWS_LAMBDA_RUNTIME_API = `127.0.0.1:${port}`;
     process.env.SLS_TEST_EXTENSION_REPORT_TYPE = 'json';
     process.env.SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT = '1';
+    process.env.SLS_TEST_EXTENSION_REPORT_DESTINATION = 'log';
   });
 
   it('should handle plain success invocation', async () => {

--- a/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/external/index.test.js
@@ -19,10 +19,7 @@ describe('external', () => {
     ensureNpmDependencies('external/otel-extension-external');
     evilDns.add('sandbox', '127.0.0.1');
     process.env.AWS_LAMBDA_RUNTIME_API = `127.0.0.1:${port}`;
-    process.env.SLS_OTEL_USER_SETTINGS = JSON.stringify({
-      metrics: { outputType: 'json' },
-      traces: { outputType: 'json' },
-    });
+    process.env.SLS_TEST_EXTENSION_REPORT_TYPE = 'json';
     process.env.SLS_TEST_EXTENSION_EXTERNAL_NO_EXIT = '1';
   });
 

--- a/node/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/internal/index.test.js
@@ -102,6 +102,7 @@ describe('internal', () => {
     process.env.AWS_REGION = 'us-east-1';
     process.env.LAMBDA_TASK_ROOT = path.resolve(fixturesDirname, 'lambdas');
     process.env.LAMBDA_RUNTIME_DIR = path.resolve(fixturesDirname, 'runtime');
+    process.env.SLS_TEST_EXTENSION_REPORT_DESTINATION = 'log';
   });
   afterEach(() => {
     delete process.env._HANDLER;

--- a/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
@@ -11,11 +11,17 @@ describe('test/unit/external/user-settings.test.js', () => {
   });
   it('should handle gently no data', () => {
     process.env.SLS_OTEL_USER_SETTINGS = JSON.stringify({
+      orgId: 'orgId',
+      namespace: 'service',
+      environment: 'dev',
       ingestToken: 'foo',
       logs: { disabled: true },
       foo: 'bar',
     });
     expect(getUserConfig()).to.deep.equal({
+      orgId: 'orgId',
+      namespace: 'service',
+      environment: 'dev',
       ingestToken: 'foo',
       logs: { disabled: true },
       request: {},

--- a/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
@@ -7,10 +7,10 @@ const requireUncached = require('ncjsm/require-uncached');
 describe('test/unit/external/user-settings.test.js', () => {
   const getUserConfig = () => requireUncached(() => require('../../../lib/user-settings'));
   afterEach(() => {
-    delete process.env.SLS_OTEL_USER_SETTINGS;
+    delete process.env.SLS_EXTENSION;
   });
   it('should handle gently no data', () => {
-    process.env.SLS_OTEL_USER_SETTINGS = JSON.stringify({
+    process.env.SLS_EXTENSION = JSON.stringify({
       orgId: 'orgId',
       namespace: 'service',
       environment: 'dev',

--- a/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
+++ b/node/packages/aws-lambda-otel-extension/test/unit/lib/user-settings.test.js
@@ -2,30 +2,25 @@
 
 const { expect } = require('chai');
 
-const _ = require('lodash');
 const requireUncached = require('ncjsm/require-uncached');
 
 describe('test/unit/external/user-settings.test.js', () => {
-  let defaultConfig;
-
   const getUserConfig = () => requireUncached(() => require('../../../lib/user-settings'));
-
-  before(() => {
-    defaultConfig = getUserConfig();
-  });
   afterEach(() => {
     delete process.env.SLS_OTEL_USER_SETTINGS;
   });
   it('should handle gently no data', () => {
     process.env.SLS_OTEL_USER_SETTINGS = JSON.stringify({
-      common: { destination: { foo: 'bar' } },
-      metrics: { destination: 'foo' },
+      ingestToken: 'foo',
+      logs: { disabled: true },
+      foo: 'bar',
     });
-    expect(getUserConfig()).to.deep.equal(
-      _.merge({}, defaultConfig, {
-        common: { destination: { foo: 'bar' } },
-        metrics: { destination: 'foo' },
-      })
-    );
+    expect(getUserConfig()).to.deep.equal({
+      ingestToken: 'foo',
+      logs: { disabled: true },
+      request: {},
+      response: {},
+      foo: 'bar',
+    });
   });
 });


### PR DESCRIPTION
As discussed internally we're converting the extension so it is Serverless Console specific.

In this PR I reshape user settings which now will be taken with `SLS_EXTENSION` (not `SLS_OTEL_USER_SETTINGS`) environment variable.

Additionally:
- (in response to above rename) improve the naming convention of internal (test purpose) environment variables
- Move test documentation to the test folder and document all test environment variables.

