### PR TITLE
SDK Schema: Define `exclusive_start_key` and `attribute_values` DynamoDB tags

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -176,6 +176,10 @@ message AwsSdkDynamodbTags {
   optional string filter = 11;
   // The value of the KeyConditionExpression request parameter.
   optional string key_condition = 12;
+  // JSON string of the ExclusiveStartKey request parameter.
+  optional string exclusive_start_key = 13;
+  // JSON string of the ExpressionAttributeValues request parameter.
+  optional string attribute_values = 14;
 
   // The value of the Count response parameter.
   optional uint64 count = 100;


### PR DESCRIPTION
Requested internally