### PR TITLE
AWS Lambda SDK: Write request and response payloads

### DIFF
--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -3,6 +3,8 @@ import TraceSpan from './lib/trace-span';
 export interface SdkOptions {
   orgId?: string;
   disableHttpMonitoring?: boolean;
+  disableRequestMonitoring?: boolean;
+  disableResponseMonitoring?: boolean;
 }
 
 interface traceSpans {

--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -1,5 +1,9 @@
 import TraceSpan from './lib/trace-span';
 
+export interface SdkOptions {
+  orgId?: string;
+}
+
 interface traceSpans {
   awsLambda: TraceSpan;
   awsLambdaInitialization: TraceSpan;
@@ -8,6 +12,7 @@ interface traceSpans {
 interface Sdk {
   orgId: string;
   traceSpans: traceSpans;
+  initialize(options?: SdkOptions): Sdk;
 }
 
 export default Sdk;

--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -2,6 +2,7 @@ import TraceSpan from './lib/trace-span';
 
 export interface SdkOptions {
   orgId?: string;
+  disableHttpMonitoring?: boolean;
 }
 
 interface traceSpans {

--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -1,8 +1,13 @@
 import TraceSpan from './lib/trace-span';
 
-export const orgId: string;
-
-export interface traceSpans {
+interface traceSpans {
   awsLambda: TraceSpan;
   awsLambdaInitialization: TraceSpan;
 }
+
+interface Sdk {
+  orgId: string;
+  traceSpans: traceSpans;
+}
+
+export default Sdk;

--- a/node/packages/aws-lambda-sdk/.ts-types/instrument.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/instrument.d.ts
@@ -1,6 +1,4 @@
-interface Options {
-  orgId?: string;
-}
+import { SdkOptions } from './';
 
-declare function instrument(handler: Function, options?: Options): Function;
+declare function instrument(handler: Function, options?: SdkOptions): Function;
 export default instrument;

--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -34,11 +34,10 @@ _CJS:_
 const instrument = require('@serverless/aws-lambda-sdk/instrument');
 
 module.exports.handler = instrument(
-  (event, context, callback) => { /* Original handler logic */ },
-  // Optional
-  {
-    orgId: <orgId> // By default taken from SLS_ORG_ID env variable
-  }
+  (event, context, callback) => {
+    /* Original handler logic */
+  },
+  options // Optional, see documentation below
 );
 ```
 
@@ -48,13 +47,20 @@ _ESM:_
 import instrument from '@serverless/aws-lambda-sdk/instrument';
 
 export const handler = instrument(
-  (event, context, callback) => { /* Original handler logic  */ },
-  // Optional
-  {
-    orgId: <orgId> // By default taken from SLS_ORG_ID env variable
-  }
+  (event, context, callback) => {
+    /* Original handler logic  */
+  },
+  options // Optional, see documentation below
 );
 ```
+
+#### Configuration options.
+
+Extension can be configured either via environment variables, or in case of manual instrumentation by passing the options object to `instrument` function;
+
+If given setting is set via both environment variable and property in options object, the environment variable takes precedence.
+
+- `SLS_ORG_ID` (or `options.orgId`) - (required) id of your organization in Serverless Console.
 
 ### Outcome
 

--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -60,7 +60,13 @@ Extension can be configured either via environment variables, or in case of manu
 
 If given setting is set via both environment variable and property in options object, the environment variable takes precedence.
 
-- `SLS_ORG_ID` (or `options.orgId`) - (required) id of your organization in Serverless Console.
+##### `SLS_ORG_ID` (or `options.orgId`)
+
+Required setting. Id of your organization in Serverless Console.
+
+##### `SLS_DISABLE_HTTP_MONITORING` (or `options.disableHttpMonitoring`)
+
+Disable tracing of HTTP and HTTPS requests
 
 ### Outcome
 

--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -68,8 +68,16 @@ Required setting. Id of your organization in Serverless Console.
 
 Disable tracing of HTTP and HTTPS requests
 
+##### `SLS_DISABLE_REQUEST_MONITORING` (or `options.disableRequestMonitoring`)
+
+Disable lambda requests (events) monitoring
+
+##### `SLS_DISABLE_RESPONSE_MONITORING` (or `options.disableResponseMonitoring`)
+
+Disable lambda responses monitoring
+
 ### Outcome
 
-SDK automatically creates the trace that covers internal process of function invocation and initialization.
+SDK automatically creates the trace that covers internal process of function invocation and initialization. For all the details check [docs/sdk-trace.md](docs/sdk-trace.md)
 
-For all the details check [docs/sdk-trace.md](docs/sdk-trace.md)
+If not disabled request and response payloads are written to logs encoded with protobuf format

--- a/node/packages/aws-lambda-sdk/docs/sdk-trace.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk-trace.md
@@ -141,7 +141,9 @@ _None_
 
 ### `node.http.request` & `node.https.request`
 
-Covers HTTP and HTTPS request as made in context of function logic
+_If not disabled by [configuration settings](../README.md#configuration-options)_
+
+Covers HTTP and HTTPS requests as made in context of function logic
 
 #### Tags
 

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -6,7 +6,7 @@ serverlessSdk.traceSpans = {
   awsLambda: require('./trace-spans/aws-lambda'),
   awsLambdaInitialization: require('./trace-spans/aws-lambda-initialization'),
 };
-serverlessSdk._settings = {};
+const settings = (serverlessSdk._settings = {});
 
 const isObject = require('type/object/is');
 const ensureString = require('type/string/ensure');
@@ -16,6 +16,10 @@ const resolveSettings = (options = {}) => {
   serverlessSdk.orgId =
     process.env.SLS_ORG_ID ||
     ensureString(options.orgId, { isOptional: true, name: 'options.orgId' });
+
+  serverlessSdk._settings.disableHttpMonitoring = Boolean(
+    process.env.SLS_DISABLE_HTTP_MONITORING || options.disableHttpMonitoring
+  );
 };
 
 let isInitialized = false;
@@ -24,8 +28,10 @@ serverlessSdk.initialize = (options = {}) => {
   isInitialized = true;
   resolveSettings(options);
 
-  // Auto generate HTTP(S) request spans
-  require('./lib/instrument/http').install();
+  if (!settings.disableHttpMonitoring) {
+    // Auto generate HTTP(S) request spans
+    require('./lib/instrument/http').install();
+  }
 
   return serverlessSdk;
 };

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -20,6 +20,12 @@ const resolveSettings = (options = {}) => {
   serverlessSdk._settings.disableHttpMonitoring = Boolean(
     process.env.SLS_DISABLE_HTTP_MONITORING || options.disableHttpMonitoring
   );
+  serverlessSdk._settings.disableRequestMonitoring = Boolean(
+    process.env.SLS_DISABLE_REQUEST_MONITORING || options.disableRequestMonitoring
+  );
+  serverlessSdk._settings.disableResponseMonitoring = Boolean(
+    process.env.SLS_DISABLE_RESPONSE_MONITORING || options.disableResponseMonitoring
+  );
 };
 
 let isInitialized = false;

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -1,11 +1,31 @@
 'use strict';
 
-module.exports.orgId = process.env.SLS_ORG_ID;
+const serverlessSdk = module.exports;
 
-module.exports.traceSpans = {
+serverlessSdk.traceSpans = {
   awsLambda: require('./trace-spans/aws-lambda'),
   awsLambdaInitialization: require('./trace-spans/aws-lambda-initialization'),
 };
+serverlessSdk._settings = {};
 
-// Auto generate HTTP(S) request spans
-require('./lib/instrument/http').install();
+const isObject = require('type/object/is');
+const ensureString = require('type/string/ensure');
+
+const resolveSettings = (options = {}) => {
+  if (!isObject(options)) options = {};
+  serverlessSdk.orgId =
+    process.env.SLS_ORG_ID ||
+    ensureString(options.orgId, { isOptional: true, name: 'options.orgId' });
+};
+
+let isInitialized = false;
+serverlessSdk.initialize = (options = {}) => {
+  if (isInitialized) return module.exports;
+  isInitialized = true;
+  resolveSettings(options);
+
+  // Auto generate HTTP(S) request spans
+  require('./lib/instrument/http').install();
+
+  return serverlessSdk;
+};

--- a/node/packages/aws-lambda-sdk/instrument.js
+++ b/node/packages/aws-lambda-sdk/instrument.js
@@ -3,10 +3,8 @@
 'use strict';
 
 const ensurePlainFunction = require('type/plain-function/ensure');
-const isObject = require('type/object/is');
 const isError = require('type/error/is');
 const coerceToString = require('type/string/coerce');
-const ensureString = require('type/string/ensure');
 const traceProto = require('@serverless/sdk-schema/dist/trace');
 const resolveEventTags = require('./lib/resolve-event-tags');
 const resolveResponseTags = require('./lib/resolve-response-tags');
@@ -24,9 +22,7 @@ const debugLog = (...args) => {
 
 module.exports = (originalHandler, options = {}) => {
   ensurePlainFunction(originalHandler, { name: 'originalHandler' });
-  if (!isObject(options)) options = {};
-  const orgId = ensureString(options.orgId, { isOptional: true, name: 'options.orgId' });
-  if (orgId) serverlessSdk.orgId = orgId;
+  serverlessSdk.initialize(options);
   if (!serverlessSdk.orgId) {
     throw new Error(
       'Serverless SDK Error: Cannot instrument function: "orgId" not provided. ' +

--- a/node/packages/aws-lambda-sdk/instrument.js
+++ b/node/packages/aws-lambda-sdk/instrument.js
@@ -22,16 +22,6 @@ const debugLog = (...args) => {
 
 const writeTrace = () => {
   const payload = (serverlessSdk._lastTrace = {
-    id: awsLambdaSpan.traceId,
-    slsTags: {
-      'orgId': serverlessSdk.orgId,
-      'service': process.env.AWS_LAMBDA_FUNCTION_NAME,
-      'sdk.name': pkgJson.name,
-      'sdk.version': pkgJson.version,
-    },
-    spans: awsLambdaSpan.spans,
-  });
-  const protoPayload = (serverlessSdk._lastProtoTrace = {
     slsTags: {
       orgId: serverlessSdk.orgId,
       service: process.env.AWS_LAMBDA_FUNCTION_NAME,
@@ -39,11 +29,9 @@ const writeTrace = () => {
     },
     spans: Array.from(awsLambdaSpan.spans).map((span) => span.toProtobufObject()),
   });
-  const protoPayloadBuffer = (serverlessSdk._lastProtoTraceBuffer =
-    traceProto.TracePayload.encode(protoPayload).finish());
-  process._rawDebug(`SERVERLESS_TELEMETRY.T.${protoPayloadBuffer.toString('base64')}`);
-
-  debugLog('Trace:', JSON.stringify(payload));
+  const payloadBuffer = (serverlessSdk._lastTraceBuffer =
+    traceProto.TracePayload.encode(payload).finish());
+  process._rawDebug(`SERVERLESS_TELEMETRY.T.${payloadBuffer.toString('base64')}`);
 };
 
 module.exports = (originalHandler, options = {}) => {

--- a/node/packages/aws-lambda-sdk/internal-extension/index.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/index.js
@@ -69,7 +69,7 @@ const isEsmContext = (dirname) => {
 };
 
 EvalError.$serverlessAwsLambdaInitializationStartTime = processStartTime;
-global.serverlessSdk = require('../');
+global.serverlessSdk = require('../').initialize();
 
 let hasInitializationFailed = false;
 const startTime = process.hrtime.bigint();

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -220,6 +220,7 @@ describe('integration', function () {
             'sns',
             {
               isAsyncInvocation: true,
+              ignoreMultipleInvocations: true,
               hooks: {
                 afterCreate: async function self(testConfig) {
                   const topicName = (testConfig.topicName = testConfig.configuration.FunctionName);

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -207,11 +207,11 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
-                  expect(tags['aws.lambda.event_source']).to.equal('aws.sqs');
-                  expect(tags['aws.lambda.event_type']).to.equal('aws.sqs');
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.sqs');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.sqs');
 
-                  expect(tags['aws.lambda.sqs.queue_name']).to.equal(testConfig.queueName);
-                  expect(tags['aws.lambda.sqs.message_ids'].length).to.equal(1);
+                  expect(tags.aws.lambda.sqs.queueName).to.equal(testConfig.queueName);
+                  expect(tags.aws.lambda.sqs.messageIds.length).to.equal(1);
                 }
               },
             },
@@ -263,11 +263,11 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
-                  expect(tags['aws.lambda.event_source']).to.equal('aws.sns');
-                  expect(tags['aws.lambda.event_type']).to.equal('aws.sns');
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.sns');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.sns');
 
-                  expect(tags['aws.lambda.sns.topic_name']).to.equal(testConfig.topicName);
-                  expect(tags['aws.lambda.sns.message_ids'].length).to.equal(1);
+                  expect(tags.aws.lambda.sns.topicName).to.equal(testConfig.topicName);
+                  expect(tags.aws.lambda.sns.messageIds.length).to.equal(1);
                 }
               },
             },
@@ -404,23 +404,23 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
-                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
-                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigateway.rest');
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigateway.rest');
 
-                  expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
-                  expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.restApiId);
-                  expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('test');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.http.host');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.http.method']).to.equal('POST');
-                  expect(tags['aws.lambda.http.path']).to.equal('/test/some-path/some-param');
-                  expect(tags['aws.lambda.api_gateway.request.path_parameters']).to.equal(
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.restApiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('test');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test/some-path/some-param');
+                  expect(tags.aws.lambda.apiGateway.request.pathParameters).to.equal(
                     JSON.stringify({ param: 'some-param' })
                   );
 
-                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
                 }
               },
             },
@@ -458,20 +458,20 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
-                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
-                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigatewayv2.http.v1');
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigatewayv2.http.v1');
 
-                  expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
-                  expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.apiId);
-                  expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('$default');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.http.host');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.http.method']).to.equal('POST');
-                  expect(tags['aws.lambda.http.path']).to.equal('/test');
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.apiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('$default');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test');
 
-                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
                 }
               },
             },
