### PR TITLE
AWS Lambda SDK: Write Protobuf payloads to output

### DIFF
--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "author": "Serverless, Inc.",
   "dependencies": {
+    "@serverless/sdk-schema": "^0.2.0",
     "d": "^1.0.1",
+    "long": "^5.2.0",
     "type": "^2.6.1"
   },
   "typesVersions": {


### PR DESCRIPTION
Depends on:
- #148 being merged first
- #154 being merged and released

Trace payload is written with log as follows:

```
⚡T.<base64 encoded payload>
```

I've decided to write in base64 encoding and not binary directly, as binary breaks the readability of logs in CloudWatch Console (many nonsense characters are spread multiline). I'm pretty sure users will not be happy about that
