### PR TITLE
SDK Schema: AWS SDK releated improvements

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -184,7 +184,7 @@ message AwsSdkDynamodbTags {
 message AwsSdkSqsTags {
   // The AWS SDK base tags that all instrumented AWS SDK calls have.
   AwsSdkBaseTags aws_sdk_tags = 1;
-  // The SQS queue URL.
+  // The SQS queue name
   optional string queue_name = 2;
   // The message IDs provided in the SDK operation response.
   repeated string message_ids = 3;
@@ -195,7 +195,7 @@ message AwsSdkSqsTags {
 message AwsSdkSnsTags {
   // The AWS SDK base tags that all instrumented AWS SDK calls have.
   AwsSdkBaseTags aws_sdk_tags = 1;
-  // The SNS Topic ARN, from the TopicArn request parameter.
+  // The SNS Topic name taken from the TopicArn request parameter.
   optional string topic_name = 2;
   // The SNS Operation that was performed.
   optional string operation = 3;

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -128,12 +128,6 @@ message AwsLambdaInvocationTags {
 }
 
 message AwsSdkTags {
-  optional AwsSdkDynamodbTags dynamodb = 100;
-  optional AwsSdkSqsTags sqs = 101;
-  optional AwsSdkSnsTags sns = 102;
-}
-
-message AwsSdkBaseTags {
   // The AWS Account Id this SDK call is being made against.
   string account_id = 1;
   // The AWS Region this SDK call is being made against.
@@ -148,11 +142,14 @@ message AwsSdkBaseTags {
   string request_id = 6;
   // An optional error returned from the AWS APIs.
   optional string error = 7;
+
+  optional AwsSdkDynamodbTags dynamodb = 100;
+  optional AwsSdkSqsTags sqs = 101;
+  optional AwsSdkSnsTags sns = 102;
+
 }
 
 message AwsSdkDynamodbTags {
-  // The AWS SDK base tags that all instrumented AWS SDK calls have.
-  AwsSdkBaseTags aws_sdk_tags = 1;
   // The Dynamodb operation that was performed. Ex. GetItem, PutItem, Query, etc.
   string operation = 2;
   // The DynamoDB table name or names that the operation was performed on.
@@ -182,8 +179,6 @@ message AwsSdkDynamodbTags {
 }
 
 message AwsSdkSqsTags {
-  // The AWS SDK base tags that all instrumented AWS SDK calls have.
-  AwsSdkBaseTags aws_sdk_tags = 1;
   // The SQS queue name
   optional string queue_name = 2;
   // The message IDs provided in the SDK operation response.
@@ -193,8 +188,6 @@ message AwsSdkSqsTags {
 }
 
 message AwsSdkSnsTags {
-  // The AWS SDK base tags that all instrumented AWS SDK calls have.
-  AwsSdkBaseTags aws_sdk_tags = 1;
   // The SNS Topic name taken from the TopicArn request parameter.
   optional string topic_name = 2;
   // The SNS Operation that was performed.

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -150,8 +150,6 @@ message AwsSdkTags {
 }
 
 message AwsSdkDynamodbTags {
-  // The Dynamodb operation that was performed. Ex. GetItem, PutItem, Query, etc.
-  string operation = 2;
   // The DynamoDB table name or names that the operation was performed on.
   repeated string table_names = 3;
   // The value of the ProjectionExpression request parameter.
@@ -183,15 +181,11 @@ message AwsSdkSqsTags {
   optional string queue_name = 2;
   // The message IDs provided in the SDK operation response.
   repeated string message_ids = 3;
-  // The SQS Operation that was performed.
-  optional string operation = 4;
 }
 
 message AwsSdkSnsTags {
   // The SNS Topic name taken from the TopicArn request parameter.
   optional string topic_name = 2;
-  // The SNS Operation that was performed.
-  optional string operation = 3;
   // The message IDs provided in the SDK operation response.
   repeated string message_ids = 4;
 }

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -170,6 +170,8 @@ message AwsSdkDynamodbTags {
   optional uint32 segment = 9;
   // The value of the TotalSegments request parameter.
   optional uint64 total_segments = 10;
+  // The value of the FilterExpression request parameter.
+  optional string filter_expression = 11;
 
   // The value of the Count response parameter.
   optional uint64 count = 100;

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -151,41 +151,43 @@ message AwsSdkTags {
 
 message AwsSdkDynamodbTags {
   // The DynamoDB table name or names that the operation was performed on.
-  repeated string table_names = 3;
+  repeated string table_names = 1;
   // The value of the ProjectionExpression request parameter.
-  optional string projection = 4;
+  optional string projection = 2;
   // The value of the ScanIndexForward request parameter.
-  optional bool scan_forward = 5;
+  optional bool scan_forward = 3;
   // The value of the AttributesToGet request parameter.
-  repeated string attributes_to_get = 6;
+  repeated string attributes_to_get = 4;
   // The value of the ConsistentRead request parameter.
-  optional bool consistent_read = 7;
+  optional bool consistent_read = 5;
   // The value of the IndexName request parameter.
-  optional string index_name = 8;
+  optional string index_name = 6;
   // The value of the Limit request parameter.
-  optional uint32 limit = 9;
+  optional uint32 limit = 7;
   // The value of the Select request parameter.
-  optional string select = 10;
+  optional string select = 8;
   // The value of the Segment request parameter.
-  optional uint32 segment = 11;
+  optional uint32 segment = 9;
   // The value of the TotalSegments request parameter.
-  optional uint64 total_segments = 12;
+  optional uint64 total_segments = 10;
+
   // The value of the Count response parameter.
-  optional uint64 count = 13;
+  optional uint64 count = 100;
   // The value of the ScannedCount response parameter.
-  optional uint64 scanned_count = 14;
+  optional uint64 scanned_count = 101;
+
 }
 
 message AwsSdkSqsTags {
   // The SQS queue name
-  optional string queue_name = 2;
+  optional string queue_name = 1;
   // The message IDs provided in the SDK operation response.
-  repeated string message_ids = 3;
+  repeated string message_ids = 2;
 }
 
 message AwsSdkSnsTags {
   // The SNS Topic name taken from the TopicArn request parameter.
-  optional string topic_name = 2;
+  optional string topic_name = 1;
   // The message IDs provided in the SDK operation response.
-  repeated string message_ids = 4;
+  repeated string message_ids = 2;
 }


### PR DESCRIPTION
- Move base AWS SDK tags into `aws.sdk` namespace
- Remove `aws.sdk.<service>.operation` tags, as we already have `aws.sdk.operation` tag
- Add `aws.sdk.dynamodb.filter_expression` tag to store Dynamodb query (as requested internally by @ac360 )
- Fix comments by some properties