### PR TITLE
Created dev mode proto file

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -31,10 +31,6 @@ message SlsTags {
   string service = 3;
   // The region that instrumentation was performed in. This is used to determine which Serverless Ingest API to use.
   optional string region = 4;
-  // The account id that instrumentation was performed in. This is used to determine which integration the payload was created in.
-  optional string account_id = 6;
-  // The request id that created the payload. This is used to determine which specific invocation a payload is tied to.
-  optional string request_id = 7;
 
   message SdkTags {
     // The Name of the Serverless SDK used to instrument.

--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -19,8 +19,8 @@ message DevModePayload {
 
   oneof payload {
     // The set of lambda traces that were generated via an internal extension
-    TracePayload traces = 4;
+    TracePayload trace = 4;
     // The req or response data from the instrumented lambda function
-    RequestResponse req_res = 5;
+    RequestResponse request_response = 5;
   }
 }

--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package serverless.instrumentation.v1;
+
+import "serverless/instrumentation/v1/trace.proto";
+import "serverless/instrumentation/v1/request_response.proto";
+
+option go_package = ".;protoc";
+
+// A DevMode Payload is a message that will contain reqRes data or span data
+// that is forwarded to ingest via the internal extension
+message DevModePayload {
+  // The AWS Account ID where this payload originated from
+  string account_id = 1;
+  // The AWS Region where this payload originated from
+  string region = 2;
+  // The lambda request id where this payload originated from
+  string request_id = 3;
+
+  oneof payload {
+    // The set of lambda traces that were generated via an internal extension
+    TracePayload traces = 4;
+    // The req or response data from the instrumented lambda function
+    RequestResponse req_res = 5;
+  }
+}


### PR DESCRIPTION
## Description
Added a dev mode proto file so that we can add any unique attributes to the dev mode payloads without doing any additional data enrichment in the external extension.

Also reverted the changes from [this PR](https://github.com/serverless/console/pull/238) and this change is in response to the [conversation in this PR](https://github.com/serverless/console/pull/237).