### PR TITLE
CI: Fix layers publication script

### DIFF
--- a/.github/workflows/node-publish-aws-lambda-otel-extension.yml
+++ b/.github/workflows/node-publish-aws-lambda-otel-extension.yml
@@ -105,7 +105,7 @@ jobs:
             --bucket-name sls-dev-layers-registry \
             --layer-basename sls-otel-extension-node \
             --version $VERSION \
-            --layer-filename packages/aws-lambda-otel-extension/dist/extension.zip \
+            --layer-filename packages/aws-lambda-otel-extension/dist/extension.zip
           ./scripts/publish-extension-layers.js \
             --bucket-name sls-dev-layers-registry \
             --layer-basename sls-otel-extension-external \
@@ -130,17 +130,17 @@ jobs:
             --bucket-name sls-layers-registry \
             --layer-basename sls-otel-extension-node \
             --version $VERSION \
-            --layer-filename packages/aws-lambda-otel-extension/dist/extension.zip
+            --layer-filename packages/aws-lambda-otel-extension/dist/extension.zip \
             --github-tag $TAG
           ./scripts/publish-extension-layers.js \
             --bucket-name sls-layers-registry \
             --layer-basename sls-otel-extension-external \
             --version $VERSION \
-            --layer-filename packages/aws-lambda-otel-extension/dist/extension-external.zip
+            --layer-filename packages/aws-lambda-otel-extension/dist/extension-external.zip \
             --github-tag $TAG
           ./scripts/publish-extension-layers.js \
             --bucket-name sls-layers-registry \
             --layer-basename sls-otel-extension-internal-node \
             --version $VERSION \
-            --layer-filename packages/aws-lambda-otel-extension/dist/extension-internal.zip
+            --layer-filename packages/aws-lambda-otel-extension/dist/extension-internal.zip \
             --github-tag $TAG

--- a/node/scripts/publish-extension-layers.js
+++ b/node/scripts/publish-extension-layers.js
@@ -19,9 +19,13 @@ if (!version) throw new Error('--version param is required');
 const layerFilename = argv.layerFilename;
 if (!layerFilename) throw new Error('--layer-filename param is required');
 
+const githubTag = argv.githubTag;
+
 const fsp = require('fs').promises;
 const publishPublicLayers = require('../lib/publish-public-layers');
 
 fsp
   .readFile(layerFilename)
-  .then((content) => publishPublicLayers({ bucketName, layerBasename, version, content }));
+  .then((content) =>
+    publishPublicLayers({ bucketName, layerBasename, version, content, githubTag })
+  );


### PR DESCRIPTION
Apparently our first attempt for layers publication failed, due to few setup issues. This fixes that. 

By introducing temporary CI workflow I've ensured that we have layers for v0.5.0 published. It got finalized with: https://github.com/serverless/console/runs/7320061288?check_suite_focus=true

And we can see list of ARN's of published layers in JSON files attached to release: https://github.com/serverless/console/releases/tag/%40serverless%2Faws-lambda-otel-extension%400.5.0

I've also confirmed that layers registry in S3 bucket was updated, and that it's publicly accessible