### PR TITLE
CI: Fix setup for `@serverless/aws-lambda-sdk`

### DIFF
--- a/.github/workflows/node-integrate.yml
+++ b/.github/workflows/node-integrate.yml
@@ -440,8 +440,7 @@ jobs:
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SLS_ORG_NAME: test
-      SLS_ORG_TOKEN: ${{ secrets.SLS_ORG_TOKEN }}
+      SLS_ORG_ID: ${{ secrets.SLS_ORG_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Observed CI fail which happened due to missing env var setup

https://github.com/serverless/console/runs/8074354584