### PR TITLE
SDK Schema: Make `status_code` optional

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -13,5 +13,5 @@ message HttpTags {
   // The HTTP protocol of the incoming HTTP Request Event.
   string protocol = 3;
   // The Response Status Code.
-  fixed64 status_code = 4;
+  optional fixed64 status_code = 4;
 }

--- a/proto/serverless/instrumentation/tags/v1/nodejs.proto
+++ b/proto/serverless/instrumentation/tags/v1/nodejs.proto
@@ -10,5 +10,5 @@ message ExpressTags {
   // The HTTP Path defined by the Express Route Handler.
   string path = 2;
   // The status code returned by the Express Route Handler.
-  uint32 status_code = 3;
+  optional uint32 status_code = 3;
 }


### PR DESCRIPTION
It's to handle properly cases where request fails before receiving a response, or goes beyond current invocation