### PR TITLE
AWS Lambda SDK: Setup benchmarks

### DIFF
--- a/node/packages/aws-lambda-sdk/test/benchmark/README.md
+++ b/node/packages/aws-lambda-sdk/test/benchmark/README.md
@@ -1,0 +1,124 @@
+# Benchmarks
+
+## Tested use cases
+
+### Node.js function ([`callback`](../../fixtures/lambdas/callback.js))
+
+No-op Node.js function. Handler takes callback and immediately invokes it with dummy payload
+
+### Node.js 250ms function ([`250ms`](../../fixtures/lambdas/250ms.js))
+
+No-op Node.js function. Handler takes callback waits 250ms and invokes it with dummy payload.
+In this case produced extension invocation overheads are slightly smaller as some of the extension work is done during lambda operation
+
+### Node.js requiring function ([`requires`](../../fixtures/lambdas/requires.js))
+
+Node.js function that requires a lot of modules
+
+## Benchmark variants
+
+### `bare`
+
+No instrumentation (bare run with no extension layers onboard).
+
+As there are no extensions loaded, there's no extension duration overhead introduced, and benchmark will naturally report them with zeros.
+
+What we get is metrics from AWS report, that confirm on initialization duration, invocation duration, billed invocation duration and max memory used.
+
+### `internal`
+
+Internal extension which calculates and logs generated traces payload to the console
+
+## Reported metrics
+
+Each benchmark variant is run against 5 lambda instances.
+
+Therefore for each metric outlined below, we get 5 numbers. Durations returned in result report are averages of those 5 values.
+
+Internally measured durations are written by the extensions to the `stdout`, and are read (together with invocation reports as written by AWS) from CloudWatch logs.
+
+### Observed AWS Lambda execution lifecycle phases
+
+#### Initialization (`init`)
+
+Lambda instance initialization
+
+##### Observed metrics
+
+###### `init:internal`
+
+Duration of the internal extension initialization logic, measured internally in internal extension. It's a time measured from start of the internal extension logic, until it returns for further evaluation by AWS runtime engine.
+
+###### `init:total`
+
+Total initialization time as reported by AWS (with `initDuration` metric provided in report of the first invocation)
+
+#### Invocation
+
+Benchmarks observe first invocation (`first`) (one that in regular circumstances immediately follows initialization), and the the second (`following`).
+
+Two first invocations are observed separately, as data shows that durations of first invocation are always worse than of the second, and that for the following (third, fourth etc.) invocations numbers are similar as for the second.
+_This difference could be attributed to how Node.js internal optimization works, where paths which were already taken usually run faster (it's to be confirmed whether we see similar differences with other runtimes)._
+
+##### Observed metrics
+
+###### `[first|following]:internal:request`
+
+Invocation request handing duration in context of the Node.js internal extension. It's a time that's measured from the moment when our handler wrapper received an invocation event from AWS until we invoke the original Lambda handler.
+
+###### `[first|following]:internal:response`
+
+Invocation response handling duration in the context of the Node.js internal extension. It's a time that's measured from the moment when original handler provided response until we pass it back to AWS.
+
+###### `[first|following]:total`
+
+Total duration time as reported by AWS (with `duration` metric provided in invocation report)
+
+###### `[first|following]:billed`
+
+Billed duration time as reported by AWS (with `billedDuration` metric provided in invocation report)
+
+###### `[first|following]:local
+
+Locally measured SDK invocation time. This value is largely influenced by the location from which we run benchmarks and quality of the internet connection.
+
+For benchmarks run against `us-east-1` region, shortest values we'll get e.g. in New York, but running benchmarks in San Francisco will already add extra latency, and numbers get additionally worse, when running benchmarks from farther locations
+
+###### `[first|following]:maxMemoryUsed
+
+Max memory used as reported by AWS (with `maxMemoryUsed` metric provided in invocation report). It's to expose what memory overhead is introduced by the extensions
+
+## Setup & Run
+
+### 1. Ensure AWS credentials
+
+_In same manner as for AWS CLI_
+
+### 2. Configure environment variables
+
+- `AWS_REGION` - region against which benchmarks should be run
+- `SLS_ORG_ID`- Console organization id (can by dummy, as it'll be part of generated trace which otherwise is not send to console servers)
+- `TEST_UID` - (optional) common name token to be used as part of generated resource names. All generated resource names will be prefixed with `test-oext-<test-uid>`. If not provided, one is generated on basis of [local machine id](https://www.npmjs.com/package/node-machine-id). Note: Script ensures that all generated resources are removed after benchmark is done
+- `LOG_LEVEL` - (optional) For more verbose output `LOG_LEVEL=info` can be used
+
+### 4. Run
+
+Benchmark for all configured use cases and benchmark variants can be run as:
+
+```bash
+./test/scripts/benchmark.js
+```
+
+Generated benchmark results are output to the console in CSV format. To store them to the file output can be piped as:
+
+```bash
+./test/scripts/benchmark.js > benchmark.csv
+```
+
+### 4.1 Run customization
+
+Benchmark run can additionally be customized with following CLI params
+
+- `--use-cases` Comma separated list of function use cases to test (e.g. `callback,require`)
+- `--benchmark-variants` Comma separated list of benchmark variants to test (e.g. `internal`)
+- `--memory-size` Memory size to provide to lambdas (by default it's 128MB).

--- a/node/packages/aws-lambda-sdk/test/benchmark/index.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const createCoreResources = require('../lib/create-core-resources');
+const resolveCommonBenchmarkVariantsConfig = require('./lib/resolve-common-benchmark-variants-config');
+const resolveUseCasesConfig = require('./lib/resolve-use-cases-config');
+const run = require('./lib/run');
+
+module.exports = async (options = {}) => {
+  const coreConfig = {};
+  await createCoreResources(coreConfig);
+
+  const allBenchmarkVariantsConfig = await resolveCommonBenchmarkVariantsConfig(
+    coreConfig,
+    options
+  );
+
+  const benchmarkVariantsConfig = options.benchmarkVariants
+    ? new Map(
+        Array.from(allBenchmarkVariantsConfig).filter(([name]) =>
+          options.benchmarkVariants.has(name)
+        )
+      )
+    : allBenchmarkVariantsConfig;
+
+  if (!benchmarkVariantsConfig.size) throw new Error('No matching benchmark variant');
+
+  const useCasesConfig = resolveUseCasesConfig(benchmarkVariantsConfig, options);
+
+  if (!useCasesConfig.size) throw new Error('No matching use case');
+
+  return run(useCasesConfig, coreConfig);
+};

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = async (coreConfig, options) => {
+  const memorySize = options.memorySize || 1024;
+  return new Map([
+    [
+      'bare',
+      {
+        configuration: {
+          MemorySize: memorySize,
+          Layers: [],
+          Environment: { Variables: {} },
+        },
+      },
+    ],
+    [
+      'internal',
+      {
+        configuration: {
+          MemorySize: memorySize,
+        },
+      },
+    ],
+  ]);
+};

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-use-cases-config.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-use-cases-config.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const _ = require('lodash');
+const path = require('path');
+const resolveFileZipBuffer = require('../../utils/resolve-file-zip-buffer');
+
+const fixturesDirname = path.resolve(__dirname, '../../fixtures/lambdas');
+
+const cloneMap = (map) => new Map(Array.from(map, ([key, value]) => [key, _.merge({}, value)]));
+
+module.exports = (benchmarkVariantsConfig, options) => {
+  const allUseCasesConfig = new Map([
+    [
+      'callback',
+      {
+        config: {
+          configuration: {
+            Code: {
+              ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, 'callback.js')),
+            },
+          },
+        },
+        variants: cloneMap(benchmarkVariantsConfig),
+      },
+    ],
+
+    [
+      '250ms',
+      {
+        config: {
+          configuration: {
+            Code: {
+              ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, '250ms.js')),
+            },
+          },
+        },
+        variants: cloneMap(benchmarkVariantsConfig),
+      },
+    ],
+    [
+      'requires',
+      {
+        configuration: {
+          Timeout: 20,
+        },
+        variants: cloneMap(benchmarkVariantsConfig),
+      },
+    ],
+  ]);
+
+  return options.useCases
+    ? new Map(Array.from(allUseCasesConfig).filter(([name]) => options.useCases.has(name)))
+    : allUseCasesConfig;
+};

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const log = require('log').get('test');
+const resolveTestVariantsConfig = require('../../lib/resolve-test-variants-config');
+const processFunction = require('../../lib/process-function');
+const cleanup = require('../../lib/cleanup');
+const { median, average } = require('../../utils/stats');
+
+module.exports = async (useCasesConfig, coreConfig) => {
+  const testVariantsConfig = resolveTestVariantsConfig(useCasesConfig, { multiplyBy: 5 });
+  for (const testConfig of testVariantsConfig) {
+    testConfig.deferredResult = processFunction(testConfig, coreConfig).catch((error) => ({
+      // As we process result promises sequentially step by step in next turn, allowing them to
+      // reject will generate unhandled rejection.
+      // Therefore this scenario is converted to successuful { error } resolution
+      error,
+    }));
+  }
+
+  try {
+    const resultsMap = new Map();
+    for (const testConfig of testVariantsConfig) {
+      const testResult = await testConfig.deferredResult;
+      if (testResult.error) throw testResult.error;
+      const basename = testConfig.name.slice(0, -2);
+      const separatorIndex = basename.lastIndexOf('-');
+      const functionVariantName = basename.slice(0, separatorIndex);
+      const benchmarkVariantName = basename.slice(separatorIndex + 1);
+      if (!resultsMap.has(functionVariantName)) resultsMap.set(functionVariantName, new Map());
+      const functionVariantResultsMap = resultsMap.get(functionVariantName);
+      if (!functionVariantResultsMap.has(benchmarkVariantName)) {
+        functionVariantResultsMap.set(benchmarkVariantName, { reports: [] });
+      }
+      functionVariantResultsMap.get(benchmarkVariantName).reports.push(testResult);
+    }
+
+    for (const [functionVariantName, functionVariantResultsMap] of resultsMap) {
+      for (const [benchmarkVariantName, benchmarkVariantResult] of functionVariantResultsMap) {
+        const { reports } = benchmarkVariantResult;
+
+        const durationsData = {
+          initialization: {
+            internal: reports.map(
+              ({
+                processesData: [
+                  {
+                    extensionOverheadDurations: { internalInit },
+                  },
+                ],
+              }) => internalInit || 0
+            ),
+            total: reports.map(({ processesData: [{ initDuration }] }) => initDuration),
+          },
+          invocation: {
+            first: {
+              internal: {
+                request: reports.map(
+                  ({
+                    invocationsData: [
+                      {
+                        extensionOverheadDurations: { internalRequest },
+                      },
+                    ],
+                  }) => internalRequest || 0
+                ),
+                response: reports.map(
+                  ({
+                    invocationsData: [
+                      {
+                        extensionOverheadDurations: { internalResponse },
+                      },
+                    ],
+                  }) => internalResponse || 0
+                ),
+              },
+              total: reports.map(({ invocationsData: [{ duration }] }) => duration),
+              billed: reports.map(({ invocationsData: [{ billedDuration }] }) => billedDuration),
+              local: reports.map(({ invocationsData: [{ localDuration }] }) => localDuration),
+              maxMemoryUsed: reports.map(
+                ({ invocationsData: [{ maxMemoryUsed }] }) => maxMemoryUsed
+              ),
+            },
+            following: {
+              internal: {
+                request: reports.map(
+                  ({
+                    invocationsData: [
+                      ,
+                      {
+                        extensionOverheadDurations: { internalRequest },
+                      },
+                    ],
+                  }) => internalRequest || 0
+                ),
+                response: reports.map(
+                  ({
+                    invocationsData: [
+                      ,
+                      {
+                        extensionOverheadDurations: { internalResponse },
+                      },
+                    ],
+                  }) => internalResponse || 0
+                ),
+              },
+              total: reports.map(({ invocationsData: [, { duration }] }) => duration),
+              billed: reports.map(({ invocationsData: [, { billedDuration }] }) => billedDuration),
+              local: reports.map(({ invocationsData: [, { localDuration }] }) => localDuration),
+              maxMemoryUsed: reports.map(
+                ({ invocationsData: [, { maxMemoryUsed }] }) => maxMemoryUsed
+              ),
+            },
+          },
+        };
+
+        benchmarkVariantResult.results = {
+          initialization: {
+            internal: {
+              average: average(durationsData.initialization.internal),
+              median: median(durationsData.initialization.internal),
+            },
+            total: {
+              average: average(durationsData.initialization.total),
+              median: median(durationsData.initialization.total),
+            },
+          },
+          invocation: {
+            first: {
+              internal: {
+                request: {
+                  average: average(durationsData.invocation.first.internal.request),
+                  median: median(durationsData.invocation.first.internal.request),
+                },
+                response: {
+                  average: average(durationsData.invocation.first.internal.response),
+                  median: median(durationsData.invocation.first.internal.response),
+                },
+              },
+              total: {
+                average: average(durationsData.invocation.first.total),
+                median: median(durationsData.invocation.first.total),
+              },
+              billed: {
+                average: average(durationsData.invocation.first.billed),
+                median: median(durationsData.invocation.first.billed),
+              },
+              local: {
+                average: average(durationsData.invocation.first.local),
+                median: median(durationsData.invocation.first.local),
+              },
+              maxMemoryUsed: {
+                average: average(durationsData.invocation.first.maxMemoryUsed),
+                median: median(durationsData.invocation.first.maxMemoryUsed),
+              },
+            },
+            following: {
+              internal: {
+                request: {
+                  average: average(durationsData.invocation.following.internal.request),
+                  median: median(durationsData.invocation.following.internal.request),
+                },
+                response: {
+                  average: average(durationsData.invocation.following.internal.response),
+                  median: median(durationsData.invocation.following.internal.response),
+                },
+              },
+              total: {
+                average: average(durationsData.invocation.following.total),
+                median: median(durationsData.invocation.following.total),
+              },
+              billed: {
+                average: average(durationsData.invocation.following.billed),
+                median: median(durationsData.invocation.following.billed),
+              },
+              local: {
+                average: average(durationsData.invocation.following.local),
+                median: median(durationsData.invocation.following.local),
+              },
+              maxMemoryUsed: {
+                average: average(durationsData.invocation.following.maxMemoryUsed),
+                median: median(durationsData.invocation.following.maxMemoryUsed),
+              },
+            },
+          },
+        };
+        log.info(
+          'Results for %s: $o',
+          `${functionVariantName}-${benchmarkVariantName}`,
+          benchmarkVariantResult.results
+        );
+      }
+    }
+
+    return resultsMap;
+  } finally {
+    await cleanup({ skipFunctionsCleanup: true });
+  }
+};

