### PR TITLE
Fix `esbuild` reference in build script

### DIFF
--- a/node/packages/aws-lambda-sdk/scripts/lib/build.js
+++ b/node/packages/aws-lambda-sdk/scripts/lib/build.js
@@ -6,9 +6,10 @@ const AdmZip = require('adm-zip');
 const mkdir = require('fs2/mkdir');
 const spawn = require('child-process-ext/spawn');
 
-const rootDir = path.resolve(__dirname, '../../');
+const rootDir = path.resolve(__dirname, '../../../../');
+const packageDir = path.resolve(rootDir, 'packages/aws-lambda-sdk');
 const esbuildFilename = path.resolve(rootDir, 'node_modules/.bin/esbuild');
-const internalDir = path.resolve(rootDir, 'internal-extension');
+const internalDir = path.resolve(packageDir, 'internal-extension');
 
 const extensionDirname = 'sls-sdk-node';
 


### PR DESCRIPTION
Noticed that CI failed after the recent dev dependencies cleanup. It was caused by invalid esbuild path resolution. This patch fixes that