### PR TITLE
AWS Lambda SDK: Upgrade API Gateway integration

### DIFF
--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -73,15 +73,17 @@ Tags collected if event is sourced by either:
 - AWS API Gateway v1 REST API endpoint configured with `AWS_PROXY` integration type.
 - AWS API Gateway v2 HTTP API endpoint configured with either v1 or v2 version of a payload
 
-| Name                                             | Value                                                                    |
-| ------------------------------------------------ | ------------------------------------------------------------------------ |
-| `aws.lambda.api_gateway.account_id`              | Account id of API Gateway                                                |
-| `aws.lambda.api_gateway.api_id`                  | API id                                                                   |
-| `aws.lambda.api_gateway.api_stage`               | API stage                                                                |
-| `aws.lambda.api_gateway.request.id`              | API Gateway request id                                                   |
-| `aws.lambda.api_gateway.request.time_epoch`      | API Gateway request time                                                 |
-| `aws.lambda.api_gateway.request.headers`         | JSON string of request headers. Multi value headers are stored as arrays |
-| `aws.lambda.api_gateway.request.path_parameters` | JSON string of request path parameters                                   |
+| Name                                             | Value                                                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `aws.lambda.event_source`                        | `"aws.apigateway"`                                                                    |
+| `aws.lambda.event_type`                          | `"aws.apigateway.rest"`, `"aws.apigatewayv2.http.v1"` or `"aws.apigatewayv2.http.v2"` |
+| `aws.lambda.api_gateway.account_id`              | Account id of API Gateway                                                             |
+| `aws.lambda.api_gateway.api_id`                  | API id                                                                                |
+| `aws.lambda.api_gateway.api_stage`               | API stage                                                                             |
+| `aws.lambda.api_gateway.request.id`              | API Gateway request id                                                                |
+| `aws.lambda.api_gateway.request.time_epoch`      | API Gateway request time                                                              |
+| `aws.lambda.api_gateway.request.headers`         | JSON string of request headers. Multi value headers are stored as arrays              |
+| `aws.lambda.api_gateway.request.path_parameters` | JSON string of request path parameters                                                |
 
 ##### SQS queue message
 
@@ -89,6 +91,8 @@ Tags collected if event is sourced by SQS queue
 
 | Name                         | Value                |
 | ---------------------------- | -------------------- |
+| `aws.lambda.event_source`    | `"aws.sqs"`          |
+| `aws.lambda.event_type`      | `"aws.sqs"`          |
 | `aws.lambda.sqs.queue_name`  | Queue name           |
 | `aws.lambda.sqs.message_ids` | Array of message ids |
 
@@ -98,6 +102,8 @@ Tags collected if event is sourced by SNS topic subscription
 
 | Name                         | Value                |
 | ---------------------------- | -------------------- |
+| `aws.lambda.event_source`    | `"aws.sns"`          |
+| `aws.lambda.event_type`      | `"aws.sns"`          |
 | `aws.lambda.sns.topic_name`  | Topic name           |
 | `aws.lambda.sns.message_ids` | Array of message ids |
 

--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -51,6 +51,21 @@ Tags set in case of `'error:handled'` outcome
 | `aws.lambda.error_exception_message`    | Error message     |
 | `aws.lambda.error_exception_stacktrace` | Error stack trace |
 
+##### HTTP Endpoint
+
+Tags collected if event is sourced by either:
+
+- AWS API Gateway v1 REST API endpoint configured with `AWS_PROXY` integration type.
+- AWS API Gateway v2 HTTP API endpoint configured with either v1 or v2 version of a payload
+
+| Name                       | Value                                                          |
+| -------------------------- | -------------------------------------------------------------- |
+| `aws.lambda.http.method`   | Request method                                                 |
+| `aws.lambda.http.protocol` | Endpoint protocol (e.g. `HTTP/1.1`)                            |
+| `aws.lambda.http.host`     | Endpoint Domain name                                           |
+| `aws.lambda.http.path`     | Request path                                                   |
+| `aws.lambda.http.query`    | Query parameters as query string (e.g. `foo=bar&query=string`) |
+
 ##### AWS API Gateway
 
 Tags collected if event is sourced by either:
