### PR TITLE
feat: Support telemetry API in us-east-1

### DIFF
--- a/go/packages/dev-mode/main_test.go
+++ b/go/packages/dev-mode/main_test.go
@@ -39,7 +39,7 @@ type ValidationResult struct {
 }
 
 var port = 9001
-var region = "us-east-1"
+var region = "us-east-2"
 var functionName = "test-function"
 
 type mockSTSClient struct {


### PR DESCRIPTION
## Description
Optionally use the `/telemetry` endpoint if the function is deployed in `us-east-1`. I am just getting ahead of that change in the current region that supports telemetry 🤷 