### PR TITLE
AWS Lambda SDK: Instrument express apps

### DIFF
--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -2,20 +2,20 @@ import TraceSpan from './lib/trace-span';
 import AwsSdkV2Instrument from './instrument/aws-sdk-v2';
 import AwsSdkV3ClientInstrument from './instrument/aws-sdk-v3-client';
 
-interface traceSpans {
+interface TraceSpans {
   awsLambda: TraceSpan;
   awsLambdaInitialization: TraceSpan;
 }
 
-interface instrument {
+interface Instrument {
   awsSdkV2: AwsSdkV2Instrument;
   awsSdkV3Client: AwsSdkV3ClientInstrument;
 }
 
 interface Sdk {
   orgId: string;
-  traceSpans: traceSpans;
-  instrument: instrument;
+  traceSpans: TraceSpans;
+  instrument: Instrument;
 }
 
 export default Sdk;

--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -1,6 +1,7 @@
 import TraceSpan from './lib/trace-span';
 import AwsSdkV2Instrument from './instrument/aws-sdk-v2';
 import AwsSdkV3ClientInstrument from './instrument/aws-sdk-v3-client';
+import ExpressAppInstrument from './instrument/express-app';
 
 interface TraceSpans {
   awsLambda: TraceSpan;
@@ -10,6 +11,7 @@ interface TraceSpans {
 interface Instrument {
   awsSdkV2: AwsSdkV2Instrument;
   awsSdkV3Client: AwsSdkV3ClientInstrument;
+  expressApp: ExpressAppInstrument;
 }
 
 interface Sdk {

--- a/node/packages/aws-lambda-sdk/.ts-types/instrument/aws-sdk-v2.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/instrument/aws-sdk-v2.d.ts
@@ -1,6 +1,6 @@
-interface awsSdkV2Instrument {
+interface AwsSdkV2Instrument {
   install(AWS: Object): Function;
   uninstall(AWS: Object): undefined;
 }
 
-export default awsSdkV2Instrument;
+export default AwsSdkV2Instrument;

--- a/node/packages/aws-lambda-sdk/.ts-types/instrument/aws-sdk-v3-client.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/instrument/aws-sdk-v3-client.d.ts
@@ -1,6 +1,6 @@
-interface awsSdkV3ClientInstrument {
+interface AwsSdkV3ClientInstrument {
   install(Client: Object): Function;
   uninstall(Client: Object): undefined;
 }
 
-export default awsSdkV3ClientInstrument;
+export default AwsSdkV3ClientInstrument;

--- a/node/packages/aws-lambda-sdk/.ts-types/instrument/express-app.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/instrument/express-app.d.ts
@@ -1,0 +1,6 @@
+interface expressAppInstrument {
+  install(expressApp: Object): Function;
+  uninstall(expressApp: Object): undefined;
+}
+
+export default expressAppInstrument;

--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -83,6 +83,10 @@ Disable lambda responses monitoring
 
 Disable automated AWS SDK monitoring
 
+##### `SLS_DISABLE_EXPRESS_MONITORING` (or `options.disableExpressMonitoring`)
+
+Disable automated express monitoring
+
 ### Outcome
 
 SDK automatically creates the trace that covers internal process of function invocation and initialization.

--- a/node/packages/aws-lambda-sdk/docs/monitoring.md
+++ b/node/packages/aws-lambda-sdk/docs/monitoring.md
@@ -98,3 +98,34 @@ Tags that apply to all AWS SDK requests:
 | `aws.sdk.dynamodb.total_segments`    | The value of the `TotalSegments` request parameter          |
 | `aws.sdk.dynamodb.count`             | The value of the `Count` response parameter                 |
 | `aws.sdk.dynamodb.scanned_count`     | The value of the `ScannedCount` response parameter          |
+
+## express middlewares
+
+_Disable with `SLS_DISABLE_EXPRESS_MONITORING` environment variable_
+
+If [`express`](https://expressjs.com/) framework (together with tools like [`serverless-http`](https://github.com/dougmoscrop/serverless-http)) is used to route incoming requests. Trace sans for it's middlewares are created
+
+Tracing is turned on automatically, assuming that `express` is loaded normally via Node.js `require`.
+If it comes bundled or imported via ESM import, then instrumentation needs to be turned on manually with following steps:
+
+```javascript
+import express from 'express';
+
+const app = express();
+
+serverlessSdk.instrument.expressApp(express);
+```
+
+Handling of express route is covered in context of main `express` span. Additionally middleware jobs are recorded as following spans:
+
+- `express.middleware.<name>`, generic middleware (setup via `app.use`)
+- `express.middlewa.route.<method>.<name>` - route specific middleware (setup via `app.get`, `app.post` etc.)
+- `express.middleware.error.<name>` - error handling middleware
+
+#### `express` trace span tags:
+
+| Name                  | Value                                                  |
+| --------------------- | ------------------------------------------------------ |
+| `express.method`      | The HTTP method defined by the Express Route Handler.  |
+| `express.path`        | The HTTP Path defined by the Express Route Handler.    |
+| `express.status_code` | The status code returned by the Express Route Handler. |

--- a/node/packages/aws-lambda-sdk/docs/monitoring.md
+++ b/node/packages/aws-lambda-sdk/docs/monitoring.md
@@ -34,7 +34,7 @@ _Disable with `SLS_DISABLE_AWS_SDK_MONITORING` environment variable_
 
 AWS SDK requests that go to SNS, SQS and DynamoDb services are traced.
 
-Tracing is turned on automatically for AWS SDK clients that are normally loaded via CJS require.
+Tracing is turned on automatically for AWS SDK clients that are normally loaded via Node.js `require`.
 
 However if AWS SDK is bundled or imported via ESM import, then instrumentation needs to be turned on manually with following steps:
 

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -29,6 +29,9 @@ const resolveSettings = (options = {}) => {
   serverlessSdk._settings.disableAwsSdkMonitoring = Boolean(
     process.env.SLS_DISABLE_AWS_SDK_MONITORING || options.disableAwsSdkMonitoring
   );
+  serverlessSdk._settings.disableExpressMonitoring = Boolean(
+    process.env.SLS_DISABLE_EXPRESS_MONITORING || options.disableExpressMonitoring
+  );
 };
 
 let isInitialized = false;
@@ -47,10 +50,16 @@ serverlessSdk._initialize = (options = {}) => {
     require('./lib/instrument/aws-sdk').install();
   }
 
+  if (!settings.disableExpressMonitoring) {
+    // Auto generate AWS SDK request spans
+    require('./lib/instrument/express').install();
+  }
+
   return serverlessSdk;
 };
 
 serverlessSdk.instrument = {
   awsSdkV2: require('./instrument/aws-sdk-v2'),
   awsSdkV3Client: require('./instrument/aws-sdk-v3-client'),
+  expressApp: require('./instrument/express-app'),
 };

--- a/node/packages/aws-lambda-sdk/instrument/express-app.js
+++ b/node/packages/aws-lambda-sdk/instrument/express-app.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const ensureObject = require('type/object/ensure');
+const ensurePlainFunction = require('type/plain-function/ensure');
+const instrumentLayerPrototype = require('../lib/instrument/express/instrument-layer-prototype');
+
+const instrumentedApps = new WeakMap();
+
+module.exports.install = (app) => {
+  if (instrumentedApps.has(app)) return instrumentedApps.get(app);
+  ensureObject(app, { errorMessage: '%v is not an instance of express app' });
+  ensurePlainFunction(app.lazyrouter, {
+    errorMessage: 'Passed argument is not an instance of express app',
+  });
+  app.lazyrouter();
+  const uninstall = instrumentLayerPrototype(Object.getPrototypeOf(app._router.stack[0]));
+  instrumentedApps.set(app, uninstall);
+  return uninstall;
+};
+
+module.exports.uninstall = (app) => {
+  const uninstall = instrumentedApps.get(app);
+  if (uninstall) uninstall();
+};

--- a/node/packages/aws-lambda-sdk/lib/instrument/express/index.js
+++ b/node/packages/aws-lambda-sdk/lib/instrument/express/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const cjsHook = require('../utils/cjs-hook');
+const instrumentLayerPrototype = require('./instrument-layer-prototype');
+
+module.exports.install = () =>
+  cjsHook.register('/express/lib/router/layer.js', ({ prototype }) =>
+    instrumentLayerPrototype.install(prototype)
+  );
+
+module.exports.uninstall = () => cjsHook.unregister('/express/lib/router/layer.js');

--- a/node/packages/aws-lambda-sdk/lib/instrument/express/instrument-layer-prototype.js
+++ b/node/packages/aws-lambda-sdk/lib/instrument/express/instrument-layer-prototype.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const instrumentedLayers = new WeakMap();
+
+const expressSpansMap = new WeakMap();
+
+const invalidNameCharsPatern = /[^0-9a-zA-Z]/g;
+const digitStartRe = /^\d+/;
+
+const generateMiddlewareName = (name) =>
+  name.replace(invalidNameCharsPatern, '').replace(digitStartRe, '').toLowerCase();
+
+module.exports.install = (layerPrototype) => {
+  if (instrumentedLayers.has(layerPrototype)) return instrumentedLayers.get(layerPrototype);
+  const originalHandleRequest = layerPrototype.handle_request;
+  const originalHandleError = layerPrototype.handle_error;
+
+  layerPrototype.handle_request = function handle(req, res, next) {
+    if (!expressSpansMap.has(req)) {
+      const expressSpan = (
+        traceSpans.awsLambdaInvocation || traceSpans.awsLambdaInitialization
+      ).createSubSpan('express', {
+        onCloseByParent: () => {
+          process.stderr.write(
+            "Serverless SDK Warning: Express route handling didn't end before end of " +
+              'lambda invocation (or initialization)\n'
+          );
+        },
+      });
+      const expressRouteData = { expressSpan };
+      expressSpansMap.set(req, expressRouteData);
+      res.on('finish', () => {
+        expressSpan.tags.setMany(
+          {
+            status_code: res.statusCode,
+            method: expressRouteData.method?.toUpperCase(),
+            path: expressRouteData.route?.path,
+          },
+          { prefix: 'express' }
+        );
+        if (!expressSpan.endTime) expressSpan.close();
+      });
+    }
+    const expressRouteData = expressSpansMap.get(req);
+    const { expressSpan, routeSpan } = expressRouteData;
+    const middlewareSpan = (() => {
+      if (routeSpan) {
+        return routeSpan.createSubSpan(
+          `express.middleware.route.${[
+            generateMiddlewareName(this.method),
+            generateMiddlewareName(this.name) || 'unknown',
+          ]
+            .filter(Boolean)
+            .join('.')}`
+        );
+      }
+      return expressSpan.createSubSpan(
+        `express.middleware.${generateMiddlewareName(this.name) || 'unknown'}`
+      );
+    })();
+    if (this.path && (!expressRouteData.path || expressRouteData.path.length < this.path.length)) {
+      expressRouteData.path = this.path;
+    }
+    if (this.method) expressRouteData.method = this.method;
+    if (!routeSpan && this.name === 'bound dispatch') {
+      middlewareSpan.name = 'express.middleware.router';
+      expressRouteData.routeSpan = middlewareSpan;
+      expressRouteData.route = this.route;
+    }
+    return originalHandleRequest.call(this, req, res, (...args) => {
+      if (!middlewareSpan.endTime) {
+        middlewareSpan.close();
+        if (this.name === 'bound dispatch') delete expressRouteData.routeSpan;
+      }
+      return next(...args);
+    });
+  };
+  // eslint-disable-next-line camelcase
+  layerPrototype.handle_error = function handle_error(error, req, res, next) {
+    const { expressSpan, routeSpan } = expressSpansMap.get(req);
+    const middlewareSpan = (routeSpan || expressSpan).createSubSpan(
+      `express.middleware.error.${generateMiddlewareName(this.name) || 'unknown'}`
+    );
+    return originalHandleError.call(this, error, req, res, (...args) => {
+      if (!middlewareSpan.endTime) middlewareSpan.close();
+      return next(...args);
+    });
+  };
+
+  const uninstall = () => {
+    if (!instrumentedLayers.has(layerPrototype)) return;
+    layerPrototype.handle_request = originalHandleRequest;
+    layerPrototype.handle_error = originalHandleError;
+    instrumentedLayers.delete(layerPrototype);
+  };
+  instrumentedLayers.set(layerPrototype, uninstall);
+  return uninstall;
+};
+
+module.exports.uninstall = (layerPrototype) => {
+  if (!instrumentedLayers.has(layerPrototype)) return;
+  instrumentedLayers.get(layerPrototype)();
+};
+
+const { traceSpans } = require('../../../');

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.4.0",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.7.0",
+    "@serverless/sdk-schema": "^0.8.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.0",

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/express.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/express.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const serverless = require('serverless-http');
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('"root"');
+});
+
+app.get('/foo', (req, res) => {
+  res.send('"ok"');
+});
+
+app.post('/test', (req, res) => {
+  res.send('"ok"');
+});
+
+app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+module.exports.handler = serverless(app);

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -3,6 +3,8 @@
     "@aws-sdk/client-dynamodb": "^3.172.0",
     "@aws-sdk/client-sns": "^3.171.0",
     "@aws-sdk/client-sqs": "^3.171.0",
+    "express": "^4.18.1",
+    "serverless-http": "^3.0.2",
     "timers-ext": "^0.1.7"
   }
 }

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -44,6 +44,7 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
       error = invocationError;
     }
     require('../../../lib/instrument/http').uninstall();
+    require('../../../lib/instrument/aws-sdk').uninstall();
     const serverlessSdk = require('../../../');
     const { TracePayload } = require('@serverless/sdk-schema/dist/trace');
     const { RequestResponse } = require('@serverless/sdk-schema/dist/request_response');

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -17,6 +17,7 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
   process.env.AWS_LAMBDA_FUNCTION_NAME = functionName;
 
   const payload = options.payload || { test: true };
+  const stringifiedPayload = JSON.stringify(payload);
   const outcome = await requireUncached(async () => {
     await require('../../../internal-extension');
     const handlerModule = await require('../../../internal-extension/wrapper');
@@ -101,7 +102,7 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
   expect(normalizeObject(outcome.request.output)).to.deep.equal(
     normalizeObject(outcome.request.input)
   );
-  expect(outcome.request.input.data.requestData).to.deep.equal(JSON.stringify(payload));
+  expect(outcome.request.input.data.requestData).to.deep.equal(stringifiedPayload);
 
   if (outcome.response.input) {
     expect(normalizeObject(outcome.response.output)).to.deep.equal(

--- a/node/packages/aws-lambda-sdk/test/utils/normalize-proto-object.js
+++ b/node/packages/aws-lambda-sdk/test/utils/normalize-proto-object.js
@@ -1,11 +1,19 @@
 'use strict';
 
+const { isLong } = require('long');
+
 module.exports = (obj) => {
   const entries = Array.isArray(obj) ? obj.entries() : Object.entries(obj);
   for (const [key, value] of entries) {
-    if (value == null) delete obj[key];
-    else if (Array.isArray(value)) module.exports(value);
-    else if (typeof value === 'object') module.exports(value);
+    if (value == null) {
+      delete obj[key];
+    } else if (Array.isArray(value)) {
+      module.exports(value);
+    } else if (isLong(value)) {
+      obj[key] = Number(String(value));
+    } else if (typeof value === 'object') {
+      module.exports(value);
+    }
   }
   return obj;
 };


### PR DESCRIPTION
_Depends on https://github.com/serverless/console/pull/203_

Additionally:
- Fix naming in TS typings
- Ensure to clear all instrumentation in unit tests
- Ensure request data confirmation in unit tests is not affected by side effects for lambda logic updating the event objects
- Improve tests, so they work well will all proto numeric types (needed after https://github.com/serverless/console/pull/203)