### PR TITLE
AWS Lambda SDK: Change payload prefix

### DIFF
--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -2,6 +2,12 @@
 
 For each function invocation single AWS Lambda SDK Trace is generated.
 
+Before returning the result to AWS Lambda trace payload is written to the console with following log line:
+
+```
+SERVERLESS_TELEMETRY.T.<base64 encoded payload>
+```
+
 ## Trace tags
 
 _Tags exposed on top trace_

--- a/node/packages/aws-lambda-sdk/instrument.js
+++ b/node/packages/aws-lambda-sdk/instrument.js
@@ -100,7 +100,7 @@ module.exports = (originalHandler, options = {}) => {
       });
       const protoTraceBuffer = (serverlessSdk._lastProtoTraceBuffer =
         traceProto.TracePayload.encode(protoTrace).finish());
-      process._rawDebug(`⚡T.${protoTraceBuffer.toString('base64')}`);
+      process._rawDebug(`SERVERLESS_TELEMETRY.T.${protoTraceBuffer.toString('base64')}`);
 
       debugLog('Trace:', JSON.stringify(trace));
       debugLog(


### PR DESCRIPTION
As agreed on Jira.

I've renamed current trace payload prefix into `SERVERLESS_TELEMETRY.T.`. Trailing `.T.` is to indicate what payload is written. In future it's possible we will write also other payloads, and I assume it's good to know upfront what payload we're dealing with.
