### PR TITLE
AWS Lambda SDK: Report closed spans on the go and other improvements

### DIFF
--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -87,6 +87,10 @@ Disable automated AWS SDK monitoring
 
 Disable automated express monitoring
 
+##### `SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB` (or `options.traceMaxCapturedBodySizeKb`)
+
+In dev mode, HTTP request and response bodies are stored as tags. To avoid performance issues, bodies that extend 10 000KB in size are not exposed. This default can be overridden with this settin
+
 ### Outcome
 
 SDK automatically creates the trace that covers internal process of function invocation and initialization.

--- a/node/packages/aws-lambda-sdk/docs/monitoring.md
+++ b/node/packages/aws-lambda-sdk/docs/monitoring.md
@@ -66,6 +66,8 @@ Tags that apply to all AWS SDK requests:
 | `aws.sdk.operation`         | Operation name (e.g. `listtopics`)                                                     |
 | `aws.sdk.request_id`        | AWS reqeust id                                                                         |
 | `aws.sdk.error`             | If request ends with error, the error message                                          |
+| `aws.sdk.request_body`      | _(dev mode only)_ Request body                                                         |
+| `aws.sdk.response_body`     | _(dev mode only)_ Response body                                                        |
 
 #### `aws.sdk.sns` span tags`
 

