### PR TITLE
SDK Schema: Dynamodb schema improvement

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -152,8 +152,8 @@ message AwsSdkTags {
 }
 
 message AwsSdkDynamodbTags {
-  // The DynamoDB table name or names that the operation was performed on.
-  repeated string table_names = 1;
+  // The DynamoDB table name
+  optional string table_name = 1;
   // The value of the ProjectionExpression request parameter.
   optional string projection = 2;
   // The value of the ScanIndexForward request parameter.

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -174,8 +174,8 @@ message AwsSdkDynamodbTags {
   optional uint64 total_segments = 10;
   // The value of the FilterExpression request parameter.
   optional string filter = 11;
-  // The value of the KeyExpression request parameter.
-  optional string key = 12;
+  // The value of the KeyConditionExpression request parameter.
+  optional string key_condition = 12;
 
   // The value of the Count response parameter.
   optional uint64 count = 100;


### PR DESCRIPTION
I didn't find a use to attribute a multiple table names with single AWS dynamodb request, therefore I renamed field `table_names` to singular `table_name` (it'll also follow how we store SQS queue name or SNS topic name)