@@ -509,20 +509,20 @@ describe('integration', function () {
                 for (const [, trace] of invocationsData.map((data) => data.trace).entries()) {
                   const { tags } = trace.spans[0];
 
-                  expect(tags['aws.lambda.event_source']).to.equal('aws.apigateway');
-                  expect(tags['aws.lambda.event_type']).to.equal('aws.apigatewayv2.http.v2');
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigatewayv2.http.v2');
 
-                  expect(tags).to.have.property('aws.lambda.api_gateway.account_id');
-                  expect(tags['aws.lambda.api_gateway.api_id']).to.equal(testConfig.apiId);
-                  expect(tags['aws.lambda.api_gateway.api_stage']).to.equal('$default');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.id');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.time_epoch');
-                  expect(tags).to.have.property('aws.lambda.http.host');
-                  expect(tags).to.have.property('aws.lambda.api_gateway.request.headers');
-                  expect(tags['aws.lambda.http.method']).to.equal('POST');
-                  expect(tags['aws.lambda.http.path']).to.equal('/test');
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.apiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('$default');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test');
 
-                  expect(tags['aws.lambda.http.status_code']).to.equal(200);
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
                 }
               },
             },
@@ -544,12 +544,12 @@ describe('integration', function () {
                   expect(httpRequestSpan.name).to.equal('node.http.request');
 
                   const { tags } = httpRequestSpan;
-                  expect(tags['http.method']).to.equal('GET');
-                  expect(tags['http.protocol']).to.equal('HTTP/1.1');
-                  expect(tags['http.host']).to.equal('localhost:3177');
-                  expect(tags['http.path']).to.equal('/');
-                  expect(tags['http.query']).to.equal('foo=bar');
-                  expect(tags['http.status_code']).to.equal(200);
+                  expect(tags.http.method).to.equal('GET');
+                  expect(tags.http.protocol).to.equal('HTTP/1.1');
+                  expect(tags.http.host).to.equal('localhost:3177');
+                  expect(tags.http.path).to.equal('/');
+                  expect(tags.http.query).to.equal('foo=bar');
+                  expect(tags.http.statusCode.toString()).to.equal('200');
                 }
               },
             },