--- a/node/packages/aws-lambda-sdk/docs/monitoring.md
+++ b/node/packages/aws-lambda-sdk/docs/monitoring.md
@@ -18,16 +18,18 @@ All HTTP and HTTPS requests are monitored and stored as `node.http.request` & `n
 
 #### Trace span tags:
 
-| Name                         | Value                                           |
-| ---------------------------- | ----------------------------------------------- |
-| `http.method`                | Request method (e.g. `GET`)                     |
-| `http.protocol`              | Currently `HTTP/1.1` in all cases               |
-| `http.host`                  | Domain name and port name if custom             |
-| `http.path`                  | Request pathname (query string is not included) |
-| `http.query_parameter_names` | Query string parameter names (if provided)      |
-| `http.request_header_names`  | Request header names                            |
-| `http.status_code`           | Response status code                            |
-| `http.error_code`            | If request errored, its error code              |
+| Name                         | Value                                            |
+| ---------------------------- | ------------------------------------------------ |
+| `http.method`                | Request method (e.g. `GET`)                      |
+| `http.protocol`              | Currently `HTTP/1.1` in all cases                |
+| `http.host`                  | Domain name and port name if custom              |
+| `http.path`                  | Request pathname (query string is not included)  |
+| `http.query_parameter_names` | Query string parameter names (if provided)       |
+| `http.request_header_names`  | Request header names                             |
+| `http.status_code`           | Response status code                             |
+| `http.error_code`            | If request errored, its error code               |
+| `http.request_body`          | _(dev mode only)_ Request body (if UTF8 string)  |
+| `http.response_body`         | _(dev mode only)_ Response body (if UTF8 string) |
 
 ## AWS SDK requests
 

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -74,3 +74,5 @@ serverlessSdk._debugLog = (...args) => {
 };
 
 serverlessSdk._isDevMode = Boolean(process.env.SLS_DEV_MODE_ORG_ID);
+serverlessSdk._traceSpanEmitter = require('./lib/trace-span/emitter');
+serverlessSdk.version = require('./package').version;

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -72,3 +72,5 @@ serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
 serverlessSdk._debugLog = (...args) => {
   if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);
 };
+
+serverlessSdk._isDevMode = Boolean(process.env.SLS_DEV_MODE_ORG_ID);

--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const coerceToNaturalNumber = require('type/natural-number/coerce');
 const TraceSpan = require('./lib/trace-span');
 
 const serverlessSdk = module.exports;
@@ -36,6 +37,10 @@ const resolveSettings = (options = {}) => {
   serverlessSdk._settings.disableExpressMonitoring = Boolean(
     process.env.SLS_DISABLE_EXPRESS_MONITORING || options.disableExpressMonitoring
   );
+  serverlessSdk._settings.traceMaxCapturedBodySizeKb =
+    coerceToNaturalNumber(process.env.SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB) ||
+    coerceToNaturalNumber(options.traceMaxCapturedBodySizeKb) ||
+    10000;
 };
 
 let isInitialized = false;

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -34,7 +34,6 @@ const reportRequest = async (event, context) => {
   });
   const payloadBuffer = (serverlessSdk._lastRequestBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());
-  process._rawDebug(`SERVERLESS_TELEMETRY.R.${payloadBuffer.toString('base64')}`);
   await sendTelemetry('request-response', payloadBuffer);
 };
 
@@ -75,7 +74,6 @@ const reportResponse = async (response, context) => {
   });
   const payloadBuffer = (serverlessSdk._lastResponseBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());
-  process._rawDebug(`SERVERLESS_TELEMETRY.R.${payloadBuffer.toString('base64')}`);
   await sendTelemetry('request-response', payloadBuffer);
 };
 

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const serverlessSdk = global.serverlessSdk || require('../');
+
+if (!serverlessSdk._isDevMode) {
+  // No dev mode, export noop function
+  module.exports.flush = () => {};
+  return;
+}
+
+const traceProto = require('@serverless/sdk-schema/dist/trace');
+const sendTelemetry = require('./send-telemetry');
+const devModeOnlyTags = require('./dev-mode-only-tags');
+
+const pendingSpans = [];
+let isScheduled = false;
+const sendSpans = () => {
+  isScheduled = false;
+  if (!pendingSpans.length) return;
+  const payload = {
+    slsTags: {
+      orgId: serverlessSdk.orgId,
+      service: process.env.AWS_LAMBDA_FUNCTION_NAME,
+      sdk: { name: '@serverless/aws-lambda-sdk', version: serverlessSdk.version },
+    },
+    spans: pendingSpans.map((span) => {
+      const result = span.toProtobufObject();
+      for (const tagName of span.tags.keys()) {
+        if (devModeOnlyTags.has(tagName)) span.tags.delete(tagName);
+      }
+      return result;
+    }),
+  };
+  pendingSpans.length = 0;
+  serverlessSdk._deferredTelemetryRequests.push(
+    sendTelemetry('trace', traceProto.TracePayload.encode(payload).finish())
+  );
+};
+
+serverlessSdk._traceSpanEmitter.on('close', (traceSpan) => {
+  pendingSpans.push(traceSpan);
+  if (!isScheduled) {
+    isScheduled = true;
+    process.nextTick(sendSpans);
+  }
+});
+
+module.exports.flush = sendSpans;

--- a/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = new Set([]);
+module.exports = new Set(['aws.sdk.request_body', 'aws.sdk.response_body']);

--- a/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
@@ -1,3 +1,8 @@
 'use strict';
 
-module.exports = new Set(['aws.sdk.request_body', 'aws.sdk.response_body']);
+module.exports = new Set([
+  'aws.sdk.request_body',
+  'aws.sdk.response_body',
+  'http.request_body',
+  'http.response_body',
+]);

--- a/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/dev-mode-only-tags.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = new Set([]);

--- a/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
@@ -1,12 +1,13 @@
 'use strict';
 
-if (!process.env.SLS_DEV_MODE_ORG_ID) {
+const serverlessSdk = global.serverlessSdk || require('../');
+
+if (!serverlessSdk._isDevMode) {
   // No dev mode, export noop function
   module.exports = async () => {};
   return;
 }
 
-const serverlessSdk = global.serverlessSdk || require('../');
 const http = require('http');
 
 const keepAliveAgent = new http.Agent({ keepAlive: true });

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -33,13 +33,20 @@ module.exports.install = (Sdk) => {
         'aws.sdk.signature_version': this.service.config.signatureVersion,
         'aws.sdk.service': serviceName,
         'aws.sdk.operation': operationName,
+        'aws.sdk.request_body': serverlessSdk._isDevMode ? JSON.stringify(params) : null,
       },
     });
     tagMapper?.params?.(traceSpan, params);
     this.on('complete', (response) => {
       if (response.requestId) traceSpan.tags.set('aws.sdk.request_id', response.requestId);
-      if (response.error) traceSpan.tags.set('aws.sdk.error', response.error.message);
-      else tagMapper?.responseData?.(traceSpan, response.data);
+      if (response.error) {
+        traceSpan.tags.set('aws.sdk.error', response.error.message);
+      } else {
+        if (serverlessSdk._isDevMode) {
+          traceSpan.tags.set('aws.sdk.response_body', JSON.stringify(response.data));
+        }
+        tagMapper?.responseData?.(traceSpan, response.data);
+      }
       if (!traceSpan.endTime) traceSpan.close();
     });
     doNotInstrumentFollowingHttpRequest();

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -31,6 +31,7 @@ module.exports.install = (client) => {
             'aws.sdk.service': serviceName,
             'aws.sdk.operation': operationName,
             'aws.sdk.signature_version': 'v4',
+            'aws.sdk.request_body': serverlessSdk._isDevMode ? JSON.stringify(args.input) : null,
           },
         });
         tagMapper?.params?.(traceSpan, args.input);
@@ -60,6 +61,9 @@ module.exports.install = (client) => {
           throw error;
         } else {
           traceSpan.tags.set('aws.sdk.request_id', response.output.$metadata.requestId);
+          if (serverlessSdk._isDevMode) {
+            traceSpan.tags.set('aws.sdk.response_body', JSON.stringify(response.output));
+          }
           tagMapper?.responseData?.(traceSpan, response.output);
           if (!traceSpan.endTime) traceSpan.close();
           return response;

--- a/node/packages/aws-lambda-sdk/lib/trace-span/emitter.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/emitter.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+module.exports = new EventEmitter();

--- a/node/packages/aws-lambda-sdk/lib/trace-span/index.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/index.js
@@ -15,6 +15,7 @@ const lazy = require('d/lazy');
 const { AsyncLocalStorage } = require('node:async_hooks');
 const Long = require('long');
 const crypto = require('crypto');
+const emitter = require('./emitter');
 
 const isValidSpanName = RegExp.prototype.test.bind(/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/);
 const isValidTagName = RegExp.prototype.test.bind(
@@ -251,6 +252,7 @@ class TraceSpan {
     asyncLocalStorage.enterWith(this);
 
     this.parentSpan?.subSpans.add(this);
+    emitter.emit('open', this);
     if (immediateDescendants?.length) {
       // eslint-disable-next-line no-new
       new TraceSpan(immediateDescendants.shift(), {
@@ -312,6 +314,7 @@ class TraceSpan {
     } else {
       this.closeContext();
     }
+    emitter.emit('close', this);
     return this;
   }
   destroy() {

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.7.0",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.10.0",
+    "@serverless/sdk-schema": "^0.10.1",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.0",

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/multi-async.js
@@ -20,11 +20,11 @@ const initializeServer = () => {
 const sendRequest = (path) => {
   return new Promise((resolve) =>
     http
-      .request(`http://localhost:${TEST_SERVER_PORT}/${path}`, (response) => {
+      .request(`http://localhost:${TEST_SERVER_PORT}/${path}`, { method: 'POST' }, (response) => {
         response.on('data', () => {});
         response.on('end', resolve);
       })