@@ -58,20 +73,15 @@ Tags collected if event is sourced by either:
 - AWS API Gateway v1 REST API endpoint configured with `AWS_PROXY` integration type.
 - AWS API Gateway v2 HTTP API endpoint configured with either v1 or v2 version of a payload
 
-| Name                                                     | Value                                                                               |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `aws.lambda.api_gateway.account_id`                      | Account id of API Gateway                                                           |
-| `aws.lambda.api_gateway.api_id`                          | API id                                                                              |
-| `aws.lambda.api_gateway.api_stage`                       | API stage                                                                           |
-| `aws.lambda.api_gateway.request.id`                      | API Gateway request id                                                              |
-| `aws.lambda.api_gateway.request.time_epoch`              | API Gateway request time                                                            |
-| `aws.lambda.api_gateway.request.protocol`                | Endpoint protocol (e.g. `HTTP/1.1`)                                                 |
-| `aws.lambda.api_gateway.request.domain`                  | Endpoint Domain name                                                                |
-| `aws.lambda.api_gateway.request.headers`                 | JSON string of request headers. Multi value headers are stored as arrays            |
-| `aws.lambda.api_gateway.request.method`                  | Request method                                                                      |
-| `aws.lambda.api_gateway.request.path`                    | Request path                                                                        |
-| `aws.lambda.api_gateway.request.path_parameters`         | JSON string of request path parameters                                              |
-| `aws.lambda.api_gateway.request.query_string_parameters` | JSON string of query string parameters. Multi value parameters are stored as arrays |
+| Name                                             | Value                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------ |
+| `aws.lambda.api_gateway.account_id`              | Account id of API Gateway                                                |
+| `aws.lambda.api_gateway.api_id`                  | API id                                                                   |
+| `aws.lambda.api_gateway.api_stage`               | API stage                                                                |
+| `aws.lambda.api_gateway.request.id`              | API Gateway request id                                                   |
+| `aws.lambda.api_gateway.request.time_epoch`      | API Gateway request time                                                 |
+| `aws.lambda.api_gateway.request.headers`         | JSON string of request headers. Multi value headers are stored as arrays |
+| `aws.lambda.api_gateway.request.path_parameters` | JSON string of request path parameters                                   |
 
 ##### SQS queue message
 

--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -58,13 +58,15 @@ Tags collected if event is sourced by either:
 - AWS API Gateway v1 REST API endpoint configured with `AWS_PROXY` integration type.
 - AWS API Gateway v2 HTTP API endpoint configured with either v1 or v2 version of a payload
 
-| Name                       | Value                                                          |
-| -------------------------- | -------------------------------------------------------------- |
-| `aws.lambda.http.method`   | Request method                                                 |
-| `aws.lambda.http.protocol` | Endpoint protocol (e.g. `HTTP/1.1`)                            |
-| `aws.lambda.http.host`     | Endpoint Domain name                                           |
-| `aws.lambda.http.path`     | Request path                                                   |
-| `aws.lambda.http.query`    | Query parameters as query string (e.g. `foo=bar&query=string`) |
+| Name                          | Value                                                           |
+| ----------------------------- | --------------------------------------------------------------- |
+| `aws.lambda.http.method`      | Request method                                                  |
+| `aws.lambda.http.protocol`    | Endpoint protocol (e.g. `HTTP/1.1`)                             |
+| `aws.lambda.http.host`        | Endpoint Domain name                                            |
+| `aws.lambda.http.path`        | Request path                                                    |
+| `aws.lambda.http.query`       | Query parameters as query string (e.g. `foo=bar&query=string`)  |
+| `aws.lambda.http.status_code` | Response status code                                            |
+| `aws.lambda.http.error_code`  | Filled, if no or invalid status code is provided by the handler |
 
 ##### AWS API Gateway
 

--- a/node/packages/aws-lambda-sdk/instrument.js
+++ b/node/packages/aws-lambda-sdk/instrument.js
@@ -9,6 +9,7 @@ const coerceToString = require('type/string/coerce');
 const ensureString = require('type/string/ensure');
 const traceProto = require('@serverless/sdk-schema/dist/trace');
 const resolveEventTags = require('./lib/resolve-event-tags');
+const resolveResponseTags = require('./lib/resolve-response-tags');
 const pkgJson = require('./package');
 
 const serverlessSdk = global.serverlessSdk || require('./');
