### PR TITLE
SDK Schema: Improve Dynamodb schema

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -174,7 +174,8 @@ message AwsSdkDynamodbTags {
   optional uint64 total_segments = 10;
   // The value of the FilterExpression request parameter.
   optional string filter = 11;
-
+  // The value of the KeyExpression request parameter.
+  optional string key = 12;
 
   // The value of the Count response parameter.
   optional uint64 count = 100;

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -173,7 +173,8 @@ message AwsSdkDynamodbTags {
   // The value of the TotalSegments request parameter.
   optional uint64 total_segments = 10;
   // The value of the FilterExpression request parameter.
-  optional string filter_expression = 11;
+  optional string filter = 11;
+
 
   // The value of the Count response parameter.
   optional uint64 count = 100;


### PR DESCRIPTION
- Remove `_expression` prefix as we do not use it in other keys
- Add `aws.sdk.dynamodb.key` tag, to store eventual `KeyExpression` which can dictate the query