-      .end()
+      .end('test')
   );
 };
 

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1141,7 +1141,7 @@ describe('integration', function () {
               expect(outerRequest2Span.parentSpanId).to.deep.equal(invocationSpan.id);
 
               const { tags: outerRequest1Tags } = outerRequest1Span;
-              expect(outerRequest1Tags.http.method).to.equal('GET');
+              expect(outerRequest1Tags.http.method).to.equal('POST');
               expect(outerRequest1Tags.http.protocol).to.equal('HTTP/1.1');
               expect(outerRequest1Tags.http.host).to.equal('localhost:3177');
               expect(outerRequest1Tags.http.path).to.equal('/out-1');
@@ -1153,7 +1153,7 @@ describe('integration', function () {
               expect(expressRequest2Span.parentSpanId).to.deep.equal(routeSpan.id);
 
               const { tags: expressRequest1Tags } = expressRequest1Span;
-              expect(expressRequest1Tags.http.method).to.equal('GET');
+              expect(expressRequest1Tags.http.method).to.equal('POST');
               expect(expressRequest1Tags.http.protocol).to.equal('HTTP/1.1');
               expect(expressRequest1Tags.http.host).to.equal('localhost:3177');
               expect(expressRequest1Tags.http.path).to.equal('/in-1');

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -306,11 +306,6 @@ describe('integration', function () {
             {
               configuration: { Runtime: 'nodejs16.x' },
               invokePayload: { test: 'foo' },
-              test: ({ invocationsData }) => {
-                for (const { request } of invocationsData) {
-                  expect(request.data.requestData).to.equal(JSON.stringify({ test: 'foo' }));
-                }
-              },
             },
           ],
           [
@@ -389,7 +384,7 @@ describe('integration', function () {
                 return { duration };
               },
               test: ({ invocationsData, testConfig }) => {
-                for (const { trace, request } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.sqs');
@@ -397,8 +392,6 @@ describe('integration', function () {
 
                   expect(tags.aws.lambda.sqs.queueName).to.equal(testConfig.queueName);
                   expect(tags.aws.lambda.sqs.messageIds.length).to.equal(1);
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('Records');
                 }
               },
             },
@@ -448,7 +441,7 @@ describe('integration', function () {
                 return { duration };
               },
               test: ({ invocationsData, testConfig }) => {
-                for (const { trace, request } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.sns');
@@ -456,8 +449,6 @@ describe('integration', function () {
 
                   expect(tags.aws.lambda.sns.topicName).to.equal(testConfig.topicName);
                   expect(tags.aws.lambda.sns.messageIds.length).to.equal(1);
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('Records');
                 }
               },
             },
@@ -591,7 +582,7 @@ describe('integration', function () {
                 return { duration, payload };
               },
               test: ({ invocationsData, testConfig }) => {
-                for (const { trace, request, response } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
@@ -613,11 +604,6 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(tags.aws.lambda.httpRouter.path).to.equal('/some-path/{param}');
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('httpMethod');
-                  expect(response.data.responseData).to.equal(
-                    JSON.stringify({ statusCode: 200, body: '"ok"' })
-                  );
                 }
               },
             },
@@ -652,7 +638,7 @@ describe('integration', function () {
                 return { duration, payload };
               },
               test: ({ invocationsData, testConfig }) => {
-                for (const { trace, request, response } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
@@ -671,11 +657,6 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(tags.aws.lambda.httpRouter.path).to.equal('/test');
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('httpMethod');
-                  expect(response.data.responseData).to.equal(
-                    JSON.stringify({ statusCode: 200, body: '"ok"' })
-                  );
                 }
               },
             },
@@ -710,7 +691,7 @@ describe('integration', function () {
                 return { duration, payload };
               },
               test: ({ invocationsData, testConfig }) => {
-                for (const { trace, request, response } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
@@ -729,11 +710,6 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
                   expect(tags.aws.lambda.httpRouter.path).to.equal('/test');
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('rawPath');
-                  expect(response.data.responseData).to.equal(
-                    JSON.stringify({ statusCode: 200, body: '"ok"' })
-                  );
                 }
               },
             },
@@ -809,7 +785,7 @@ describe('integration', function () {
                 return { duration, payload };
               },
               test: ({ invocationsData }) => {
-                for (const { trace, request, response } of invocationsData) {
+                for (const { trace } of invocationsData) {
                   const { tags } = trace.spans[0];
 
                   expect(tags.aws.lambda.eventSource).to.equal('aws.lambda');
@@ -821,11 +797,6 @@ describe('integration', function () {
                   expect(tags.aws.lambda.http.path).to.equal('/test');
 
                   expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
-
-                  expect(JSON.parse(request.data.requestData)).to.have.property('rawPath');
-                  expect(response.data.responseData).to.equal(
-                    JSON.stringify({ statusCode: 200, body: '"ok"' })
-                  );
                 }
               },
             },
@@ -1043,8 +1014,6 @@ describe('integration', function () {
             index,
             {
               trace: { spans },
-              request,
-              response,
             },
           ] of invocationsData.entries()) {
             const lambdaSpan = spans.shift();
@@ -1067,9 +1036,6 @@ describe('integration', function () {
             expect(lambdaTags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
             expect(lambdaTags.aws.lambda.httpRouter.path.toString()).to.equal('/test');
-
-            expect(JSON.parse(request.data.requestData)).to.have.property('rawPath');
-            expect(JSON.parse(response.data.responseData).body).to.deep.equal(JSON.stringify('ok'));
 
             const [invocationSpan, expressSpan, ...middlewareSpans] = spans;
             const routeSpan = middlewareSpans.pop();


### PR DESCRIPTION
- Report closed spans on the go
- In dev mode:
  - Report AWS SDK request and response bodies
  - Report HTTP(S) request and response bodies (added prevention to not report bodies that are larger than 10MB - configurable value)
- Do not write request and response bodies to CW logs