### PR TITLE
Improve `requre-in-the-middle` overhead

### DIFF
--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -469,7 +469,10 @@ registerInstrumentations({
 
 module.exports = detectResources({
   detectors: [awsLambdaDetector, envDetector, processDetector],
-}).then((resource) => (tracerProvider.resource = tracerProvider.resource.merge(resource)));
+}).then((resource) => {
+  tracerProvider.resource = tracerProvider.resource.merge(resource);
+  return { keepAliveAgent }; // For testing purposes
+});
 
 const { handlerLoadDuration } = require('./prepare-wrapper')();
 

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/index.js
@@ -24,6 +24,8 @@ const userSettings = (() => {
 })();
 if (!userSettings) return;
 
+const initializeRequireInTheMiddle = require('./require-in-the-middle-patch');
+
 const http = require('http');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { InMemorySpanExporter } = require('@opentelemetry/sdk-trace-base');
@@ -473,6 +475,8 @@ module.exports = detectResources({
   tracerProvider.resource = tracerProvider.resource.merge(resource);
   return { keepAliveAgent }; // For testing purposes
 });
+
+initializeRequireInTheMiddle();
 
 const { handlerLoadDuration } = require('./prepare-wrapper')();
 

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/package.json
@@ -24,6 +24,7 @@
     "@opentelemetry/sdk-trace-base": "^1.4.0",
     "@opentelemetry/sdk-trace-node": "^1.4.0",
     "lodash.clone": "^4.5.0",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "require-in-the-middle": "^5.1.0"
   }
 }

--- a/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/require-in-the-middle-patch.js
+++ b/node/packages/aws-lambda-otel-extension/internal/otel-extension-internal-node/require-in-the-middle-patch.js
@@ -1,0 +1,37 @@
+// Otel libraries initialize internally mutliple hooks for `require-in-the-middle`.
+// It's highly ineffective as each hook introduces extra decorator over each require call
+// and creates new hook instance.
+// Same functionality can be achieved with a single hook, and this is what this patch ensures
+
+'use strict';
+
+require('require-in-the-middle');
+
+const requireInTheMiddleModule = require.cache[require.resolve('require-in-the-middle')];
+const originalHook = requireInTheMiddleModule.exports;
+const hooksMap = new Map();
+requireInTheMiddleModule.exports = (modules, options, onrequire) => {
+  if (modules.length !== 1) {
+    throw new Error('RequireInTheMiddle patch error: Unexpected modules length');
+  }
+  if (!options.internals) {
+    throw new Error('RequireInTheMiddle patch error: Unexpected options');
+  }
+  if (typeof onrequire !== 'function') {
+    throw new Error('RequireInTheMiddle patch error: Missing "onrequire" callback');
+  }
+  if (hooksMap.has(modules[0])) {
+    throw new Error(`RequireInTheMiddle patch error: Duplicate hook for "${modules[0]}"`);
+  }
+  hooksMap.set(modules[0], onrequire);
+};
+
+module.exports = () => {
+  originalHook(Array.from(hooksMap.keys()), { internals: true }, (exports, name, baseDir) => {
+    if (hooksMap.has(name)) return hooksMap.get(name)(exports, name, baseDir);
+    for (const [id, onrequire] of hooksMap) {
+      if (name.startsWith(`${id}/`)) return onrequire(exports, name, baseDir);
+    }
+    throw new Error(`RequireInTheMiddle patch error: Unmatched hook for "${name}"`);
+  });
+};

--- a/node/packages/aws-lambda-otel-extension/scripts/lib/build.js
+++ b/node/packages/aws-lambda-otel-extension/scripts/lib/build.js
@@ -88,6 +88,22 @@ module.exports = async (distFilename, options = {}) => {
               '--bundle',
               '--platform=node',
               '--external:./user-settings',
+              '--external:require-in-the-middle',
+            ])
+          ).stdoutBuffer
+        );
+        zip.addFile(
+          'otel-extension-internal-node/node_modules/require-in-the-middle.js',
+          (
+            await spawn(esbuildFilename, [
+              path.resolve(
+                path.resolve(
+                  internalDir,
+                  'otel-extension-internal-node/node_modules/require-in-the-middle/index.js'
+                )
+              ),
+              '--bundle',
+              '--platform=node',
             ])
           ).stdoutBuffer
         );

