### PR TITLE
chore: Updated sls tags to include additional identifying information

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -31,6 +31,10 @@ message SlsTags {
   string service = 3;
   // The region that instrumentation was performed in. This is used to determine which Serverless Ingest API to use.
   optional string region = 4;
+  // The account id that instrumentation was performed in. This is used to determine which integration the payload was created in.
+  optional string account_id = 6;
+  // The request id that created the payload. This is used to determine which specific invocation a payload is tied to.
+  optional string request_id = 7;
 
   message SdkTags {
     // The Name of the Serverless SDK used to instrument.


### PR DESCRIPTION
## Description
Per the discussion in [this PR](https://github.com/serverless/console/pull/237) I am adding account id and request id to the slsTags so that we can include accountId, requestId, and region on each trace and req/res proto payloads.

I put this in `slsTags` rather than directly on the root payload since this is specific to processing the payloads in our ingest pipeline 🤷 