### PR TITLE
AWS Lambda SDK: Fix span relations

### DIFF
--- a/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
@@ -14,6 +14,8 @@ declare class TraceSpan {
   tags: TraceSpanTags;
 
   close(): TraceSpan;
+  closeContext(): undefined;
+  destroy(): undefined;
   spans(): Set<TraceSpan>;
   toJSON(): Object;
 }

--- a/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/lib/trace-span.d.ts
@@ -11,12 +11,12 @@ declare class TraceSpan {
   id: string;
   parentSpan: TraceSpan | null;
   subSpans: Set<TraceSpan>;
+  spans: Set<TraceSpan>;
   tags: TraceSpanTags;
 
   close(): TraceSpan;
   closeContext(): undefined;
   destroy(): undefined;
-  spans(): Set<TraceSpan>;
   toJSON(): Object;
 }
 

--- a/node/packages/aws-lambda-sdk/docs/trace-span.md
+++ b/node/packages/aws-lambda-sdk/docs/trace-span.md
@@ -64,6 +64,35 @@ Supported options:
 
 - `endTime` - Externally recorded _end time_. If not provided, it's resolved automatically. Cannot be earlier than `startTime` and cannot be set in a future
 
+### `closeContext`
+
+After creating a span, this needs to be called if, after a certain point, we do not want to attribute the following logic to the span context
+
+e.g.:
+
+```javascript
+const fooSpan = serverlessSdk.createTraceSpan('foo');
+runFoo();
+// Ensure "bar" trace span is not a sub span of "foo"
+fooSpan.closeContext();
+const barSpan = serverlessSdk.createTraceSpan('bar');
+runBar();
+```
+
+### `destroy()`
+
+Permanently removes the span from the trace. Useful if we created span, but logic it was supposed to describe failed to initialize,, e.g.:
+
+```javascript
+const fooSpan = serverlessSdk.createTraceSpan('foo');
+try {
+  runFoo().finally(() => fooSpan.close());
+} catch (error) {
+  fooSpan.destroy();
+  throw error;
+}
+```
+
 #### `toJSON()`
 
 Returns JSON representation of the span

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -67,3 +67,8 @@ serverlessSdk.instrumentation = {
   awsSdkV3Client: require('./instrumentation/aws-sdk-v3-client'),
   expressApp: require('./instrumentation/express-app'),
 };
+
+serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
+serverlessSdk._debugLog = (...args) => {
+  if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);
+};

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -18,10 +18,6 @@ const { traceSpans } = serverlessSdk;
 const { awsLambda: awsLambdaSpan, awsLambdaInitialization: awsLambdaInitializationSpan } =
   traceSpans;
 
