### PR TITLE
SC-813: External extension with sdk endpoints

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -27,7 +27,10 @@ type ReqResAPIPayload struct {
 }
 
 type SpanAPIPayload struct {
-	Payloads []string `json:"payloads"`
+	Payloads  []string `json:"payloads"`
+	AccountId string   `json:"accountId"`
+	Region    string   `json:"region"`
+	RequestId string   `json:"requestId"`
 }
 
 type LogMessage struct {
@@ -178,7 +181,10 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string) (int, error
 	tracePayloads := CollectTraceData(logs)
 	if len(tracePayloads) != 0 {
 		spansPayload := SpanAPIPayload{
-			Payloads: tracePayloads,
+			Payloads:  tracePayloads,
+			AccountId: accountId,
+			Region:    os.Getenv("AWS_REGION"),
+			RequestId: requestId,
 		}
 		spanBody, err := json.Marshal(spansPayload)
 		if err == nil {

--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -101,13 +101,10 @@ func CollectRequestResponseData(logs []LogItem) ([]string, []int64) {
 	messages := make([]string, 0)
 	timestamps := make([]int64, 0)
 	for _, log := range logs {
-		if log.LogType == "function" {
+		if log.LogType == "reqRes" {
 			t, _ := time.Parse(time.RFC3339, log.Time)
-			if strings.Contains(log.Record.(string), "SERVERLESS_TELEMETRY.R.") {
-				splitString := strings.Split(log.Record.(string), ".R.")
-				messages = append(messages, strings.TrimSuffix(splitString[len(splitString)-1], "\n"))
-				timestamps = append(timestamps, t.UnixMilli())
-			}
+			messages = append(messages, log.Record.(string))
+			timestamps = append(timestamps, t.UnixMilli())
 		}
 	}
 	return messages, timestamps
@@ -116,11 +113,8 @@ func CollectRequestResponseData(logs []LogItem) ([]string, []int64) {
 func CollectTraceData(logs []LogItem) []string {
 	messages := make([]string, 0)
 	for _, log := range logs {
-		if log.LogType == "function" {
-			if strings.Contains(log.Record.(string), "SERVERLESS_TELEMETRY.T.") {
-				splitString := strings.Split(log.Record.(string), ".T.")
-				messages = append(messages, strings.TrimSuffix(splitString[len(splitString)-1], "\n"))
-			}
+		if log.LogType == "spans" {
+			messages = append(messages, log.Record.(string))
 		}
 	}
 	return messages

--- a/go/packages/dev-mode/agent/http.go
+++ b/go/packages/dev-mode/agent/http.go
@@ -123,7 +123,6 @@ func (h *LogsApiHttpListener) span_http_handler(w http.ResponseWriter, r *http.R
 	spanString, _ := json.Marshal(spanPayload)
 	// Puts the log message into the queue
 	logSet := string(spanString)
-	fmt.Println("Span str", logSet)
 	err = h.logQueue.Put(logSet)
 	if err != nil {
 		h.logger.Error("Can't push spans to destination", zap.Error(err))
@@ -147,7 +146,6 @@ func (h *LogsApiHttpListener) req_res_http_handler(w http.ResponseWriter, r *htt
 	reqResString, _ := json.Marshal(reqResPayload)
 	// Puts the log message into the queue
 	logSet := string(reqResString)
-	fmt.Println("ReqRes str", logSet)
 	err = h.logQueue.Put(logSet)
 	if err != nil {
 		h.logger.Error("Can't push reqRes to destination", zap.Error(err))

--- a/go/packages/dev-mode/agent/http.go
+++ b/go/packages/dev-mode/agent/http.go
@@ -67,8 +67,8 @@ func (s *LogsApiHttpListener) Start() (bool, error) {
 
 	sdkAddress := SdkListenOnAddress()
 	sdkMux := http.NewServeMux()
-	sdkMux.HandleFunc("/spans", s.span_http_handler)
-	sdkMux.HandleFunc("/reqres", s.req_res_http_handler)
+	sdkMux.HandleFunc("/trace", s.span_http_handler)
+	sdkMux.HandleFunc("/request-response", s.req_res_http_handler)
 	s.sdkHttpServer = &http.Server{Addr: sdkAddress, Handler: sdkMux}
 
 	go func() {

--- a/go/packages/dev-mode/agent/http.go
+++ b/go/packages/dev-mode/agent/http.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -17,10 +18,13 @@ import (
 
 // DefaultHttpListenerPort is used to set the URL where the logs will be sent by Logs API
 const DefaultHttpListenerPort = "1234"
+const DefaultSDKHttpListenerPort = "2772"
 
 // LogsApiHttpListener is used to listen to the Logs API using HTTP
 type LogsApiHttpListener struct {
 	httpServer *http.Server
+	// http server for sdk communication
+	sdkHttpServer *http.Server
 	// logQueue is a synchronous queue and is used to put the received logs to be consumed later (see main)
 	logQueue *queue.Queue
 	// logger
@@ -31,9 +35,10 @@ type LogsApiHttpListener struct {
 func NewLogsApiHttpListener(lq *queue.Queue, l *zap.Logger) (*LogsApiHttpListener, error) {
 
 	return &LogsApiHttpListener{
-		httpServer: nil,
-		logQueue:   lq,
-		logger:     l,
+		httpServer:    nil,
+		sdkHttpServer: nil,
+		logQueue:      lq,
+		logger:        l,
 	}, nil
 }
 
@@ -45,18 +50,41 @@ func ListenOnAddress() string {
 	return "sandbox:" + DefaultHttpListenerPort
 }
 
+func SdkListenOnAddress() string {
+	env_aws_local, ok := os.LookupEnv("SLS_TEST_EXTENSION")
+	if ok && env_aws_local == "1" {
+		return "127.0.0.1:" + DefaultSDKHttpListenerPort
+	}
+	return "localhost:" + DefaultSDKHttpListenerPort
+}
+
 // Start initiates the server in a goroutine where the logs will be sent
 func (s *LogsApiHttpListener) Start() (bool, error) {
 	address := ListenOnAddress()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.http_handler)
 	s.httpServer = &http.Server{Addr: address, Handler: mux}
+
+	sdkAddress := SdkListenOnAddress()
+	sdkMux := http.NewServeMux()
+	sdkMux.HandleFunc("/spans", s.span_http_handler)
+	sdkMux.HandleFunc("/reqres", s.req_res_http_handler)
+	s.sdkHttpServer = &http.Server{Addr: sdkAddress, Handler: sdkMux}
+
 	go func() {
 		err := s.httpServer.ListenAndServe()
 		if err != http.ErrServerClosed {
 			s.Shutdown()
 		}
 	}()
+
+	go func() {
+		err := s.sdkHttpServer.ListenAndServe()
+		if err != http.ErrServerClosed {
+			s.Shutdown()
+		}
+	}()
+
 	return true, nil
 }
 
@@ -80,6 +108,52 @@ func (h *LogsApiHttpListener) http_handler(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (h *LogsApiHttpListener) span_http_handler(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Error("Error reading body", zap.Error(err))
+		return
+	}
+
+	spanPayload := []LogItem{{
+		LogType: "spans",
+		Record:  string(body),
+	}}
+
+	spanString, _ := json.Marshal(spanPayload)
+	// Puts the log message into the queue
+	logSet := string(spanString)
+	fmt.Println("Span str", logSet)
+	err = h.logQueue.Put(logSet)
+	if err != nil {
+		h.logger.Error("Can't push spans to destination", zap.Error(err))
+	}
+}
+
+func (h *LogsApiHttpListener) req_res_http_handler(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Error("Error reading body", zap.Error(err))
+		return
+	}
+
+	t, _ := time.Now().MarshalText()
+	reqResPayload := []LogItem{{
+		Time:    string(t),
+		LogType: "reqRes",
+		Record:  string(body),
+	}}
+
+	reqResString, _ := json.Marshal(reqResPayload)
+	// Puts the log message into the queue
+	logSet := string(reqResString)
+	fmt.Println("ReqRes str", logSet)
+	err = h.logQueue.Put(logSet)
+	if err != nil {
+		h.logger.Error("Can't push reqRes to destination", zap.Error(err))
+	}
+}
+
 // Shutdown terminates the HTTP server listening for logs
 func (s *LogsApiHttpListener) Shutdown() {
 	if s.httpServer != nil {
@@ -89,6 +163,16 @@ func (s *LogsApiHttpListener) Shutdown() {
 			s.logger.Error("Failed to shutdown http server gracefully", zap.Error(err))
 		} else {
 			s.httpServer = nil
+		}
+	}
+
+	if s.sdkHttpServer != nil {
+		ctx, _ := context.WithTimeout(context.Background(), 4*time.Second)
+		err := s.sdkHttpServer.Shutdown(ctx)
+		if err != nil {
+			s.logger.Error("Failed to shutdown sdk http server gracefully", zap.Error(err))
+		} else {
+			s.sdkHttpServer = nil
 		}
 	}
 }

--- a/go/packages/dev-mode/go.mod
+++ b/go/packages/dev-mode/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
-	go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.5 // indirect
+	go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.6 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect

--- a/go/packages/dev-mode/go.sum
+++ b/go/packages/dev-mode/go.sum
@@ -68,6 +68,8 @@ github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.5 h1:iwqYbnwK7lRpP7fNlYhayIIl+7bqYgOniambP2IxAJw=
 go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.5/go.mod h1:6WY9HNTpyOtrLS29m5eTD1/XdrTSqnWDmLqwX3gaO0s=
+go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.6 h1:54dCo+Iu5C7V9S5KKiSi8TLn9aSdV3doRzkZgh91JOo=
+go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.6/go.mod h1:6WY9HNTpyOtrLS29m5eTD1/XdrTSqnWDmLqwX3gaO0s=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=

--- a/go/packages/dev-mode/lib/logger.go
+++ b/go/packages/dev-mode/lib/logger.go
@@ -92,6 +92,14 @@ func ReportReqRes(logPayload string) {
 	}
 }
 
+func ReportSpans(logPayload string) {
+	_, ok := os.LookupEnv("SLS_DEBUG_EXTENSION")
+	_, toLogs := os.LookupEnv("SLS_TEST_EXTENSION_LOG")
+	if ok || toLogs {
+		BaseLogger.Printf("⚡ DEV-MODE: Spans###%s", logPayload)
+	}
+}
+
 func ReportShutdownDuration(t time.Time) {
 	_, ok := os.LookupEnv("SLS_DEBUG_EXTENSION")
 	_, toLogs := os.LookupEnv("SLS_TEST_EXTENSION_LOG")

--- a/go/packages/dev-mode/utils/MockLambdAPI.go
+++ b/go/packages/dev-mode/utils/MockLambdAPI.go
@@ -258,7 +258,7 @@ func SubmitReqRes(data []byte) {
 		}
 	}
 	for {
-		_, err := SendPost(validations.SdkURI+"/reqres", data)
+		_, err := SendPost(validations.SdkURI+"/request-response", data)
 		if err == nil {
 			break
 		} else {
@@ -275,7 +275,7 @@ func SubmitTrace(data []byte) {
 		}
 	}
 	for {
-		_, err := SendPost(validations.SdkURI+"/spans", data)
+		_, err := SendPost(validations.SdkURI+"/trace", data)
 		if err == nil {
 			break
 		} else {

--- a/go/packages/dev-mode/utils/MockLambdAPI.go
+++ b/go/packages/dev-mode/utils/MockLambdAPI.go
@@ -210,7 +210,6 @@ func saveReqRes(c *gin.Context) {
 	if err := c.BindJSON(&input); err != nil {
 		return
 	}
-	fmt.Println("Expected reqres", input.Payloads)
 	validations.ReqRes = append(validations.ReqRes, input)
 	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte("OK"))
 }
@@ -220,7 +219,6 @@ func saveSpans(c *gin.Context) {
 	if err := c.BindJSON(&input); err != nil {
 		return
 	}
-	fmt.Println("Expected span", input.Payloads)
 	validations.Spans = append(validations.Spans, input)
 	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte("OK"))
 }
@@ -259,7 +257,6 @@ func SubmitReqRes(data []byte) {
 			break
 		}
 	}
-	fmt.Println("Making reqres...", validations.SdkURI+"/reqres")
 	for {
 		_, err := SendPost(validations.SdkURI+"/reqres", data)
 		if err == nil {
@@ -269,7 +266,6 @@ func SubmitReqRes(data []byte) {
 			time.Sleep(1 * time.Second)
 		}
 	}
-	fmt.Println("Done reqres...")
 }
 
 func SubmitTrace(data []byte) {
@@ -278,7 +274,6 @@ func SubmitTrace(data []byte) {
 			break
 		}
 	}
-	fmt.Println("Making trace...")
 	for {
 		_, err := SendPost(validations.SdkURI+"/spans", data)
 		if err == nil {
@@ -287,7 +282,6 @@ func SubmitTrace(data []byte) {
 			time.Sleep(1 * time.Second)
 		}
 	}
-	fmt.Println("Done trace...")
 }
 
 func SubmitLogsAsync(logs []byte) {

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -61,16 +61,6 @@ describe('Integration', function () {
             const allReqResData = invocationsData.map((data) => data.reqRes);
             expect(allReqResData[0].length).to.equal(0);
             expect(allReqResData[1].length).to.equal(0);
-
-            // for (const [, reqRes] of invocationsData.map((data) => data.reqRes).entries()) {
-            //   expect(reqRes.length).to.equal(1);
-            //   for (const payload of reqRes) {
-            //     expect(payload).to.haveOwnProperty('region');
-            //     expect(payload).to.haveOwnProperty('accountId');
-            //     expect(payload).to.haveOwnProperty('timestamps');
-            //     expect(payload).to.haveOwnProperty('payloads');
-            //   }
-            // }
           },
         },
       },

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -56,15 +56,21 @@ describe('Integration', function () {
         ]),
         config: {
           test: ({ invocationsData }) => {
-            for (const [, reqRes] of invocationsData.map((data) => data.reqRes).entries()) {
-              expect(reqRes.length).to.equal(1);
-              for (const payload of reqRes) {
-                expect(payload).to.haveOwnProperty('region');
-                expect(payload).to.haveOwnProperty('accountId');
-                expect(payload).to.haveOwnProperty('timestamps');
-                expect(payload).to.haveOwnProperty('payloads');
-              }
-            }
+            // Replace with external + sdk integration results once the sdk is configured
+            // to communicate with the external extension
+            const allReqResData = invocationsData.map((data) => data.reqRes);
+            expect(allReqResData[0].length).to.equal(0);
+            expect(allReqResData[1].length).to.equal(0);
+
+            // for (const [, reqRes] of invocationsData.map((data) => data.reqRes).entries()) {
+            //   expect(reqRes.length).to.equal(1);
+            //   for (const payload of reqRes) {
+            //     expect(payload).to.haveOwnProperty('region');
+            //     expect(payload).to.haveOwnProperty('accountId');
+            //     expect(payload).to.haveOwnProperty('timestamps');
+            //     expect(payload).to.haveOwnProperty('payloads');
+            //   }
+            // }
           },
         },
       },


### PR DESCRIPTION
## Description
Added an internal server at `localhost:2772` with a `POST /spans` and `POST /reqres` route so our internal sdk extension can post spans and reqres data to our external server and we can forward this data long to our dev mode backend.