@@ -670,12 +670,12 @@ describe('integration', function () {
                   expect(httpRequestSpan.name).to.equal('node.https.request');
 
                   const { tags } = httpRequestSpan;
-                  expect(tags['http.method']).to.equal('GET');
-                  expect(tags['http.protocol']).to.equal('HTTP/1.1');
-                  expect(tags['http.host']).to.equal(functionUrl.slice('https://'.length, -1));
-                  expect(tags['http.path']).to.equal('/');
-                  expect(tags['http.query']).to.equal('foo=bar');
-                  expect(tags['http.status_code']).to.equal(200);
+                  expect(tags.http.method).to.equal('GET');
+                  expect(tags.http.protocol).to.equal('HTTP/1.1');
+                  expect(tags.http.host).to.equal(functionUrl.slice('https://'.length, -1));
+                  expect(tags.http.path).to.equal('/');
+                  expect(tags.http.query).to.equal('foo=bar');
+                  expect(tags.http.statusCode.toString()).to.equal('200');
                 }
               },
             },
@@ -720,32 +720,31 @@ describe('integration', function () {
               'aws.lambda.initialization',
               'aws.lambda.invocation',
             ]);
-            expect(awsLambdaSpan.tags['aws.lambda.is_coldstart']).to.be.true;
+            expect(awsLambdaSpan.tags.aws.lambda.isColdstart).to.be.true;
           } else {
             expect(trace.spans.map(({ name }) => name).slice(0, 2)).to.deep.equal([
               'aws.lambda',
               'aws.lambda.invocation',
             ]);
-            expect(awsLambdaSpan.tags).to.not.have.property('aws.lambda.is_coldstart');
+            expect(awsLambdaSpan.tags.aws.lambda.isColdstart).to.be.false;
           }
           expect(trace.slsTags).to.deep.equal({
-            'orgId': process.env.SLS_ORG_ID,
-            'service': testConfig.configuration.FunctionName,
-            'sdk.name': pkgJson.name,
-            'sdk.version': pkgJson.version,
+            orgId: process.env.SLS_ORG_ID,
+            service: testConfig.configuration.FunctionName,
+            sdk: { name: pkgJson.name, version: pkgJson.version },
           });