-const debugLog = (...args) => {
-  if (process.env.SLS_SDK_DEBUG) process._rawDebug('⚡ SDK:', ...args);
-};
-
 const writeRequest = (event, context) => {
   const payload = (serverlessSdk._lastRequest = {
     slsTags: {
@@ -108,7 +104,7 @@ module.exports = (originalHandler, options = {}) => {
   awsLambdaInitializationSpan.close();
   return (event, context, awsCallback) => {
     const requestStartTime = process.hrtime.bigint();
-    debugLog('Invocation: start');
+    serverlessSdk._debugLog('Invocation: start');
     let isResolved = false;
     let responseStartTime;
     const invocationId = ++currentInvocationId;
@@ -158,7 +154,7 @@ module.exports = (originalHandler, options = {}) => {
       awsLambdaInvocationSpan.close({ endTime });
       awsLambdaSpan.close({ endTime });
       writeTrace();
-      debugLog(
+      serverlessSdk._debugLog(
         'Overhead duration: Internal response:',
         `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`
       );
@@ -179,7 +175,7 @@ module.exports = (originalHandler, options = {}) => {
     context.fail = (err) => contextDone(err == null ? 'handled' : err);
 
     // TODO: Insert eventual request handling
-    debugLog(
+    serverlessSdk._debugLog(
       'Overhead duration: Internal request:',
       `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
     );

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -43,7 +43,11 @@ module.exports.install = (Sdk) => {
       if (!traceSpan.endTime) traceSpan.close();
     });
     doNotInstrumentFollowingHttpRequest();
-    return originalRunTo.call(this, state, done);
+    try {
+      return originalRunTo.call(this, state, done);
+    } finally {
+      traceSpan.closeContext();
+    }
   };
 
   const uninstall = () => {

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -37,9 +37,18 @@ module.exports.install = (client) => {
         const deferredRegion = client.config
           .region()
           .then((region) => traceSpan.tags.set('aws.sdk.region', region));
+
+        const nextDeferred = (() => {
+          try {
+            return next(args);
+          } catch (error) {
+            return Promise.reject(error);
+          }
+        })();
+        traceSpan.closeContext();
         const { response, error } = await (async () => {
           try {
-            return { response: await next(args) };
+            return { response: await nextDeferred };
           } catch (requestError) {
             return { error: requestError };
           }

--- a/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
@@ -38,6 +38,7 @@ const install = (protocol, httpModule) => {
 
   const request = function request(url, options, cb) {
     const startTime = process.hrtime.bigint();
+    serverlessSdk._debugLog('HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
     if (shouldIgnoreFollowingRequest) {
       shouldIgnoreFollowingRequest = false;
       return originalRequest.call(this, url, options, cb);
@@ -149,8 +150,10 @@ module.exports.install = () => {
 };
 
 module.exports.ignoreFollowingRequest = () => {
+  serverlessSdk._debugLog('ignore HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
   shouldIgnoreFollowingRequest = true;
   process.nextTick(() => {
+    serverlessSdk._debugLog('reset ignore HTTP request', shouldIgnoreFollowingRequest);
     shouldIgnoreFollowingRequest = false;
   });
 };

--- a/node/packages/aws-lambda-sdk/lib/trace-span.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span.js
@@ -298,9 +298,9 @@ class TraceSpan {
       }
       asyncLocalStorage.enterWith(this);
     } else {
-      const openParentSpan = ((span) => {
-        if (!span?.endsWith) return span;
-        return span.parentSpan || rootSpan;
+      const openParentSpan = (function self(span) {
+        if (!span.endTime) return span;
+        return span.parentSpan ? self(span.parentSpan) : rootSpan;
       })(this.parentSpan);
       asyncLocalStorage.enterWith(openParentSpan);
     }

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
@@ -17,13 +17,15 @@ const initializeServer = () => {
     .listen(TEST_SERVER_PORT);
 };
 
-const sendRequest = (path, callback) => {
-  http
-    .request(`http://localhost:${TEST_SERVER_PORT}/${path}`, (response) => {
-      response.on('data', () => {});
-      response.on('end', callback);
-    })
-    .end();
+const sendRequest = (path) => {
+  return new Promise((resolve) =>
+    http
+      .request(`http://localhost:${TEST_SERVER_PORT}/${path}`, (response) => {
+        response.on('data', () => {});
+        response.on('end', resolve);
+      })
+      .end()
+  );
 };
 
 const serverless = require('serverless-http');
@@ -34,9 +36,7 @@ app.use(express.json());
 
 app.get('/foo', (req, res) => {
   setTimeout(() => {
-    sendRequest('in', () => {
-      res.send('"ok"');
-    });
+    sendRequest('in').then(() => res.send('"ok"'));
   }, 200);
 });
 
@@ -46,7 +46,7 @@ const expressHandler = serverless(app);
 
 module.exports.handler = async (event, context, callback) => {
   initializeServer();
-  setTimeout(() => sendRequest('out', () => {}), 100);
+  setTimeout(() => sendRequest('out'), 100);
   try {
     await expressHandler(
       {

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
@@ -36,7 +36,7 @@ app.use(express.json());
 
 app.get('/foo', (req, res) => {
   setTimeout(() => {
-    sendRequest('in').then(() => res.send('"ok"'));
+    Promise.all([sendRequest('in-1'), sendRequest('in-2')]).then(() => res.send('"ok"'));
   }, 200);
 });
 
@@ -46,7 +46,10 @@ const expressHandler = serverless(app);
 
 module.exports.handler = async (event, context, callback) => {
   initializeServer();
-  setTimeout(() => sendRequest('out'), 100);
+  setTimeout(() => {
+    sendRequest('out-1');
+    sendRequest('out-2');
+  }, 100);
   try {
     await expressHandler(
       {

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1019,11 +1019,13 @@ describe('integration', function () {
               if (!index) spans.shift();
 
               const [invocationSpan, expressSpan, ...otherSpans] = spans;
-              const middlewareSpans = otherSpans.slice(0, -2);
+              const middlewareSpans = otherSpans.slice(0, -4);
               const routeSpan = middlewareSpans.pop();
               const routerSpan = middlewareSpans[middlewareSpans.length - 1];
-              const expressRequestSpan = otherSpans[otherSpans.length - 2];
-              const outerRequestSpan = otherSpans[otherSpans.length - 1];
+              const expressRequest1Span = otherSpans[otherSpans.length - 4];
+              const expressRequest2Span = otherSpans[otherSpans.length - 3];
+              const outerRequest1Span = otherSpans[otherSpans.length - 2];
+              const outerRequest2Span = otherSpans[otherSpans.length - 1];
 
               expect(expressSpan.parentSpanId).to.deep.equal(invocationSpan.id);
 
@@ -1041,25 +1043,29 @@ describe('integration', function () {
               expect(routeSpan.name).to.equal('express.middleware.route.get.anonymous');
               expect(String(routeSpan.parentSpanId)).to.equal(String(routerSpan.id));
 
-              expect(outerRequestSpan.name).to.equal('node.http.request');
-              expect(outerRequestSpan.parentSpanId).to.deep.equal(invocationSpan.id);
+              expect(outerRequest1Span.name).to.equal('node.http.request');
+              expect(outerRequest1Span.parentSpanId).to.deep.equal(invocationSpan.id);
+              expect(outerRequest2Span.name).to.equal('node.http.request');
+              expect(outerRequest2Span.parentSpanId).to.deep.equal(invocationSpan.id);
 
-              const { tags: outerRequestTags } = outerRequestSpan;
-              expect(outerRequestTags.http.method).to.equal('GET');
-              expect(outerRequestTags.http.protocol).to.equal('HTTP/1.1');
-              expect(outerRequestTags.http.host).to.equal('localhost:3177');
-              expect(outerRequestTags.http.path).to.equal('/out');
-              expect(outerRequestTags.http.statusCode.toString()).to.equal('200');
+              const { tags: outerRequest1Tags } = outerRequest1Span;
+              expect(outerRequest1Tags.http.method).to.equal('GET');
+              expect(outerRequest1Tags.http.protocol).to.equal('HTTP/1.1');
+              expect(outerRequest1Tags.http.host).to.equal('localhost:3177');
+              expect(outerRequest1Tags.http.path).to.equal('/out-1');
+              expect(outerRequest1Tags.http.statusCode.toString()).to.equal('200');
 
-              expect(expressRequestSpan.name).to.equal('node.http.request');
-              expect(expressRequestSpan.parentSpanId).to.deep.equal(routeSpan.id);
+              expect(expressRequest1Span.name).to.equal('node.http.request');
+              expect(expressRequest1Span.parentSpanId).to.deep.equal(routeSpan.id);
+              expect(expressRequest2Span.name).to.equal('node.http.request');
+              expect(expressRequest2Span.parentSpanId).to.deep.equal(routeSpan.id);
 
-              const { tags: expressRequestTags } = expressRequestSpan;
-              expect(expressRequestTags.http.method).to.equal('GET');
-              expect(expressRequestTags.http.protocol).to.equal('HTTP/1.1');
-              expect(expressRequestTags.http.host).to.equal('localhost:3177');
-              expect(expressRequestTags.http.path).to.equal('/in');
-              expect(expressRequestTags.http.statusCode.toString()).to.equal('200');
+              const { tags: expressRequest1Tags } = expressRequest1Span;
+              expect(expressRequest1Tags.http.method).to.equal('GET');
+              expect(expressRequest1Tags.http.protocol).to.equal('HTTP/1.1');
+              expect(expressRequest1Tags.http.host).to.equal('localhost:3177');
+              expect(expressRequest1Tags.http.path).to.equal('/in-1');
+              expect(expressRequest1Tags.http.statusCode.toString()).to.equal('200');
             }
           },
         },

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -679,11 +679,13 @@ describe('internal-extension/index.test.js', () => {
     } = await handleInvocation('multi-async');
 
     const [lambdaSpan, , invocationSpan, expressSpan, ...otherSpans] = spans;
-    const middlewareSpans = otherSpans.slice(0, -2);
+    const middlewareSpans = otherSpans.slice(0, -4);
     const routeSpan = middlewareSpans.pop();
     const routerSpan = middlewareSpans[middlewareSpans.length - 1];
-    const expressRequestSpan = otherSpans[otherSpans.length - 2];
-    const outerRequestSpan = otherSpans[otherSpans.length - 1];
+    const expressRequest1Span = otherSpans[otherSpans.length - 4];
+    const expressRequest2Span = otherSpans[otherSpans.length - 3];
+    const outerRequest1Span = otherSpans[otherSpans.length - 2];
+    const outerRequest2Span = otherSpans[otherSpans.length - 1];
 
     expect(lambdaSpan.tags.aws.lambda.httpRouter.path).to.equal('/foo');
 
@@ -702,24 +704,28 @@ describe('internal-extension/index.test.js', () => {
     expect(routeSpan.name).to.equal('express.middleware.route.get.anonymous');
     expect(String(routeSpan.parentSpanId)).to.equal(String(routerSpan.id));
 
-    expect(outerRequestSpan.name).to.equal('node.http.request');
-    expect(outerRequestSpan.parentSpanId).to.deep.equal(invocationSpan.id);
+    expect(outerRequest1Span.name).to.equal('node.http.request');
+    expect(outerRequest1Span.parentSpanId).to.deep.equal(invocationSpan.id);
+    expect(outerRequest2Span.name).to.equal('node.http.request');
+    expect(outerRequest2Span.parentSpanId).to.deep.equal(invocationSpan.id);
 
-    const { tags: outerRequestTags } = outerRequestSpan;
-    expect(outerRequestTags.http.method).to.equal('GET');
-    expect(outerRequestTags.http.protocol).to.equal('HTTP/1.1');
-    expect(outerRequestTags.http.host).to.equal('localhost:3177');
-    expect(outerRequestTags.http.path).to.equal('/out');
-    expect(outerRequestTags.http.statusCode.toString()).to.equal('200');
+    const { tags: outerRequest1Tags } = outerRequest1Span;
+    expect(outerRequest1Tags.http.method).to.equal('GET');
+    expect(outerRequest1Tags.http.protocol).to.equal('HTTP/1.1');
+    expect(outerRequest1Tags.http.host).to.equal('localhost:3177');
+    expect(outerRequest1Tags.http.path).to.equal('/out-1');
+    expect(outerRequest1Tags.http.statusCode.toString()).to.equal('200');
 
-    expect(expressRequestSpan.name).to.equal('node.http.request');
-    expect(expressRequestSpan.parentSpanId).to.deep.equal(routeSpan.id);
+    expect(expressRequest1Span.name).to.equal('node.http.request');
+    expect(expressRequest1Span.parentSpanId).to.deep.equal(routeSpan.id);
+    expect(expressRequest2Span.name).to.equal('node.http.request');
+    expect(expressRequest2Span.parentSpanId).to.deep.equal(routeSpan.id);
 
-    const { tags: expressRequestTags } = expressRequestSpan;
-    expect(expressRequestTags.http.method).to.equal('GET');
-    expect(expressRequestTags.http.protocol).to.equal('HTTP/1.1');
-    expect(expressRequestTags.http.host).to.equal('localhost:3177');
-    expect(expressRequestTags.http.path).to.equal('/in');
-    expect(expressRequestTags.http.statusCode.toString()).to.equal('200');
+    const { tags: expressRequest1Tags } = expressRequest1Span;
+    expect(expressRequest1Tags.http.method).to.equal('GET');
+    expect(expressRequest1Tags.http.protocol).to.equal('HTTP/1.1');
+    expect(expressRequest1Tags.http.host).to.equal('localhost:3177');
+    expect(expressRequest1Tags.http.path).to.equal('/in-1');
+    expect(expressRequest1Tags.http.statusCode.toString()).to.equal('200');
   });
 });

--- a/node/packages/aws-lambda-sdk/test/unit/lib/trace-span.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/lib/trace-span.test.js
@@ -70,7 +70,7 @@ describe('lib/trace-span.test.js', () => {
   it('should support creation of immediate descendant spans', () => {
     const childSpan = new TraceSpan('child', {
       immediateDescendants: ['grandchild', 'grandgrandchild'],
-    }).close();
+    });
     const grandChildren = Array.from(childSpan.subSpans);
     expect(grandChildren.map(({ name }) => name)).to.deep.equal(['grandchild']);
     const grandChild = grandChildren[0];
@@ -79,6 +79,9 @@ describe('lib/trace-span.test.js', () => {
     const grandGrandChild = grandGrandChildren[0];
     expect(grandChild.startTime).to.equal(childSpan.startTime);
     expect(grandGrandChild.startTime).to.equal(childSpan.startTime);
+    grandGrandChild.close();
+    grandChild.close();
+    childSpan.close();
   });
 
   it('should not close descendant spans on span closure', () => {
@@ -104,7 +107,8 @@ describe('lib/trace-span.test.js', () => {
     it('should resolve self and all descendants', () => {
       const span = new TraceSpan('child');
       const subSpan = new TraceSpan('subchild');
-      const subSubSpan = new TraceSpan('subsubchild');
+      const subSubSpan = new TraceSpan('subsubchild').close();
+      subSpan.close();
       expect(Array.from(span.close().spans)).to.deep.equal([span, subSpan, subSubSpan]);
     });
   });


### PR DESCRIPTION
In case of async operations started consequentially in same event loop, they were attributed as sub span of previous started span which was not correct.

Introduce API that closes the attribution context for given span and make use of it in already configured instrumentations.

Additionally:
- Add debug logs to better diagnose issue observed locally where HTTP span was reported for AWS SDK call (it happened when AWS SDK had performance issues, it's likely that HTTP call was postponed and not properly filtered out)