### PR TITLE
AWS Lambda SDK: Fix response data propagation

### DIFF
--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -612,7 +612,9 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(JSON.parse(request.data.requestData)).to.have.property('httpMethod');
-                  expect(response.data.responseData).to.equal('"ok"');
+                  expect(response.data.responseData).to.equal(
+                    JSON.stringify({ statusCode: 200, body: '"ok"' })
+                  );
                 }
               },
             },
@@ -666,7 +668,9 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(JSON.parse(request.data.requestData)).to.have.property('httpMethod');
-                  expect(response.data.responseData).to.equal('"ok"');
+                  expect(response.data.responseData).to.equal(
+                    JSON.stringify({ statusCode: 200, body: '"ok"' })
+                  );
                 }
               },
             },
@@ -720,7 +724,9 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(JSON.parse(request.data.requestData)).to.have.property('rawPath');
-                  expect(response.data.responseData).to.equal('"ok"');
+                  expect(response.data.responseData).to.equal(
+                    JSON.stringify({ statusCode: 200, body: '"ok"' })
+                  );
                 }
               },
             },
@@ -962,7 +968,7 @@ describe('integration', function () {
             expect(lambdaTags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
             expect(JSON.parse(request.data.requestData)).to.have.property('rawPath');
-            expect(response.data.responseData).to.equal('"ok"');
+            expect(JSON.parse(response.data.responseData).body).to.deep.equal(JSON.stringify('ok'));
 
             const [invocationSpan, expressSpan, ...middlewareSpans] = spans;
             const routeSpan = middlewareSpans.pop();

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -233,7 +233,9 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
-    expect(response.data.responseData).to.deep.equal(JSON.stringify('ok'));
+    expect(response.data.responseData).to.deep.equal(
+      JSON.stringify({ statusCode: 200, body: '"ok"' })
+    );
   });
 
   it('should handle API Gateway v2 HTTP API, payload v1 event', async () => {
@@ -332,7 +334,9 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
-    expect(response.data.responseData).to.deep.equal(JSON.stringify('ok'));
+    expect(response.data.responseData).to.deep.equal(
+      JSON.stringify({ statusCode: 200, body: '"ok"' })
+    );
   });
 
   it('should handle API Gateway v2 HTTP API, payload v2 event', async () => {
@@ -406,7 +410,9 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
-    expect(response.data.responseData).to.deep.equal(JSON.stringify('ok'));
+    expect(response.data.responseData).to.deep.equal(
+      JSON.stringify({ statusCode: 200, body: '"ok"' })
+    );
   });
 
   it('should handle SQS event', async () => {
@@ -639,7 +645,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(lambdaTags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
-    expect(response.data.responseData).to.deep.equal(JSON.stringify('ok'));
+    expect(JSON.parse(response.data.responseData).body).to.deep.equal(JSON.stringify('ok'));
 
     expect(expressSpan.name).to.equal('express');
     expect(expressSpan.parentSpanId).to.deep.equal(invocationSpan.id);


### PR DESCRIPTION
_Depends on https://github.com/serverless/console/pull/214_

Fixes so we correctly report full response objects, and with just `body` stripped if it contains binary (or non JSON) data.