### PR TITLE
Updated to span_id

### DIFF
--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -27,7 +27,7 @@ const testTracePayload = {
   },
   spans: [
     {
-      id: Buffer.from('Y2M4MWUwNjctMWNmYi00ZmYxLWE2OWItMDVhOTQ4NGZmZmFk'),
+      spanId: Buffer.from('Y2M4MWUwNjctMWNmYi00ZmYxLWE2OWItMDVhOTQ4NGZmZmFk'),
       traceId: Buffer.from('YTZkZTMxMzgtMmM0ZS00M2QxLTk0YTAtMDVmMjQ0NzJlNjg1'),
       name: 'test',
       startTimeUnixNano: longValue,

--- a/proto/serverless/instrumentation/v1/trace.proto
+++ b/proto/serverless/instrumentation/v1/trace.proto
@@ -23,7 +23,7 @@ message TracePayload {
 
 message Span {
     // The Span ID, this will be a random 8-byte ID encoded as a length 16 lowercase hex string.
-    bytes id = 1;
+    bytes span_id = 1;
 
     // The Trace ID, this will be a random 16-byte ID encoded as a length 32 lowercase hex string.
     // The Trace ID is what is used to group all spans for specific trace together.


### PR DESCRIPTION
I think it might make more sense to just call this `span_id` instead of `id`. I know it is implied since it is attached to a span but given elastic already has an id property this might help reduce some confusion 👍 