### PR TITLE
AWS Lambda SDK: Instrument API Gateway HTTP API (v1 payload) events

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-api-gateway": "^3.162.0",
+    "@aws-sdk/client-apigatewayv2": "^3.162.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.162.0",
     "@aws-sdk/client-iam": "^3.162.0",
     "@aws-sdk/client-lambda": "^3.162.0",

--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -51,9 +51,12 @@ Tags set in case of `'error:handled'` outcome
 | `aws.lambda.error_exception_message`    | Error message     |
 | `aws.lambda.error_exception_stacktrace` | Error stack trace |
 
-##### AWS API Gateway (v1) REST API endpoint
+##### AWS API Gateway, v1 REST API endpoint & v2 HTTP API (v1 payload)
 
-Tags collected if event comes from AWS API Gateway REST API endpoint configured with `AWS_PROXY` integration type.
+Tags collected if event is sourced by either:
+
+- AWS API Gateway v1 REST API endpoint configured with `AWS_PROXY` integration type.
+- AWS API Gateway v2 HTTP API endpoint configured with v1 version of a payload
 
 | Name                                                     | Value                                                                               |
 | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
+++ b/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
@@ -78,7 +78,7 @@ const apiGatewayEventMap = [
 module.exports = (event) => {
   if (!isObject(event)) return;
   if (doesObjectMatchMap(event, apiGatewayEventMap)) {
-    // API Gateway (v1) event
+    // API Gateway v1 REST API or v2 HTTP API (v1 payload) event
     const { requestContext } = event;
     awsLambdaSpan.tags.setMany(
       {

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -102,7 +102,7 @@ describe('integration', function () {
                 afterCreate: async (testConfig) => {
                   const restApiId = (testConfig.restApiId = (
                     await awsRequest(APIGateway, 'createRestApi', {
-                      name: testConfig.name,
+                      name: testConfig.configuration.FunctionName,
                     })
                   ).id);
                   const deferredAddPermission = awsRequest(Lambda, 'addPermission', {

--- a/node/packages/aws-lambda-sdk/test/lib/cleanup.js
+++ b/node/packages/aws-lambda-sdk/test/lib/cleanup.js
@@ -22,6 +22,14 @@ const getAllFunctionNames = async (marker = undefined) => {
   }
   return new Set(functionNames);
 };
+const deleteFunctions = async () => {
+  await Promise.all(
+    Array.from(await getAllFunctionNames(), async (functionName) => {
+      await awsRequest(Lambda, 'deleteFunction', { FunctionName: functionName });
+      log.notice('Deleted function %s', functionName);
+    })
+  );
+};
 
 const getAllRestApiIds = async (position = undefined) => {
   const result = await awsRequest(APIGateway, 'getRestApis', { limit: 500, position });
@@ -34,16 +42,6 @@ const getAllRestApiIds = async (position = undefined) => {
   }
   return new Set(apiIds);
 };
-
-const deleteFunctions = async () => {
-  await Promise.all(
-    Array.from(await getAllFunctionNames(), async (functionName) => {
-      await awsRequest(Lambda, 'deleteFunction', { FunctionName: functionName });
-      log.notice('Deleted function %s', functionName);
-    })
-  );
-};
-
 const deleteRestApis = async () => {
   await Promise.all(
     Array.from(await getAllRestApiIds(), async (restApiId) => {
@@ -52,6 +50,7 @@ const deleteRestApis = async () => {
     })
   );
 };
+
 const listLayerVersions = async (layerName, nextMarker = undefined) => {
   const response = await awsRequest(Lambda, 'listLayerVersions', {
     LayerName: layerName,

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -209,4 +209,103 @@ describe('internal-extension/index.test.js', () => {
       })
     );
   });
+
+  it('should handle API Gateway v2 HTTP API, payload v1 event', async () => {
+    const {
+      trace: {
+        spans: [{ tags }],
+      },
+    } = await handleInvocation('api-endpoint', {
+      isApiEndpoint: true,
+      payload: {
+        version: '1.0',
+        resource: '/v1',
+        path: '/v1',
+        httpMethod: 'POST',
+        headers: {
+          'Content-Length': '385',
+          'Content-Type':
+            'multipart/form-data; boundary=--------------------------182902192059219621976732',
+          'Multi': 'two',
+        },
+        multiValueHeaders: {
+          'Content-Length': ['385'],
+          'Content-Type': [
+            'multipart/form-data; boundary=--------------------------182902192059219621976732',
+          ],
+          'Multi': ['one,stillone', 'two'],
+        },
+        queryStringParameters: {
+          lone: 'value',
+          multi: 'two',
+        },
+        multiValueQueryStringParameters: {
+          lone: ['value'],
+          multi: ['one,stillone', 'two'],
+        },
+        requestContext: {
+          accountId: '205994128558',
+          apiId: 'xxx',
+          domainName: 'xxx.execute-api.us-east-1.amazonaws.com',
+          domainPrefix: 'xxx',
+          extendedRequestId: 'XyGqvi5mIAMEJtw=',
+          httpMethod: 'POST',
+          identity: {
+            accessKey: null,
+            accountId: null,
+            caller: null,
+            cognitoAmr: null,
+            cognitoAuthenticationProvider: null,
+            cognitoAuthenticationType: null,
+            cognitoIdentityId: null,
+            cognitoIdentityPoolId: null,
+            principalOrgId: null,
+            sourceIp: '80.55.87.22',
+            user: null,
+            userAgent: 'PostmanRuntime/7.29.0',
+            userArn: null,
+          },
+          path: '/v1',
+          protocol: 'HTTP/1.1',
+          requestId: 'XyGqvi5mIAMEJtw=',
+          requestTime: '01/Sep/2022:13:47:10 +0000',
+          requestTimeEpoch: 1662040030156,
+          resourceId: 'POST /v1',
+          resourcePath: '/v1',
+          stage: '$default',
+        },
+        pathParameters: null,
+        stageVariables: null,
+        body: 'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTE4MjkwMjE5MjA1OTIxOTYyMTk3NjczMg0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJMb25lIg0KDQpvbmUNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0xODI5MDIxOTIwNTkyMTk2MjE5NzY3MzINCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0ibXVsdGkiDQoNCm9uZSxzdGlsbG9uZQ0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTE4MjkwMjE5MjA1OTIxOTYyMTk3NjczMg0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJtdWx0aSINCg0KdHdvDQotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tMTgyOTAyMTkyMDU5MjE5NjIxOTc2NzMyLS0NCg==',
+        isBase64Encoded: true,
+      },
+    });
+
+    expect(tags.get('aws.lambda.api_gateway.account_id')).to.equal('205994128558');
+    expect(tags.get('aws.lambda.api_gateway.api_id')).to.equal('xxx');
+    expect(tags.get('aws.lambda.api_gateway.api_stage')).to.equal('$default');
+
+    expect(tags.get('aws.lambda.api_gateway.request.id')).to.equal('XyGqvi5mIAMEJtw=');
+    expect(tags.get('aws.lambda.api_gateway.request.time_epoch')).to.equal(1662040030156);
+    expect(tags.get('aws.lambda.api_gateway.request.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('aws.lambda.api_gateway.request.domain')).to.equal(
+      'xxx.execute-api.us-east-1.amazonaws.com'
+    );
+    expect(tags.get('aws.lambda.api_gateway.request.headers')).to.equal(
+      JSON.stringify({
+        'Content-Length': '385',
+        'Content-Type':
+          'multipart/form-data; boundary=--------------------------182902192059219621976732',
+        'Multi': ['one,stillone', 'two'],
+      })
+    );
+    expect(tags.get('aws.lambda.api_gateway.request.method')).to.equal('POST');
+    expect(tags.get('aws.lambda.api_gateway.request.path')).to.equal('/v1');
+    expect(tags.get('aws.lambda.api_gateway.request.query_string_parameters')).to.equal(
+      JSON.stringify({
+        lone: 'value',
+        multi: ['one,stillone', 'two'],
+      })
+    );
+  });
 });


### PR DESCRIPTION
They share the same schema as REST API events, so the update is mostly about integration tests configuration