### PR TITLE
SDK Schema: Cleanup base properties of AWS SDK spans

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -128,8 +128,10 @@ message AwsLambdaInvocationTags {
 }
 
 message AwsSdkTags {
-  // The AWS Account Id this SDK call is being made against.
-  string account_id = 1;
+  // Retrieving AWS Account id is not straightforward therefore we it's not pursued at this point
+  reserved 1;
+  reserved "account_id";
+
   // The AWS Region this SDK call is being made against.
   string region = 2;
   // AWS Authentication signature version of the request.

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -133,7 +133,7 @@ message AwsSdkTags {
   reserved "account_id";
 
   // The AWS Region this SDK call is being made against.
-  string region = 2;
+  optional string region = 2;
   // AWS Authentication signature version of the request.
   string signature_version = 3;
   // The name of the service to which a request is made.
@@ -141,7 +141,7 @@ message AwsSdkTags {
   // The name of the operation corresponding to the request.
   string operation = 5;
   // The unique ID of the request.
-  string request_id = 6;
+  optional string request_id = 6;
   // An optional error returned from the AWS APIs.
   optional string error = 7;
 


### PR DESCRIPTION
- Account id of authenticated account is not accessible directly, therefore we cannot set it on the span without added cost. In light of that `aws.sdk.account_id` tag is removed
- Make `aws.sdk.region` optional, as request can be initialized without a region setting.
- Make `aws.sdk.request_id` optional, as request may fail without issuing a valid request internally (e.g. due to invalid credentials error)