### PR TITLE
Base setup for `aws.lambda*` trace spans

### DIFF
--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -1,0 +1,6 @@
+import TraceSpan from './lib/trace-span';
+
+export interface traceSpans {
+  awsLambda: TraceSpan;
+  awsLambdaInitialization: TraceSpan;
+}

--- a/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
@@ -1,0 +1,20 @@
+declare class TraceSpanTags extends Map {
+  set(key: string, value: boolean | number | string | Date): TraceSpanTags;
+}
+
+declare class TraceSpan {
+  traceId: string;
+  id: string;
+  parentSpan: TraceSpan | null;
+  subSpans: Set<TraceSpan>;
+  tags: TraceSpanTags;
+  createSubSpan(
+    name: string,
+    options?: { startTime: bigint; immediateDescendants: string[] }
+  ): TraceSpan;
+  close(): TraceSpan;
+  spans(): Set<TraceSpan>;
+  toJSON(): Object;
+}
+
+export default TraceSpan;

--- a/node/packages/aws-lambda-sdk/.ts-types/trace-spans/aws-lambda-initialization.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/trace-spans/aws-lambda-initialization.d.ts
@@ -1,0 +1,5 @@
+import TraceSpan from '../lib/trace-span';
+
+declare const awsLambdaInitializationTraceSpan: TraceSpan;
+
+export default awsLambdaInitializationTraceSpan;

--- a/node/packages/aws-lambda-sdk/.ts-types/trace-spans/aws-lambda.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/trace-spans/aws-lambda.ts
@@ -1,0 +1,5 @@
+import TraceSpan from '../lib/trace-span';
+
+declare const awsLambdaTraceSpan: TraceSpan;
+
+export default awsLambdaTraceSpan;

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.traceSpans = {
+  awsLambda: require('./trace-spans/aws-lambda'),
+  awsLambdaInitialization: require('./trace-spans/aws-lambda-initialization'),
+};

--- a/node/packages/aws-lambda-sdk/internal-extension/index.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/index.js
@@ -53,8 +53,12 @@ const doesModuleExist = (filename) => {
   }
 };
 
+EvalError.$serverlessAwsLambdaInitializationStartTime = processStartTime;
+global.serverlessSdk = require('../');
+
 let hasInitializationFailed = false;
 const startTime = process.hrtime.bigint();