--- a/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { expect } = require('chai');
+
+const runBenchmarks = require('./');
+
+describe('performance', function () {
+  this.timeout(120000);
+
+  let results;
+  before(async () => {
+    const resultsMap = await runBenchmarks({
+      benchmarkVariants: new Set(['internal']),
+      useCases: new Set(['callback']),
+    });
+    ({ results } = resultsMap.get('callback').get('internal'));
+  });
+
+  // TODO: Reduce acceptable durations once improvements are made
+  it('should introduce reasonable initialization overhead', () => {
+    expect(results.initialization.total.median).to.be.below(200);
+  });
+
+  it('should introduce reasonable first invocation overhead', () => {
+    expect(results.invocation.first.total.median).to.be.below(10);
+  });
+
+  it('should introduce reasonable following invocation overhead', () => {
+    expect(results.invocation.following.total.median).to.be.below(10);
+  });
+});

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/250ms.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/250ms.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.handler = (event, context, callback) => {
+  setTimeout(
+    () =>
+      callback(null, {
+        statusCode: 200,
+        body: JSON.stringify({ result: 'ok', filename: __filename }),
+      }),
+    250
+  );
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/requires.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/requires.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+require('aws-sdk');
+
+module.exports.handler = (event, context, callback) => {
+  callback(null, { statusCode: 200, body: JSON.stringify({ result: 'ok', filename: __filename }) });
+};

--- a/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
+++ b/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('essentials');
+require('log-node')();
+
+const argv = require('yargs-parser')(process.argv.slice(2));
+
+const resolveSet = (comaSeparatedValue) =>
+  new Set(
+    comaSeparatedValue
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+
+require('../benchmark')({
+  benchmarkVariants: argv['benchmark-variants'] ? resolveSet(argv['benchmark-variants']) : null,
+  useCases: argv['use-cases'] ? resolveSet(argv['use-cases']) : null,
+  memorySize: argv['memory-size'] ? Number(argv['memory-size']) : null,
+}).then((resultsMap) => {
+  process.stdout.write(
+    `${[
+      [
+        'name',
+        'init:internal',
+        'init:total',
+
+        'first:internal:request',
+        'first:internal:response',
+        'first:total',
+        'first:billed',
+        'first:local',
+        'first:maxMemoryUsed',
+
+        'following:internal:request',
+        'following:internal:response',
+        'following:total',
+        'following:billed',
+        'following:local',
+        'following:maxMemoryUsed',
+      ]
+        .map(JSON.stringify)
+        .join('\t'),
+      ...Array.from(resultsMap, ([functionVariantName, functionVariantResultsMap]) =>
+        Array.from(
+          functionVariantResultsMap,
+          ([benchmarkVariantName, { results: benchmarkVariantResults }]) =>
+            [
+              JSON.stringify(`${functionVariantName}:${benchmarkVariantName}`),
+              Math.round(benchmarkVariantResults.initialization.internal.average),
+              Math.round(benchmarkVariantResults.initialization.total.average),
+
+              Math.round(benchmarkVariantResults.invocation.first.internal.request.average),
+              Math.round(benchmarkVariantResults.invocation.first.internal.response.average),
+              Math.round(benchmarkVariantResults.invocation.first.total.average),
+              Math.round(benchmarkVariantResults.invocation.first.billed.average),
+              Math.round(benchmarkVariantResults.invocation.first.local.average),
+              Math.round(benchmarkVariantResults.invocation.first.maxMemoryUsed.average),
+
+              Math.round(benchmarkVariantResults.invocation.following.internal.request.average),
+              Math.round(benchmarkVariantResults.invocation.following.internal.response.average),
+              Math.round(benchmarkVariantResults.invocation.following.total.average),
+              Math.round(benchmarkVariantResults.invocation.following.billed.average),
+              Math.round(benchmarkVariantResults.invocation.following.local.average),
+              Math.round(benchmarkVariantResults.invocation.following.maxMemoryUsed.average),
+            ].join('\t')
+        )
+      ).flat(),
+    ].join('\n')}\n`
+  );
+});

--- a/node/packages/aws-lambda-sdk/test/utils/stats.js
+++ b/node/packages/aws-lambda-sdk/test/utils/stats.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const asc = (arr) => arr.sort((a, b) => a - b);
+
+const quantile = (values, q) => {
+  const sorted = asc(values);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+};
+
+const q50 = (values) => quantile(values, 0.5);
+
+module.exports.median = (values) => q50(values);
+
+module.exports.average = (values) => {
+  let sum = 0;
+  for (const value of values) sum += value;
+  return sum / values.length;
+};


### PR DESCRIPTION
Similarly, as we had with otel version, this PR setups a benchmarks script, that tracks the effect of instrumentation against few basic cases.

Current numbers as very promising, ca 40ms initiaization overhead, 4ms first invocation overhead and 1ms for following invocation overhead (e.g. for Lumigo it's 85ms, 70ms, 20ms respectively - but we need to take into account that Lumigo sends the requests, while we just log them into console)