### PR TITLE
AWS Lambda SDK: Upgrade HTTP related tags to contain only param names information

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/instrument/http.js
+++ b/node/packages/aws-lambda-sdk/lib/instrument/http.js
@@ -89,7 +89,7 @@ const install = (protocol, httpModule) => {
           ? options.hostname + (options.port ? `:${options.port}` : '')
           : options.host || 'localhost',
         'http.path': options.pathname || '/',
-        'http.request_header_names': [],
+        'http.request_header_names': Object.keys(options.headers || {}),
         'http.query_parameter_names': resolveQueryParamNamesFromSearchString(options.search),
       },
       onCloseByRoot: () => {

--- a/node/packages/aws-lambda-sdk/lib/instrument/http.js
+++ b/node/packages/aws-lambda-sdk/lib/instrument/http.js
@@ -24,6 +24,14 @@ const resolveMethod = (options) => {
   return null;
 };
 
+const resolveQueryParamNamesFromSearchString = (searchString) => {
+  const result = [];
+  if (searchString) {
+    for (const [paramName] of new URLSearchParams(searchString)) result.push(paramName);
+  }
+  return result;
+};
+
 const install = (protocol, httpModule) => {
   const originalRequest = httpModule.request;
   const originalGet = httpModule.get;
@@ -81,7 +89,8 @@ const install = (protocol, httpModule) => {
           ? options.hostname + (options.port ? `:${options.port}` : '')
           : options.host || 'localhost',
         'http.path': options.pathname || '/',
-        'http.query': options.search ? options.search.slice(1) : null,
+        'http.request_header_names': [],
+        'http.query_parameter_names': resolveQueryParamNamesFromSearchString(options.search),
       },
       onCloseByRoot: () => {
         if (responseReadableState?.flowing === false) {

--- a/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
+++ b/node/packages/aws-lambda-sdk/lib/resolve-event-tags.js
@@ -16,28 +16,6 @@ const doesObjectMatchMap = (object, map) =>
     return objHasOwnProperty.call(object, key);
   });
 
-const resolveParametersJson = (multiValueParameters) => {
-  if (!multiValueParameters) return null;
-  const result = {};
-  for (const [name, values] of Object.entries(multiValueParameters)) {
-    result[name] = values.length > 1 ? values : values[0];
-  }
-  return JSON.stringify(result);
-};
-
-const resolveQueryString = (queryParameters) => {
-  if (!queryParameters) return null;
-  const params = new URLSearchParams();
-  for (const [name, values] of Object.entries(queryParameters)) {
-    if (!Array.isArray(values)) {
-      params.append(name, values);
-      continue;
-    }
-    for (const value of values) params.append(name, value);
-  }
-  return params.toString();
-};
-
 const apiGatewayEventMap = [
   'resource',
   'path',
@@ -198,8 +176,7 @@ module.exports = (event) => {
       {
         id: requestContext.requestId,
         time_epoch: requestContext.requestTimeEpoch,
-        headers: resolveParametersJson(event.multiValueHeaders) || '{}',
-        path_parameters: event.pathParameters ? JSON.stringify(event.pathParameters) : null,
+        path_parameter_names: Object.keys(event.pathParameters || {}),
       },
       { prefix: 'aws.lambda.api_gateway.request' }
     );
@@ -209,7 +186,8 @@ module.exports = (event) => {
         protocol: requestContext.protocol,
         host: requestContext.domainName,
         path: requestContext.path,
-        query: resolveQueryString(event.multiValueQueryStringParameters),
+        query_parameter_names: Object.keys(event.queryStringParameters || {}),
+        request_header_names: Object.keys(event.headers || {}),
       },
       { prefix: 'aws.lambda.http' }
     );
@@ -234,8 +212,7 @@ module.exports = (event) => {
       {
         id: requestContext.requestId,
         time_epoch: requestContext.timeEpoch,
-        headers: JSON.stringify(event.headers || {}),
-        path_parameters: event.pathParameters ? JSON.stringify(event.pathParameters) : null,
+        path_parameter_names: Object.keys(event.pathParameters || {}),
       },
       { prefix: 'aws.lambda.api_gateway.request' }
     );
@@ -245,7 +222,8 @@ module.exports = (event) => {
         protocol: requestContext.http.protocol,
         host: requestContext.domainName,
         path: requestContext.http.path,
-        query: resolveQueryString(event.queryStringParameters),
+        query_parameter_names: Object.keys(event.queryStringParameters || {}),
+        request_header_names: Object.keys(event.headers || {}),
       },
       { prefix: 'aws.lambda.http' }
     );

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.0",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.8.0",
+    "@serverless/sdk-schema": "^0.9.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.0",

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/http-requester.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/http-requester.js
@@ -24,7 +24,7 @@ module.exports.handler = (event, context, callback) => {
     url = `http://localhost:${TEST_SERVER_PORT}/?foo=bar`;
   }
   const request = url.startsWith('https') ? https.request : http.request;
-  request(url, (response) => {
+  request(url, { headers: { someHeader: 'bar' } }, (response) => {
     let body = '';
     response.on('data', (data) => {
       body += data;

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -602,12 +602,12 @@ describe('integration', function () {
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
                   expect(tags.aws.lambda.http).to.have.property('host');
-                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
                   expect(tags.aws.lambda.http.method).to.equal('POST');
                   expect(tags.aws.lambda.http.path).to.equal('/test/some-path/some-param');
-                  expect(tags.aws.lambda.apiGateway.request.pathParameters).to.equal(
-                    JSON.stringify({ param: 'some-param' })
-                  );
+                  expect(tags.aws.lambda.apiGateway.request.pathParameterNames).to.deep.equal([
+                    'param',
+                  ]);
 
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
@@ -659,7 +659,7 @@ describe('integration', function () {
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
                   expect(tags.aws.lambda.http).to.have.property('host');
-                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
                   expect(tags.aws.lambda.http.method).to.equal('POST');
                   expect(tags.aws.lambda.http.path).to.equal('/test');
 
@@ -713,7 +713,7 @@ describe('integration', function () {
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
                   expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
                   expect(tags.aws.lambda.http).to.have.property('host');
-                  expect(tags.aws.lambda.apiGateway.request).to.have.property('headers');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
                   expect(tags.aws.lambda.http.method).to.equal('POST');
                   expect(tags.aws.lambda.http.path).to.equal('/test');
 
@@ -756,7 +756,7 @@ describe('integration', function () {
                   expect(tags.http.protocol).to.equal('HTTP/1.1');
                   expect(tags.http.host).to.equal('localhost:3177');
                   expect(tags.http.path).to.equal('/');
-                  expect(tags.http.query).to.equal('foo=bar');
+                  expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
                   expect(tags.http.statusCode.toString()).to.equal('200');
                 }
               },
@@ -892,7 +892,7 @@ describe('integration', function () {
                   expect(tags.http.protocol).to.equal('HTTP/1.1');
                   expect(tags.http.host).to.equal(functionUrl.slice('https://'.length, -1));
                   expect(tags.http.path).to.equal('/');
-                  expect(tags.http.query).to.equal('foo=bar');
+                  expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
                   expect(tags.http.statusCode.toString()).to.equal('200');
                 }
               },
@@ -954,7 +954,7 @@ describe('integration', function () {
             expect(lambdaTags.aws.lambda.apiGateway.request).to.have.property('id');
             expect(lambdaTags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
             expect(lambdaTags.aws.lambda.http).to.have.property('host');
-            expect(lambdaTags.aws.lambda.apiGateway.request).to.have.property('headers');
+            expect(lambdaTags.aws.lambda.http).to.have.property('requestHeaderNames');
             expect(lambdaTags.aws.lambda.http.method).to.equal('POST');
             expect(lambdaTags.aws.lambda.http.path).to.equal('/test');
 

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -757,6 +757,7 @@ describe('integration', function () {
                   expect(tags.http.host).to.equal('localhost:3177');
                   expect(tags.http.path).to.equal('/');
                   expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
+                  expect(tags.http.requestHeaderNames).to.deep.equal(['someHeader']);
                   expect(tags.http.statusCode.toString()).to.equal('200');
                 }
               },

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -559,6 +559,7 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.http.host).to.equal('localhost:3177');
     expect(tags.http.path).to.equal('/');
     expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
+    expect(tags.http.requestHeaderNames).to.deep.equal(['someHeader']);
     expect(tags.http.statusCode.toString()).to.equal('200');
   });
 

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -221,19 +221,15 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.aws.lambda.apiGateway.request.timeEpoch.toString()).to.equal('1661872803090');
     expect(tags.aws.lambda.http.protocol).to.equal('HTTP/1.1');
     expect(tags.aws.lambda.http.host).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
-    expect(tags.aws.lambda.apiGateway.request.headers).to.equal(
-      JSON.stringify({
-        'Accept': '*/*',
-        'Accept-Encoding': 'gzip,deflate',
-        'Other': ['First', 'Second'],
-      })
-    );
+    expect(tags.aws.lambda.http.requestHeaderNames).to.deep.equal([
+      'Accept',
+      'Accept-Encoding',
+      'Other',
+    ]);
     expect(tags.aws.lambda.http.method).to.equal('POST');
     expect(tags.aws.lambda.http.path).to.equal('/test/some-path/some-param');
-    expect(tags.aws.lambda.apiGateway.request.pathParameters).to.equal(
-      JSON.stringify({ param: 'some-param' })
-    );
-    expect(tags.aws.lambda.http.query).to.equal('foo=bar&next=first&next=second');
+    expect(tags.aws.lambda.apiGateway.request.pathParameterNames).to.deep.equal(['param']);
+    expect(tags.aws.lambda.http.queryParameterNames).to.deep.equal(['foo', 'next']);
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
@@ -325,17 +321,14 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.aws.lambda.apiGateway.request.timeEpoch.toString()).to.equal('1662040030156');
     expect(tags.aws.lambda.http.protocol).to.equal('HTTP/1.1');
     expect(tags.aws.lambda.http.host).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
-    expect(tags.aws.lambda.apiGateway.request.headers).to.equal(
-      JSON.stringify({
-        'Content-Length': '385',
-        'Content-Type':
-          'multipart/form-data; boundary=--------------------------182902192059219621976732',
-        'Multi': ['one,stillone', 'two'],
-      })
-    );
+    expect(tags.aws.lambda.http.requestHeaderNames).to.deep.equal([
+      'Content-Length',
+      'Content-Type',
+      'Multi',
+    ]);
     expect(tags.aws.lambda.http.method).to.equal('POST');
     expect(tags.aws.lambda.http.path).to.equal('/v1');
-    expect(tags.aws.lambda.http.query).to.equal('lone=value&multi=one%2Cstillone&multi=two');
+    expect(tags.aws.lambda.http.queryParameterNames).to.deep.equal(['lone', 'multi']);
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
@@ -401,17 +394,15 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.aws.lambda.apiGateway.request.timeEpoch.toString()).to.equal('1662040011065');
     expect(tags.aws.lambda.http.protocol).to.equal('HTTP/1.1');
     expect(tags.aws.lambda.http.host).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
-    expect(tags.aws.lambda.apiGateway.request.headers).to.equal(
-      JSON.stringify({
-        'content-length': '385',
-        'content-type':
-          'multipart/form-data; boundary=--------------------------419073009317249310175915',
-        'multi': 'one,stillone,two',
-      })
-    );
+    expect(tags.aws.lambda.http.requestHeaderNames).to.deep.equal([
+      'content-length',
+      'content-type',
+      'multi',
+    ]);
+
     expect(tags.aws.lambda.http.method).to.equal('POST');
     expect(tags.aws.lambda.http.path).to.equal('/v2');
-    expect(tags.aws.lambda.http.query).to.equal('lone=value&multi=one%2Cstillone%2Ctwo');
+    expect(tags.aws.lambda.http.queryParameterNames).to.deep.equal(['lone', 'multi']);
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
@@ -567,7 +558,7 @@ describe('internal-extension/index.test.js', () => {
     expect(tags.http.protocol).to.equal('HTTP/1.1');
     expect(tags.http.host).to.equal('localhost:3177');
     expect(tags.http.path).to.equal('/');
-    expect(tags.http.query).to.equal('foo=bar');
+    expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
     expect(tags.http.statusCode.toString()).to.equal('200');
   });
 
@@ -634,17 +625,16 @@ describe('internal-extension/index.test.js', () => {
     expect(lambdaTags.aws.lambda.apiGateway.request.timeEpoch.toString()).to.equal('1662040011065');
     expect(lambdaTags.aws.lambda.http.protocol).to.equal('HTTP/1.1');
     expect(lambdaTags.aws.lambda.http.host).to.equal('xxx.execute-api.us-east-1.amazonaws.com');
-    expect(lambdaTags.aws.lambda.apiGateway.request.headers).to.equal(
-      JSON.stringify({
-        'content-length': '385',
-        'content-type':
-          'multipart/form-data; boundary=--------------------------419073009317249310175915',
-        'multi': 'one,stillone,two',
-      })
-    );
+
+    expect(lambdaTags.aws.lambda.http.requestHeaderNames).to.deep.equal([
+      'content-length',
+      'content-type',
+      'multi',
+    ]);
+
     expect(lambdaTags.aws.lambda.http.method).to.equal('GET');
     expect(lambdaTags.aws.lambda.http.path).to.equal('/foo');
-    expect(lambdaTags.aws.lambda.http.query).to.equal('lone=value&multi=one%2Cstillone%2Ctwo');
+    expect(lambdaTags.aws.lambda.http.queryParameterNames).to.deep.equal(['lone', 'multi']);
 
     expect(lambdaTags.aws.lambda.http.statusCode.toString()).to.equal('200');
 


### PR DESCRIPTION
Additionally expose header names for HTTP requests