+
 const handlerModule = (() => {
   try {
     if (importEsm) {

--- a/node/packages/aws-lambda-sdk/lib/trace-span.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span.js
@@ -9,17 +9,14 @@ const ensureIterable = require('type/iterable/ensure');
 const isDate = require('type/date/is');
 const isObject = require('type/object/is');
 const resolveException = require('type/lib/resolve-exception');
-const uuid = require('uuid');
+const crypto = require('crypto');
 
 const isValidSpanName = RegExp.prototype.test.bind(/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/);
 const isValidTagName = RegExp.prototype.test.bind(
   /^[a-z][a-z0-9]*(?:_[a-z][a-z0-9]*)*(?:\.[a-z][a-z0-9]*(?:_[a-z][a-z0-9]*)*)*$/
 );
 
-const generateId = () =>
-  Array.from(uuid.parse(uuid.v4()))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
+const generateId = () => crypto.randomBytes(16).toString('hex');
 
 const resolveEpochTimestampString = (() => {
   const diff = BigInt(Date.now()) * BigInt(1000000) - process.hrtime.bigint();

--- a/node/packages/aws-lambda-sdk/lib/trace-span.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const ensureString = require('type/string/ensure');
+const ensureFinite = require('type/finite/ensure');
+const ensureBigInt = require('type/big-int/ensure');
+const d = require('d');
+const lazy = require('d/lazy');
+const ensureIterable = require('type/iterable/ensure');
+const isDate = require('type/date/is');
+const isObject = require('type/object/is');
+const resolveException = require('type/lib/resolve-exception');
+const uuid = require('uuid');
+
+const isValidSpanName = RegExp.prototype.test.bind(/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/);
+const isValidTagName = RegExp.prototype.test.bind(
+  /^[a-z][a-z0-9]*(?:_[a-z][a-z0-9]*)*(?:\.[a-z][a-z0-9]*(?:_[a-z][a-z0-9]*)*)*$/
+);
+
+const generateId = () =>
+  Array.from(uuid.parse(uuid.v4()))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const resolveEpochTimestampString = (() => {
+  const diff = BigInt(Date.now()) * BigInt(1000000) - process.hrtime.bigint();
+  return (uptimeTimestamp) => String(uptimeTimestamp + diff);
+})();
+
+const ensureSpanName = (() => {
+  const errorCode = 'INVALID_TRACE_SPAN_NAME';
+  return (inputValue) => {
+    const value = ensureString(inputValue, {
+      errorCode,
+      errorMessage: 'Invalid trace span name: Expected string, received "%v"',
+    });
+    if (isValidSpanName(value)) return value;
+    return resolveException(inputValue, null, {
+      errorCode,
+      errorMessage:
+        'Invalid trace span name: Name should contain dot separated tokens that follow ' +
+        '"[a-z][a-z0-9]*" pattern. Received "%v"',
+    });
+  };
+})();
+
+const ensureTagName = (() => {
+  const errorCode = 'INVALID_TRACE_SPAN_TAG_NAME';
+  return (inputValue) => {
+    const value = ensureString(inputValue, {
+      errorCode,
+      errorMessage: 'Invalid trace span tag name: Expected string, received "%v"',
+    });
+    if (isValidTagName(value)) return value;
+    return resolveException(inputValue, null, {
+      errorCode,
+      errorMessage:
+        'Invalid trace span tag name: Name should contain dot separated tokens that follow ' +
+        '"[a-z][a-z0-9_]*" pattern. Received "%v"',
+    });
+  };
+})();
+
+const ensureTagValue = (() => {
+  const errorCode = 'INVALID_TRACE_SPAN_TAG_VALUE';
+  return (inputValue) => {
+    if (typeof inputValue === 'string') return inputValue;
+    if (typeof inputValue === 'number') {
+      return ensureFinite(inputValue, {
+        errorCode,
+        errorMessage: 'Invalid trace span tag value: Number must be finite, received "%v"',
+      });
+    }
+    if (typeof inputValue === 'boolean') return inputValue;
+    if (isDate(inputValue)) return inputValue.toISOString();
+    return resolveException(inputValue, null, {
+      errorCode,
+      errorMessage:
+        'Invalid trace span tag value: Value must be either boolean, number, string, or date. Received "%v"',
+    });
+  };
+})();
+
+class StringifiableSet extends Set {
+  toJSON() {
+    return Array.from(this);
+  }
+}
+
+class TraceSpanTags extends Map {
+  set(inputName, value) {
+    const name = ensureTagName(inputName);
+    if (this.has(name)) {
+      throw Object.assign(new Error(`Cannot set tag: Tag "${inputName}" is already set`), {
+        code: 'DUPLICATE_TRACE_SPAN_TAG_NAME',
+      });
+    }
+    return super.set(name, ensureTagValue(value));
+  }
+}
+
+class TraceSpan {
+  constructor(name, options = {}) {
+    this.startTime = options.startTime || process.hrtime.bigint();
+    this.name = name;
+    this.parentSpan = options.parentSpan || null;
+    if (options.immediateDescendants) {
+      const immediateDescendants = Array.from(options.immediateDescendants);
+      if (immediateDescendants.length) {
+        this.createSubSpan(immediateDescendants.shift(), {
+          startTime: this.startTime,
+          immediateDescendants,
+        });
+      }
+    }
+  }
+  createSubSpan(name, options = {}) {
+    if (this.endTime) {
+      throw Object.assign(new Error('Cannot initialize span in ended span'), {
+        code: 'INIT_IN_ENDED_SPAN',
+      });
+    }
+    name = ensureSpanName(name);
+    if (!isObject(options)) options = {};
+    const startTime = ensureBigInt(options.startTime, { isOptional: true });
+    if (startTime) {
+      if (startTime > process.hrtime.bigint()) {
+        throw Object.assign(
+          new Error('Cannot intialize span: Start time cannot be set in the future'),
+          { code: 'FUTURE_SPAN_START_TIME' }
+        );
+      }
+    }
+    const span = new TraceSpan(name, {
+      parentSpan: this,
+      startTime,
+      immediateDescendants: ensureIterable(options.immediateDescendants, {
+        isOptional: true,
+        ensureItem: ensureSpanName,
+      }),
+    });
+    this.subSpans.add(span);
+    return span;
+  }
+  close(options = {}) {
+    if (this.endTime) {
+      throw Object.assign(new Error('Cannot close span: Span already closed'), {
+        code: 'CLOSURE_ON_CLOSED_SPAN',
+      });
+    }
+    if (!isObject(options)) options = {};
+    const defaultEndTime = process.hrtime.bigint();
+    const targetEndTime = ensureBigInt(options.endTime, { isOptional: true });
+    if (targetEndTime) {
+      if (targetEndTime < this.startTime) {
+        throw Object.assign(
+          new Error('Cannot close span: End time cannot be earlier than start time'),
+          { code: 'PAST_SPAN_END_TIME' }
+        );
+      }
+      if (targetEndTime > defaultEndTime) {
+        throw Object.assign(new Error('Cannot close span: End time cannot be set in the future'), {
+          code: 'FUTURE_SPAN_END_TIME',
+        });
+      }
+    }
+    this.endTime = targetEndTime || defaultEndTime;
+    for (const child of this.subSpans) {
+      if (!child.endTime) child.close({ endTime: this.endTime });
+    }
+    return this;
+  }
+  toJSON() {
+    return {
+      traceId: this.traceId,
+      id: this.id,
+      name: this.name,
+      startTime: resolveEpochTimestampString(this.startTime),
+      endTime: this.endTime && resolveEpochTimestampString(this.endTime),
+      tags: Object.fromEntries(this.tags),
+    };
+  }
+  get spans() {
+    return new StringifiableSet([
+      this,
+      ...Array.from(this.subSpans, (subSpan) => Array.from(subSpan.spans)).flat(Infinity),
+    ]);
+  }
+}
+
+Object.defineProperties(
+  TraceSpan.prototype,
+  lazy({
+    traceId: d(function () {
+      return this.parentSpan ? this.parentSpan.traceId : generateId();
+    }),
+    id: d(() => generateId()),
+    subSpans: d(() => new Set()),
+    tags: d(() => new TraceSpanTags()),
+  })
+);
+
+module.exports = TraceSpan;

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -5,8 +5,7 @@
   "author": "Serverless, Inc.",
   "dependencies": {
     "d": "^1.0.1",
-    "type": "^2.6.1",
-    "uuid": "^8.3.2"
+    "type": "^2.6.1"
   },
   "typesVersions": {
     "*": {

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -3,6 +3,11 @@
   "repository": "serverless/runtime",
   "version": "0.0.0",
   "author": "Serverless, Inc.",
+  "dependencies": {
+    "d": "^1.0.1",
+    "type": "^2.6.1",
+    "uuid": "^8.3.2"
+  },
   "typesVersions": {
     "*": {
       "*": [

--- a/node/packages/aws-lambda-sdk/scripts/lib/build.js
+++ b/node/packages/aws-lambda-sdk/scripts/lib/build.js
@@ -20,7 +20,16 @@ module.exports = async (distFilename) => {
     mkdir(path.dirname(distFilename), { intermediate: true, silent: true }),
     (async () => {
       zip.addLocalFile(path.resolve(internalDir, 'exec-wrapper.sh'), extensionDirname);
-      zip.addLocalFile(path.resolve(internalDir, 'index.js'), extensionDirname);
+      zip.addFile(
+        `${extensionDirname}/index.js`,
+        (
+          await spawn(esbuildFilename, [
+            path.resolve(path.resolve(internalDir, 'index.js')),
+            '--bundle',
+            '--platform=node',
+          ])
+        ).stdoutBuffer
+      );
       zip.addFile(
         `${extensionDirname}/wrapper.js`,
         (
@@ -28,6 +37,7 @@ module.exports = async (distFilename) => {
             path.resolve(path.resolve(internalDir, 'wrapper.js')),
             '--bundle',
             '--platform=node',
+            '--external:./',
           ])
         ).stdoutBuffer
       );

--- a/node/packages/aws-lambda-sdk/test/lib/process-function.js
+++ b/node/packages/aws-lambda-sdk/test/lib/process-function.js
@@ -192,7 +192,7 @@ const retrieveReports = async (testConfig) => {
         continue;
       }
       if (message.startsWith('START RequestId: ')) {
-        currentInvocationData = { reports: [], extensionOverheadDurations: {} };
+        currentInvocationData = { extensionOverheadDurations: {} };
         continue;
       }
       if (message.startsWith('⚡ SDK: Overhead duration: Internal request')) {
@@ -202,27 +202,19 @@ const retrieveReports = async (testConfig) => {
         );
         continue;
       }
-      if (message.startsWith('⚡.')) {
-        const reportType = message.slice(2, message.indexOf(':'));
-        if (reportType === 'logs') continue;
-        const reportJsonString = message.slice(message.indexOf(':') + 1);
-        if (reportJsonString.endsWith('\n')) {
-          getCurrentInvocationData().reports.push([
-            reportType,
-            JSON.parse(reportJsonString.trim()),
-          ]);
+      if (message.startsWith('⚡ SDK: Trace: ')) {
+        const traceJsonString = message.slice(message.indexOf('e:') + 3);
+        if (traceJsonString.endsWith('\n')) {
+          getCurrentInvocationData().trace = JSON.parse(traceJsonString.trim());
         } else {
-          startedMessage = { type: reportType, report: reportJsonString };
+          startedMessage = traceJsonString;
         }
         continue;
       }
       if (startedMessage) {
-        startedMessage.report += message;
-        if (startedMessage.report.endsWith('\n')) {
-          getCurrentInvocationData().reports.push([
-            startedMessage.type,
-            JSON.parse(startedMessage.report.trim()),
-          ]);
+        startedMessage += message;
+        if (startedMessage.endsWith('\n')) {
+          getCurrentInvocationData().trace = JSON.parse(startedMessage.trim());
           startedMessage = null;
           continue;
         }

--- a/node/packages/aws-lambda-sdk/test/unit/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/index.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const TraceSpan = require('../../lib/trace-span');
+
+const serverlessSdk = require('../../');
+
+describe('index.test.js', () => {
+  it('should expose "aws.lambda" trace span', () =>
+    expect(serverlessSdk.traceSpans.awsLambda).to.be.instanceOf(TraceSpan));
+  it('should expose "aws.lambda.initialization" trace span', () =>
+    expect(serverlessSdk.traceSpans.awsLambdaInitialization).to.be.instanceOf(TraceSpan));
+});

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -37,7 +37,7 @@ const handleSuccess = async (handlerModuleName, payload = {}) => {
   });
 };
 
-describe('internal-extension', () => {
+describe('internal-extension/index.test.js', () => {
   before(() => {
     process.env.AWS_LAMBDA_FUNCTION_VERSION = '$LATEST';
     process.env.AWS_REGION = 'us-east-1';

--- a/node/packages/aws-lambda-sdk/test/unit/lib/trace-span.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/lib/trace-span.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const TraceSpan = require('../../../lib/trace-span');
+
+describe('lib/trace-span.test.js', () => {
+  let rootSpan;
+  before(() => {
+    rootSpan = new TraceSpan('test');
+  });
+
+  describe('root span', () => {
+    it('should automatically generate `traceId`', () =>
+      expect(typeof rootSpan.traceId).to.equal('string'));
+
+    it('should automatically generate `id`', () => expect(typeof rootSpan.id).to.equal('string'));
+
+    it('should automatically set `startTime`', () =>
+      expect(typeof rootSpan.startTime).to.equal('bigint'));
+
+    it('should expose `name`', () => expect(rootSpan.name).to.equal('test'));
+  });
+
+  describe('sub span', () => {
+    let childSpan;
+    before(() => {
+      childSpan = rootSpan.createSubSpan('child');
+    });
+
+    it('should expose `traceId` of a root span', () =>
+      expect(childSpan.traceId).to.equal(rootSpan.traceId));
+
+    it('should automatically generate unique `id`', () => {
+      expect(typeof childSpan.id).to.equal('string');
+      expect(childSpan.id).to.not.equal(rootSpan.id);
+    });
+
+    it('should automatically set `startTime`', () => {
+      expect(typeof childSpan.startTime).to.equal('bigint');
+      expect(childSpan.startTime).to.not.equal(rootSpan.startTime);
+    });
+
+    it('should expose `name`', () => expect(childSpan.name).to.equal('child'));
+  });
+
+  it('should support injection of `startTime`', () => {
+    const startTime = process.hrtime.bigint();
+    expect(rootSpan.createSubSpan('child', { startTime }).startTime).to.equal(startTime);
+  });
+
+  it('should support injection of `endTime`', () => {
+    const childSpan = rootSpan.createSubSpan('child');
+    const endTime = process.hrtime.bigint();
+    childSpan.close({ endTime });
+    expect(childSpan.endTime).to.equal(endTime);
+  });
+
+  it('should support creation of immediate descendant spans', () => {
+    const childSpan = rootSpan.createSubSpan('child', {
+      immediateDescendants: ['grandchild', 'grandgrandchild'],
+    });
+    const grandChildren = Array.from(childSpan.subSpans);
+    expect(grandChildren.map(({ name }) => name)).to.deep.equal(['grandchild']);
+    const grandChild = grandChildren[0];
+    const grandGrandChildren = Array.from(grandChild.subSpans);
+    expect(grandGrandChildren.map(({ name }) => name)).to.deep.equal(['grandgrandchild']);
+    const grandGrandChild = grandGrandChildren[0];
+    expect(grandChild.startTime).to.equal(childSpan.startTime);
+    expect(grandGrandChild.startTime).to.equal(childSpan.startTime);
+  });
+
+  it('should close all descendant spans on span closure', () => {
+    const childSpan = rootSpan.createSubSpan('child', {
+      immediateDescendants: ['grandchild', 'grandgrandchild'],
+    });
+    const grandChild = Array.from(childSpan.subSpans)[0];
+    const grandGrandChild = Array.from(grandChild.subSpans)[0];
+    childSpan.close();
+
+    expect(grandChild.endTime).to.equal(childSpan.endTime);
+    expect(grandGrandChild.endTime).to.equal(childSpan.endTime);
+  });
+
+  describe('spans', () => {
+    it('should resolve just self when no subspans', () => {
+      const span = rootSpan.createSubSpan('child');
+      expect(Array.from(span.spans)).to.deep.equal([span]);
+    });
+
+    it('should resolve self and all descendants', () => {
+      const span = rootSpan.createSubSpan('child');
+      const subSpan = span.createSubSpan('subchild');
+      const subSubSpan = subSpan.createSubSpan('subsubchild');
+      expect(Array.from(span.spans)).to.deep.equal([span, subSpan, subSubSpan]);
+    });
+  });
+
+  it('should stringify to JSON', () => {
+    const childSpan = rootSpan.createSubSpan('child');
+    childSpan.tags.set('foo', 12);
+    childSpan.close();
+    const jsonValue = JSON.parse(JSON.stringify(childSpan));
+    // Validate bigint valid values
+    BigInt(jsonValue.startTime);
+    BigInt(jsonValue.endTime);
+
+    expect(jsonValue).to.deep.equal({
+      traceId: rootSpan.traceId,
+      id: childSpan.id,
+      name: 'child',
+      startTime: jsonValue.startTime,
+      endTime: jsonValue.endTime,
+      tags: { foo: 12 },
+    });
+  });
+
+  describe('tags', () => {
+    it('should allow setting tags', () => {
+      const childSpan = rootSpan.createSubSpan('child');
+      childSpan.tags.set('bool', true);
+      childSpan.tags.set('string', 'string');
+      childSpan.tags.set('num', 23);
+      expect(Array.from(childSpan.tags)).to.deep.equal([
+        ['bool', true],
+        ['string', 'string'],
+        ['num', 23],
+      ]);
+    });
+
+    it('should reject setting tag that alraedy exists', () => {
+      const childSpan = rootSpan.createSubSpan('child');
+      childSpan.tags.set('tag', true);
+      expect(() => childSpan.tags.set('tag', 'again'))
+        .to.throw(Error)
+        .with.property('code', 'DUPLICATE_TRACE_SPAN_TAG_NAME');
+    });
+  });
+});

--- a/node/packages/aws-lambda-sdk/test/unit/trace-spans/aws-lambda-initilization.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/trace-spans/aws-lambda-initilization.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const TraceSpan = require('../../../lib/trace-span');
+
+const awsLambdaTraceSpan = require('../../../trace-spans/aws-lambda');
+const awsLambdaInitializationTraceSpan = require('../../../trace-spans/aws-lambda-initialization');
+
+describe('trace-spans/aws-lambda-initialization.test.js', () => {
+  it('should be TraceSpan instance', () =>
+    expect(awsLambdaInitializationTraceSpan).to.be.instanceOf(TraceSpan));
+  it('should be sub span of "aws.lambda"', () =>
+    expect(awsLambdaInitializationTraceSpan.parentSpan).to.equal(awsLambdaTraceSpan));
+  it('should be named "aws.lambda.initialization"', () =>
+    expect(awsLambdaInitializationTraceSpan.name).to.equal('aws.lambda.initialization'));
+});

--- a/node/packages/aws-lambda-sdk/test/unit/trace-spans/aws-lambda.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/trace-spans/aws-lambda.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const TraceSpan = require('../../../lib/trace-span');
+
+const awsLambdaTraceSpan = require('../../../trace-spans/aws-lambda');
+
+describe('trace-spans/aws-lambda.test.js', () => {
+  it('should be TraceSpan instance', () => expect(awsLambdaTraceSpan).to.be.instanceOf(TraceSpan));
+  it('should be root span', () => expect(awsLambdaTraceSpan.parentSpan).to.be.null);
+  it('should be named "aws.lambda"', () => expect(awsLambdaTraceSpan.name).to.equal('aws.lambda'));
+});

--- a/node/packages/aws-lambda-sdk/trace-spans/aws-lambda-initialization.js
+++ b/node/packages/aws-lambda-sdk/trace-spans/aws-lambda-initialization.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const awsLambdaTraceSpan = require('./aws-lambda');
+
+module.exports = awsLambdaTraceSpan.subSpans[Symbol.iterator]().next().value;

--- a/node/packages/aws-lambda-sdk/trace-spans/aws-lambda.js
+++ b/node/packages/aws-lambda-sdk/trace-spans/aws-lambda.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const TraceSpan = require('../lib/trace-span');
+
+module.exports = new TraceSpan('aws.lambda', {
+  startTime: EvalError.$serverlessAwsLambdaInitializationStartTime,
+  immediateDescendants: ['aws.lambda.initialization'],
+});


### PR DESCRIPTION
- `TraceSpan` class implementation
- Configuration of `aws.lambda`, `aws.lambda.initialization` and `aws.lambda.invocation` spans and its integretion into internal extension (trace spans come with no tags assigned at this point, but interface is ready to host them)
- Integration tests that confirm that spans are created with each lambda invocation.

First number show, no overhead during initialization, and 1-2ms overhead for each invocation. That may go slightly bigger once we add other instrumentation and start writing tags, but I wouldn't expect it to go bigger than those few milliseconds, we'll see.