### PR TITLE
SDK Schema: Improve types of numeric properties

### DIFF
--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -42,7 +42,7 @@ const testTracePayload = {
             eventSource: 'aws.apigatewayv2',
             logGroup: 'abc12',
             logStreamName: 'abc123',
-            maxMemory: longValue,
+            maxMemory: 1024,
             name: 'my-test-function',
             requestId: 'bdb40738-ff36-48c0-9842-9befd0141cd6',
             version: '$LATEST',

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -26,7 +26,7 @@ message AwsApiGatewayTags {
     // The unique API GW Request ID.
     string id = 1;
     // The request time in milliseconds from epoch.
-    fixed64 time_epoch = 2;
+    uint64 time_epoch = 2;
     // JSON string containing Request Headers
     string headers = 3;
 
@@ -52,7 +52,7 @@ message AwsLambdaTags {
   // The Log Stream for the invocation.
   optional string log_stream_name = 6;
   // The Max Memory that is configured for the Lambda Function.
-  optional fixed64 max_memory = 7;
+  optional uint32 max_memory = 7;
   // The Lambda Function name.
   string name = 8;
   // The Request ID for the invocation.
@@ -83,7 +83,7 @@ message AwsLambdaTags {
 
   // The billed duration of the invocation in milliseconds. This will not be available
   // when instrumented, this will be upserted into this tag set after the report log from Cloudwatch is available.
-  optional fixed64 duration = 17;
+  optional uint32 duration = 17;
   // Optional Event Tags are from 100 on
 
   // Will be set if the function is handling a SQS event
@@ -118,13 +118,13 @@ message AwsSnsEventTags {
 message AwsLambdaInitializationTags {
   // The Initialization Duration of the Lambda Function. This is one part of the billed duration.
   // Maps to the Cloudwatch Logs Report "Init Duration"
-  fixed64 initialization_duration = 1;
+  uint32 initialization_duration = 1;
 }
 
 message AwsLambdaInvocationTags {
   // The Invocation Duration of the Lambda Function. This is one part of the billed duration.
   // Maps to the Cloudwatch Logs Report "Duration"
-  fixed64 invocation_duration = 1;
+  uint32 invocation_duration = 1;
 }
 
 message AwsSdkTags {

--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -17,7 +17,7 @@ message HttpTags {
   optional string query = 5;
 
   // The Response Status Code.
-  optional fixed64 status_code = 6;
+  optional uint32 status_code = 6;
   // Eventual request error code
   optional string error_code = 7;
 }


### PR DESCRIPTION
`fixed64` feels as overkill for storing status code, also different type was used to store status code at `http.status_code` and `express.status_code`.

Additionally revisited other numeric fields and improved their types when it was applicable