-          expect(awsLambdaSpan.tags).to.have.property('aws.lambda.arch');
-          expect(awsLambdaSpan.tags['aws.lambda.name']).to.equal(
+          expect(awsLambdaSpan.tags.aws.lambda).to.have.property('arch');
+          expect(awsLambdaSpan.tags.aws.lambda.name).to.equal(
             testConfig.configuration.FunctionName
           );
-          expect(awsLambdaSpan.tags).to.have.property('aws.lambda.request_id');
-          expect(awsLambdaSpan.tags).to.have.property('aws.lambda.version');
+          expect(awsLambdaSpan.tags.aws.lambda).to.have.property('requestId');
+          expect(awsLambdaSpan.tags.aws.lambda).to.have.property('version');
           if (expectedOutcome === 'success') {
-            expect(awsLambdaSpan.tags['aws.lambda.outcome']).to.equal('success');
+            expect(awsLambdaSpan.tags.aws.lambda.outcome).to.equal(1);
           } else {
-            expect(awsLambdaSpan.tags['aws.lambda.outcome']).to.equal('error:handled');
-            expect(awsLambdaSpan.tags).to.have.property('aws.lambda.error_exception_message');
-            expect(awsLambdaSpan.tags).to.have.property('aws.lambda.error_exception_stacktrace');
+            expect(awsLambdaSpan.tags.aws.lambda.outcome).to.equal(5);
+            expect(awsLambdaSpan.tags.aws.lambda).to.have.property('errorExceptionMessage');
+            expect(awsLambdaSpan.tags.aws.lambda).to.have.property('errorExceptionStacktrace');
           }
         }
       }