--- a/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
+++ b/node/packages/aws-lambda-otel-extension/test/benchmark/lib/resolve-use-cases-config.js
@@ -145,6 +145,15 @@ module.exports = (benchmarkVariantsConfig, options) => {
           ))(),
       },
     ],
+    [
+      'requires',
+      {
+        configuration: {
+          Timeout: 20,
+        },
+        variants: cloneMap(benchmarkVariantsConfig),
+      },
+    ],
   ]);
 
   return options.useCases

--- a/node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/requires.js
+++ b/node/packages/aws-lambda-otel-extension/test/fixtures/lambdas/requires.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+require('aws-sdk');
+
+module.exports.handler = (event, context, callback) => {
+  callback(null, { statusCode: 200, body: JSON.stringify({ result: 'ok', filename: __filename }) });
+};

--- a/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
+++ b/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
@@ -5,9 +5,13 @@
 
 'use strict';
 
+require('essentials');
+require('log-node')();
+
 const http = require('http');
 const path = require('path');
 const isThenable = require('type/thenable/is');
+const log = require('log').get('test');
 const ensureNpmDependencies = require('../../scripts/lib/ensure-npm-dependencies');
 
 const fixturesDirname = path.resolve(__dirname, '../fixtures');
@@ -51,7 +55,7 @@ const payload = {};
 
           if (logsQueue.length > 1) {
             server.close();
-            resolve();
+            resolve(logsQueue);
           }
         });
       }
@@ -79,8 +83,9 @@ const payload = {};
       if (isThenable(maybeThenable)) resolve(maybeThenable);
     });
 
-    await deferredResultProcessing;
+    const logs = await deferredResultProcessing;
     keepAliveAgent.destroy();
+    log.info(logs);
   } finally {
     server.close();
   }

--- a/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
+++ b/node/packages/aws-lambda-otel-extension/test/scripts/invoke-internal.js
@@ -22,6 +22,7 @@ const payload = {};
 (async () => {
   ensureNpmDependencies('internal/otel-extension-internal-node');
   ensureNpmDependencies('test/fixtures/lambdas');
+  process.env.SLS_TEST_EXTENSION_REPORT_DESTINATION = 'log';
   process.env.AWS_LAMBDA_FUNCTION_VERSION = '$LATEST';
   process.env.AWS_REGION = 'us-east-1';
   process.env.LAMBDA_TASK_ROOT = path.resolve(fixturesDirname, 'lambdas');
@@ -60,7 +61,7 @@ const payload = {};
   server.listen(OTEL_SERVER_PORT);
 
   try {
-    await require('../../internal/otel-extension-internal-node');
+    const { keepAliveAgent } = await require('../../internal/otel-extension-internal-node');
     await new Promise((resolve, reject) => {
       const maybeThenable = require('../../internal/otel-extension-internal-node/wrapper').handler(
         payload,
@@ -79,6 +80,7 @@ const payload = {};
     });
 
     await deferredResultProcessing;
+    keepAliveAgent.destroy();
   } finally {
     server.close();
   }


### PR DESCRIPTION
Introduce a patch which ensures that `require-in-the-middle` is initialized just once and not 20 times.

In benchmarks for case where `aws-sdk` is required (it implies a lot of require's internally), this cuts down overhead as introduced by `require-in-the-middle` from ca 590ms to 230ms.

Related benchmark data can be seen here: https://docs.google.com/spreadsheets/d/1Wg9aNEFWzZX1jTfc9g39ygCEcx6-0AAe8l4_QB4h_lo/edit?usp=sharing

I believe we can improve things further, but it'll require more sophisticated patch (most likely override of `require-in-the-middle` or revise of the approach as the whole).

I've confirmed with integration tests that instrumentation is not affected (we test it with `express` case)

-- 

Additionally improved `invoke-internal` script (up to recent changes) as I've used to observe improvement when testing the patch

