### PR TITLE
SDK Schema: Introduce query, header and path param name collection tags

### DIFF
--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -53,7 +53,6 @@ const testTracePayload = {
               apiStage: 'dev',
               request: {
                 id: '2e4d98fe-1603-477f-b976-1013e84ea4a6',
-                headers: '',
                 timeEpoch: longValue,
               },
             },
@@ -63,6 +62,7 @@ const testTracePayload = {
               method: 'GET',
               path: '/test',
               queryParameterNames: [],
+              requestHeaderNames: [],
             },
           },
         },

--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -54,6 +54,7 @@ const testTracePayload = {
               request: {
                 id: '2e4d98fe-1603-477f-b976-1013e84ea4a6',
                 timeEpoch: longValue,
+                pathParameterNames: [],
               },
             },
             http: {

--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -62,6 +62,7 @@ const testTracePayload = {
               host: 'abc.example.com',
               method: 'GET',
               path: '/test',
+              queryParameterNames: [],
             },
           },
         },

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -23,13 +23,14 @@ message AwsApiGatewayTags {
   string api_stage = 3;
 
   message AwsApiGatewayRequestTags {
+    reserved 3;
+    reserved "path_parameters";
     // The unique API GW Request ID.
     string id = 1;
     // The request time in milliseconds from epoch.
     uint64 time_epoch = 2;
-
     // JSON string containing Request Path Parameters
-    optional string path_parameters = 10;
+    repeated string path_parameter_names = 4;
   }
 
   AwsApiGatewayRequestTags request = 15;

--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -27,8 +27,6 @@ message AwsApiGatewayTags {
     string id = 1;
     // The request time in milliseconds from epoch.
     uint64 time_epoch = 2;
-    // JSON string containing Request Headers
-    string headers = 3;
 
     // JSON string containing Request Path Parameters
     optional string path_parameters = 10;

--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -5,8 +5,8 @@ package serverless.instrumentation.tags.v1;
 option go_package = ".;protoc";
 
 message HttpTags {
-  reserved 5, 10, 11;
-  reserved "query", "response_headers", "response_header_names";
+  reserved 5, 7, 10, 11;
+  reserved "query", "request_headers", "response_headers", "response_header_names";
 
   // The method of the HTTP Request
   string method = 1;
@@ -18,6 +18,8 @@ message HttpTags {
   string path = 4;
   // Names of the query parameters
   repeated string query_parameter_names = 6;
+  // Request header names
+  repeated string request_header_names = 8;
 
   // The Response Status Code.
   optional uint32 status_code = 9;

--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -5,8 +5,8 @@ package serverless.instrumentation.tags.v1;
 option go_package = ".;protoc";
 
 message HttpTags {
-  reserved 5;
-  reserved "query";
+  reserved 5, 10, 11;
+  reserved "query", "response_headers", "response_header_names";
 
   // The method of the HTTP Request
   string method = 1;

--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -5,6 +5,9 @@ package serverless.instrumentation.tags.v1;
 option go_package = ".;protoc";
 
 message HttpTags {
+  reserved 5;
+  reserved "query";
+
   // The method of the HTTP Request
   string method = 1;
   // The protocol of the HTTP Request
@@ -13,12 +16,12 @@ message HttpTags {
   string host = 3;
   // The path of the HTTP Request
   string path = 4;
-  // The query string of the HTTP Request
-  optional string query = 5;
+  // Names of the query parameters
+  repeated string query_parameter_names = 6;
 
   // The Response Status Code.
-  optional uint32 status_code = 6;
+  optional uint32 status_code = 9;
   // Eventual request error code
-  optional string error_code = 7;
+  optional string error_code = 12;
 }
 


### PR DESCRIPTION
Per internal agreement, we do not want to by default collect sensitive data, so instead of e.g. full headers, we're going to collect just header names. This PR introduces schemas for `*_names` tags, and improve surrounding schema shape