--- a/node/packages/aws-lambda-sdk/test/lib/process-function.js
+++ b/node/packages/aws-lambda-sdk/test/lib/process-function.js
@@ -146,6 +146,15 @@ const retrieveReports = async (testConfig) => {
   let processesData;
   do {
     const events = await retrieveAllEvents();
+    const eventGroups = new Map();
+    for (const event of events) {
+      const { logStreamName } = event;
+      if (!eventGroups.has(logStreamName)) eventGroups.set(logStreamName, []);
+      eventGroups.get(logStreamName).push(event);
+    }
+    if (eventGroups.size > 1) {
+      throw new Error(`Unexpected count of lambda instances: ${Array.from(eventGroups.keys())}`);
+    }
 
     let startEventsCount = 0;
     let reportEventsCount = 0;

--- a/node/packages/aws-lambda-sdk/test/lib/process-function.js
+++ b/node/packages/aws-lambda-sdk/test/lib/process-function.js
@@ -147,7 +147,7 @@ const retrieveReports = async (testConfig) => {
   let invocationsData;
   let processesData;
   do {
-    const events = await retrieveAllEvents();
+    let events = await retrieveAllEvents();
     const eventGroups = new Map();
     for (const event of events) {
       const { logStreamName } = event;
@@ -155,7 +155,11 @@ const retrieveReports = async (testConfig) => {
       eventGroups.get(logStreamName).push(event);
     }
     if (eventGroups.size > 1) {
-      throw new Error(`Unexpected count of lambda instances: ${Array.from(eventGroups.keys())}`);
+      if (testConfig.ignoreMultipleInvocations) {
+        events = eventGroups.values()[Symbol.iterator]().next().value;
+      } else {
+        throw new Error(`Unexpected count of lambda instances: ${Array.from(eventGroups.keys())}`);
+      }
     }
 
     let startEventsCount = 0;

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -92,10 +92,9 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
     expect(tags.get('aws.lambda.outcome')).to.equal('success');
   }
 
-  const input = normalizeObject(outcome.trace.protoInput);
-  const output = normalizeObject(outcome.trace.protoOutput);
-
-  expect(output.spans[0]).to.deep.equal(input.spans[0]);
+  expect(normalizeObject(outcome.trace.protoOutput)).to.deep.equal(
+    normalizeObject(outcome.trace.protoInput)
+  );
 
   return outcome;
 };

--- a/node/packages/aws-lambda-sdk/test/utils/normalize-proto-object.js
+++ b/node/packages/aws-lambda-sdk/test/utils/normalize-proto-object.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (obj) => {
+  const entries = Array.isArray(obj) ? obj.entries() : Object.entries(obj);
+  for (const [key, value] of entries) {
+    if (value == null) delete obj[key];
+    else if (Array.isArray(value)) module.exports(value);
+    else if (typeof value === 'object') module.exports(value);
+  }
+  return obj;
+};


### PR DESCRIPTION
Additionally:
- Centralize handling of instrumentation configuration
-  Add option to disable HTTP instrumentation
- Improve tests to validate against written protobuf payloads only (and no longer write debug JSON payload)
- Prevent test failures if SNS notifications are doubled by AWS