@@ -75,6 +76,8 @@ module.exports = (originalHandler, options = {}) => {
             awsLambdaSpan.tags.set('aws.lambda.error_exception_stacktrace', outcomeResult.stack);
           }
         }
+      } else {
+        resolveResponseTags(outcomeResult);
       }
 
       awsLambdaSpan.close();

--- a/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
+++ b/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
@@ -181,6 +181,13 @@ module.exports = (event) => {
     const { requestContext } = event;
     awsLambdaSpan.tags.setMany(
       {
+        event_source: 'aws.apigateway',
+        event_type: event.version ? 'aws.apigatewayv2.http.v1' : 'aws.apigateway.rest',
+      },
+      { prefix: 'aws.lambda' }
+    );
+    awsLambdaSpan.tags.setMany(
+      {
         account_id: requestContext.accountId,
         api_id: requestContext.apiId,
         api_stage: requestContext.stage,
@@ -211,6 +218,10 @@ module.exports = (event) => {
   if (doesObjectMatchMap(event, httpApiV2EventMap)) {
     // API Gateway v2 HTTP API (v2 payload) event
     const { requestContext } = event;
+    awsLambdaSpan.tags.setMany(
+      { event_source: 'aws.apigateway', event_type: 'aws.apigatewayv2.http.v2' },
+      { prefix: 'aws.lambda' }
+    );
     awsLambdaSpan.tags.setMany(
       {
         account_id: requestContext.accountId,
@@ -245,6 +256,10 @@ module.exports = (event) => {
     // SQS Queue event
     const queueArn = event.Records[0].eventSourceARN;
     awsLambdaSpan.tags.setMany(
+      { event_source: 'aws.sqs', event_type: 'aws.sqs' },
+      { prefix: 'aws.lambda' }
+    );
+    awsLambdaSpan.tags.setMany(
       {
         queue_name: queueArn.slice(queueArn.lastIndexOf(':') + 1),
         message_ids: event.Records.map(({ messageId }) => messageId),
@@ -256,6 +271,10 @@ module.exports = (event) => {
   if (doesObjectMatchMap(event, snsEventMap)) {
     // SNS message
     const topicArn = event.Records[0].Sns.TopicArn;
+    awsLambdaSpan.tags.setMany(
+      { event_source: 'aws.sns', event_type: 'aws.sns' },
+      { prefix: 'aws.lambda' }
+    );
     awsLambdaSpan.tags.setMany(
       {
         topic_name: topicArn.slice(topicArn.lastIndexOf(':') + 1),

--- a/node/packages/aws-lambda-sdk/lib/resolve-response-tags.js
+++ b/node/packages/aws-lambda-sdk/lib/resolve-response-tags.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const coerceNaturalNumber = require('type/natural-number/coerce');
+
+const awsLambdaSpan = (global.serverlessSdk || require('../')).traceSpans.awsLambda;
+
+module.exports = (response) => {
+  switch (awsLambdaSpan.tags.get('aws.lambda.event_source')) {
+    case 'aws.apigateway':
+      {
+        let statusCode = response?.statusCode;
+        if (statusCode == null) {
+          awsLambdaSpan.tags.set('aws.lambda.http.error_code', 'MISSING_STATUS_CODE');
+          break;
+        }
+        if (typeof statusCode === 'string') statusCode = Number(statusCode);
+        if (
+          coerceNaturalNumber(statusCode) === statusCode &&
+          statusCode >= 100 &&
+          statusCode < 600
+        ) {
+          awsLambdaSpan.tags.set('aws.lambda.http.status_code', statusCode);
+        } else {
+          awsLambdaSpan.tags.set('aws.lambda.http.error_code', 'INVALID_STATUS_CODE');
+        }
+      }
+      break;
+    default:
+  }
+};

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.1",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.4.0",
+    "@serverless/sdk-schema": "^0.5.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.0",

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -391,12 +391,10 @@ describe('integration', function () {
                   expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('test');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.domain');
+                  expect(tags).to.have.property('aws.lambda.http.host');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.api_gateway.request.method']).to.equal('POST');
-                  expect(tags['aws.lambda.api_gateway.request.path']).to.equal(
-                    '/test/some-path/some-param'
-                  );
+                  expect(tags['aws.lambda.http.method']).to.equal('POST');
+                  expect(tags['aws.lambda.http.path']).to.equal('/test/some-path/some-param');
                   expect(tags['aws.lambda.api_gateway.request.path_parameters']).to.equal(
                     JSON.stringify({ param: 'some-param' })
                   );
@@ -442,10 +440,10 @@ describe('integration', function () {
                   expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('$default');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.domain');
+                  expect(tags).to.have.property('aws.lambda.http.host');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.api_gateway.request.method']).to.equal('POST');
-                  expect(tags['aws.lambda.api_gateway.request.path']).to.equal('/test');
+                  expect(tags['aws.lambda.http.method']).to.equal('POST');
+                  expect(tags['aws.lambda.http.path']).to.equal('/test');
                 }
               },
             },
@@ -488,10 +486,10 @@ describe('integration', function () {
                   expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('$default');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.domain');
+                  expect(tags).to.have.property('aws.lambda.http.host');
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.api_gateway.request.method']).to.equal('POST');
-                  expect(tags['aws.lambda.api_gateway.request.path']).to.equal('/test');
+                  expect(tags['aws.lambda.http.method']).to.equal('POST');
+                  expect(tags['aws.lambda.http.path']).to.equal('/test');
                 }
               },
             },

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -407,6 +407,8 @@ describe('integration', function () {
                   expect(tags['aws.lambda.api_gateway.request.path_parameters']).to.equal(
                     JSON.stringify({ param: 'some-param' })
                   );
+
+                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
                 }
               },
             },
@@ -456,6 +458,8 @@ describe('integration', function () {
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
                   expect(tags['aws.lambda.http.method']).to.equal('POST');
                   expect(tags['aws.lambda.http.path']).to.equal('/test');
+
+                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
                 }
               },
             },
@@ -505,6 +509,8 @@ describe('integration', function () {
                   expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
                   expect(tags['aws.lambda.http.method']).to.equal('POST');
                   expect(tags['aws.lambda.http.path']).to.equal('/test');
+
+                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
                 }
               },
             },

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -195,6 +195,9 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
+                  expect(tags['aws.lambda.event_source']).to.equal('aws.sqs');
+                  expect(tags['aws.lambda.event_type']).to.equal('aws.sqs');
+
                   expect(tags['aws.lambda.sqs.queue_name']).to.equal(testConfig.queueName);
                   expect(tags['aws.lambda.sqs.message_ids'].length).to.equal(1);
                 }
@@ -247,6 +250,9 @@ describe('integration', function () {
               test: ({ invocationsData, testConfig }) => {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
+
+                  expect(tags['aws.lambda.event_source']).to.equal('aws.sns');
+                  expect(tags['aws.lambda.event_type']).to.equal('aws.sns');
 
                   expect(tags['aws.lambda.sns.topic_name']).to.equal(testConfig.topicName);
                   expect(tags['aws.lambda.sns.message_ids'].length).to.equal(1);
@@ -386,6 +392,9 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
+                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
+                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigateway.rest');
+
                   expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
                   expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.restApiId);
                   expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('test');
@@ -435,6 +444,9 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
+                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
+                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigatewayv2.http.v1');
+
                   expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
                   expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.apiId);
                   expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('$default');
@@ -480,6 +492,9 @@ describe('integration', function () {
               test: ({ invocationsData, testConfig }) => {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
+
+                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
+                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigatewayv2.http.v2');
 
                   expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
                   expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.apiId);

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -182,6 +182,9 @@ describe('internal-extension/index.test.js', () => {
       },
     });
 
+    expect(tags.get('aws.lambda.event_source')).to.equal('aws.apigateway');
+    expect(tags.get('aws.lambda.event_type')).to.equal('aws.apigateway.rest');
+
     expect(tags.get('aws.lambda.api_gateway.account_id')).to.equal('205994128558');
     expect(tags.get('aws.lambda.api_gateway.api_id')).to.equal('xxx');
     expect(tags.get('aws.lambda.api_gateway.api_stage')).to.equal('test');
@@ -278,6 +281,9 @@ describe('internal-extension/index.test.js', () => {
       },
     });
 
+    expect(tags.get('aws.lambda.event_source')).to.equal('aws.apigateway');
+    expect(tags.get('aws.lambda.event_type')).to.equal('aws.apigatewayv2.http.v1');
+
     expect(tags.get('aws.lambda.api_gateway.account_id')).to.equal('205994128558');
     expect(tags.get('aws.lambda.api_gateway.api_id')).to.equal('xxx');
     expect(tags.get('aws.lambda.api_gateway.api_stage')).to.equal('$default');
@@ -343,6 +349,9 @@ describe('internal-extension/index.test.js', () => {
         isBase64Encoded: true,
       },
     });
+
+    expect(tags.get('aws.lambda.event_source')).to.equal('aws.apigateway');
+    expect(tags.get('aws.lambda.event_type')).to.equal('aws.apigatewayv2.http.v2');
 
     expect(tags.get('aws.lambda.api_gateway.account_id')).to.equal('205994128558');
     expect(tags.get('aws.lambda.api_gateway.api_id')).to.equal('xxx');
@@ -417,6 +426,9 @@ describe('internal-extension/index.test.js', () => {
       },
     });
 
+    expect(tags.get('aws.lambda.event_source')).to.equal('aws.sqs');
+    expect(tags.get('aws.lambda.event_type')).to.equal('aws.sqs');
+
     expect(tags.get('aws.lambda.sqs.queue_name')).to.equal('test.fifo');
     expect(tags.get('aws.lambda.sqs.message_ids')).to.deep.equal([
       '6f606577-4d1f-455c-b504-807abed7ca02',
@@ -479,6 +491,9 @@ describe('internal-extension/index.test.js', () => {
         ],
       },
     });
+
+    expect(tags.get('aws.lambda.event_source')).to.equal('aws.sns');
+    expect(tags.get('aws.lambda.event_type')).to.equal('aws.sns');
 
     expect(tags.get('aws.lambda.sns.topic_name')).to.equal('test');
     expect(tags.get('aws.lambda.sns.message_ids')).to.deep.equal([

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -208,6 +208,8 @@ describe('internal-extension/index.test.js', () => {
       JSON.stringify({ param: 'some-param' })
     );
     expect(tags.get('aws.lambda.http.query')).to.equal('foo=bar&next=first&next=second');
+
+    expect(tags.get('aws.lambda.http.status_code')).to.equal(200);
   });
 
   it('should handle API Gateway v2 HTTP API, payload v1 event', async () => {
@@ -303,6 +305,8 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.get('aws.lambda.http.method')).to.equal('POST');
     expect(tags.get('aws.lambda.http.path')).to.equal('/v1');
     expect(tags.get('aws.lambda.http.query')).to.equal('lone=value&multi=one%2Cstillone&multi=two');
+
+    expect(tags.get('aws.lambda.http.status_code')).to.equal(200);
   });
 
   it('should handle API Gateway v2 HTTP API, payload v2 event', async () => {
@@ -372,6 +376,8 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.get('aws.lambda.http.method')).to.equal('POST');
     expect(tags.get('aws.lambda.http.path')).to.equal('/v2');
     expect(tags.get('aws.lambda.http.query')).to.equal('lone=value&multi=one%2Cstillone%2Ctwo');
+
+    expect(tags.get('aws.lambda.http.status_code')).to.equal(200);
   });
 
   it('should handle SQS event', async () => {

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -190,10 +190,8 @@ describe('internal-extension/index.test.js', () => {
       'da6c4e62-62c8-4693-8a4a-d6c4d943ddb4'
     );
     expect(tags.get('aws.lambda.api_gateway.request.time_epoch')).to.equal(1661872803090);
-    expect(tags.get('aws.lambda.api_gateway.request.protocol')).to.equal('HTTP/1.1');
-    expect(tags.get('aws.lambda.api_gateway.request.domain')).to.equal(
-      'xxx.execute-api.us-east-1.amazonaws.com'
-    );
+    expect(tags.get('aws.lambda.http.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('aws.lambda.http.host')).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
     expect(tags.get('aws.lambda.api_gateway.request.headers')).to.equal(
       JSON.stringify({
         'Accept': '*/*',
@@ -201,17 +199,12 @@ describe('internal-extension/index.test.js', () => {
         'Other': ['First', 'Second'],
       })
     );
-    expect(tags.get('aws.lambda.api_gateway.request.method')).to.equal('POST');
-    expect(tags.get('aws.lambda.api_gateway.request.path')).to.equal('/test/some-path/some-param');
+    expect(tags.get('aws.lambda.http.method')).to.equal('POST');
+    expect(tags.get('aws.lambda.http.path')).to.equal('/test/some-path/some-param');
     expect(tags.get('aws.lambda.api_gateway.request.path_parameters')).to.equal(
       JSON.stringify({ param: 'some-param' })
     );
-    expect(tags.get('aws.lambda.api_gateway.request.query_string_parameters')).to.equal(
-      JSON.stringify({
-        foo: 'bar',
-        next: ['first', 'second'],
-      })
-    );
+    expect(tags.get('aws.lambda.http.query')).to.equal('foo=bar&next=first&next=second');
   });
 
   it('should handle API Gateway v2 HTTP API, payload v1 event', async () => {
@@ -291,10 +284,8 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.get('aws.lambda.api_gateway.request.id')).to.equal('XyGqvi5mIAMEJtw=');
     expect(tags.get('aws.lambda.api_gateway.request.time_epoch')).to.equal(1662040030156);
-    expect(tags.get('aws.lambda.api_gateway.request.protocol')).to.equal('HTTP/1.1');
-    expect(tags.get('aws.lambda.api_gateway.request.domain')).to.equal(
-      'xxx.execute-api.us-east-1.amazonaws.com'
-    );
+    expect(tags.get('aws.lambda.http.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('aws.lambda.http.host')).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
     expect(tags.get('aws.lambda.api_gateway.request.headers')).to.equal(
       JSON.stringify({
         'Content-Length': '385',
@@ -303,14 +294,9 @@ describe('internal-extension/index.test.js', () => {
         'Multi': ['one,stillone', 'two'],
       })
     );
-    expect(tags.get('aws.lambda.api_gateway.request.method')).to.equal('POST');
-    expect(tags.get('aws.lambda.api_gateway.request.path')).to.equal('/v1');
-    expect(tags.get('aws.lambda.api_gateway.request.query_string_parameters')).to.equal(
-      JSON.stringify({
-        lone: 'value',
-        multi: ['one,stillone', 'two'],
-      })
-    );
+    expect(tags.get('aws.lambda.http.method')).to.equal('POST');
+    expect(tags.get('aws.lambda.http.path')).to.equal('/v1');
+    expect(tags.get('aws.lambda.http.query')).to.equal('lone=value&multi=one%2Cstillone&multi=two');
   });
 
   it('should handle API Gateway v2 HTTP API, payload v2 event', async () => {
@@ -364,10 +350,8 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.get('aws.lambda.api_gateway.request.id')).to.equal('XyGnwhe0oAMEJJw=');
     expect(tags.get('aws.lambda.api_gateway.request.time_epoch')).to.equal(1662040011065);
-    expect(tags.get('aws.lambda.api_gateway.request.protocol')).to.equal('HTTP/1.1');
-    expect(tags.get('aws.lambda.api_gateway.request.domain')).to.equal(
-      'xxx.execute-api.us-east-1.amazonaws.com'
-    );
+    expect(tags.get('aws.lambda.http.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('aws.lambda.http.host')).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
     expect(tags.get('aws.lambda.api_gateway.request.headers')).to.equal(
       JSON.stringify({
         'content-length': '385',
@@ -376,14 +360,9 @@ describe('internal-extension/index.test.js', () => {
         'multi': 'one,stillone,two',
       })
     );
-    expect(tags.get('aws.lambda.api_gateway.request.method')).to.equal('POST');
-    expect(tags.get('aws.lambda.api_gateway.request.path')).to.equal('/v2');
-    expect(tags.get('aws.lambda.api_gateway.request.query_string_parameters')).to.equal(
-      JSON.stringify({
-        lone: 'value',
-        multi: 'one,stillone,two',
-      })
-    );
+    expect(tags.get('aws.lambda.http.method')).to.equal('POST');
+    expect(tags.get('aws.lambda.http.path')).to.equal('/v2');
+    expect(tags.get('aws.lambda.http.query')).to.equal('lone=value&multi=one%2Cstillone%2Ctwo');
   });
 
   it('should handle SQS event', async () => {


### PR DESCRIPTION
_Depends on #180_

- Upgrade up to SDK Schema changes introduced with v0.5.0
- Configure `aws.lambda.event_source` and `aws.lambda.event_type` for all so far configured integrations
- Configure `aws.lambda.http.status_code` for API Gatway integrations