### PR TITLE
AWS Lambda SDK: Fix dev mode support and improve its testing

### DIFF
--- a/.github/workflows/node-integrate.yml
+++ b/.github/workflows/node-integrate.yml
@@ -531,6 +531,11 @@ jobs:
           cd node/packages/aws-lambda-sdk
           npm run test:integration
 
+      - name: Performance tests
+        run: |
+          cd node/packages/aws-lambda-sdk
+          npm run test:performance
+
       - name: Tag if new version
         run: |
           NEW_VERSION=`git diff -U0 ${{ github.event.before }} node/packages/aws-lambda-sdk/package.json | grep '"version": "' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -110,7 +110,6 @@ module.exports = (originalHandler, options = {}) => {
     let isResolved = false;
     let responseStartTime;
     const invocationId = ++currentInvocationId;
-    serverlessSdk._deferredTelemetryRequests = [];
     if (invocationId > 1) {
       // Reset root span ids and startTime with every next invocation
       delete awsLambdaSpan.traceId;
@@ -161,6 +160,7 @@ module.exports = (originalHandler, options = {}) => {
       reportTrace();
       flushSpans();
       await Promise.all(serverlessSdk._deferredTelemetryRequests);
+      serverlessSdk._deferredTelemetryRequests.length = 0;
       serverlessSdk._debugLog(
         'Overhead duration: Internal response:',
         `${Math.round(Number(process.hrtime.bigint() - responseStartTime) / 1000000)}ms`

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -2,6 +2,8 @@
 
 const serverlessSdk = global.serverlessSdk || require('../');
 
+serverlessSdk._deferredTelemetryRequests = [];
+
 if (!serverlessSdk._isDevMode) {
   // No dev mode, export noop function
   module.exports.flush = () => {};

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -48,7 +48,8 @@
     "prepare-release": "standard-version && prettier --write CHANGELOG.md",
     "test": "mocha \"test/unit/**/*.test.js\"",
     "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\"",
-    "test:integration": "mocha \"test/integration/**/*.test.js\""
+    "test:integration": "mocha \"test/integration/**/*.test.js\"",
+    "test:performance": "mocha test/benchmark/performance.test.js"
   },
   "publishConfig": {
     "access": "public"

--- a/node/packages/aws-lambda-sdk/test/benchmark/index.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/index.js
@@ -7,7 +7,9 @@ const run = require('./lib/run');
 
 module.exports = async (options = {}) => {
   const coreConfig = {};
-  await createCoreResources(coreConfig);
+  await createCoreResources(coreConfig, {
+    layerTypes: ['nodeInternal', 'nodeExternal'],
+  });
 
   const allBenchmarkVariantsConfig = await resolveCommonBenchmarkVariantsConfig(
     coreConfig,

--- a/node/packages/aws-lambda-sdk/test/benchmark/index.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/index.js
@@ -7,9 +7,7 @@ const run = require('./lib/run');
 
 module.exports = async (options = {}) => {
   const coreConfig = {};
-  await createCoreResources(coreConfig, {
-    layerTypes: ['nodeInternal', 'nodeExternal'],
-  });
+  await createCoreResources(coreConfig);
 
   const allBenchmarkVariantsConfig = await resolveCommonBenchmarkVariantsConfig(
     coreConfig,

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-common-benchmark-variants-config.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/resolve-common-benchmark-variants-config.js
@@ -21,5 +21,34 @@ module.exports = async (coreConfig, options) => {
         },
       },
     ],
+    [
+      'external',
+      {
+        configuration: {
+          MemorySize: memorySize,
+          Layers: [coreConfig.layerExternalArn],
+          Environment: {
+            Variables: { SLS_SDK_DEBUG: '1' },
+          },
+        },
+      },
+    ],
+    [
+      'internalAndExternal',
+      {
+        configuration: {
+          MemorySize: memorySize,
+          Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
+          Environment: {
+            Variables: {
+              AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
+              SLS_ORG_ID: process.env.SLS_ORG_ID,
+              SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
+              SLS_SDK_DEBUG: '1',
+            },
+          },
+        },
+      },
+    ],
   ]);
 };

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
@@ -40,6 +40,15 @@ module.exports = async (useCasesConfig, coreConfig) => {
 
         const durationsData = {
           initialization: {
+            externalOverhead: reports.map(
+              ({
+                processesData: [
+                  {
+                    extensionOverheadDurations: { externalInit },
+                  },
+                ],
+              }) => externalInit || 0
+            ),
             internal: {
               overhead: reports.map(
                 ({
@@ -93,6 +102,15 @@ module.exports = async (useCasesConfig, coreConfig) => {
                   }) => invocation || 0
                 ),
               },
+              externalResponseOverhead: reports.map(
+                ({
+                  invocationsData: [
+                    {
+                      extensionOverheadDurations: { externalResponse },
+                    },
+                  ],
+                }) => externalResponse || 0
+              ),
               total: reports.map(({ invocationsData: [{ duration }] }) => duration),
               billed: reports.map(({ invocationsData: [{ billedDuration }] }) => billedDuration),
               local: reports.map(({ invocationsData: [{ localDuration }] }) => localDuration),
@@ -133,6 +151,16 @@ module.exports = async (useCasesConfig, coreConfig) => {
                   }) => invocation || 0
                 ),
               },
+              externalResponseOverhead: reports.map(
+                ({
+                  invocationsData: [
+                    ,
+                    {
+                      extensionOverheadDurations: { externalResponse },
+                    },
+                  ],
+                }) => externalResponse || 0
+              ),
               total: reports.map(({ invocationsData: [, { duration }] }) => duration),
               billed: reports.map(({ invocationsData: [, { billedDuration }] }) => billedDuration),
               local: reports.map(({ invocationsData: [, { localDuration }] }) => localDuration),
@@ -145,6 +173,10 @@ module.exports = async (useCasesConfig, coreConfig) => {
 
         benchmarkVariantResult.results = {
           initialization: {
+            externalOverhead: {
+              average: average(durationsData.initialization.externalOverhead),
+              median: median(durationsData.initialization.externalOverhead),
+            },
             internal: {
               overhead: {
                 average: average(durationsData.initialization.internal.overhead),
@@ -175,6 +207,10 @@ module.exports = async (useCasesConfig, coreConfig) => {
                   average: average(durationsData.invocation.first.internal.total),
                   median: median(durationsData.invocation.first.internal.total),
                 },
+              },
+              externalResponseOverhead: {
+                average: average(durationsData.invocation.first.externalResponseOverhead),
+                median: median(durationsData.invocation.first.externalResponseOverhead),
               },
               total: {
                 average: average(durationsData.invocation.first.total),
@@ -207,6 +243,10 @@ module.exports = async (useCasesConfig, coreConfig) => {
                   average: average(durationsData.invocation.following.internal.total),
                   median: median(durationsData.invocation.following.internal.total),
                 },
+              },
+              externalResponseOverhead: {
+                average: average(durationsData.invocation.following.externalResponseOverhead),
+                median: median(durationsData.invocation.following.externalResponseOverhead),
               },
               total: {
                 average: average(durationsData.invocation.following.total),

--- a/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/lib/run.js
@@ -40,21 +40,32 @@ module.exports = async (useCasesConfig, coreConfig) => {
 
         const durationsData = {
           initialization: {
-            internal: reports.map(
-              ({
-                processesData: [
-                  {
-                    extensionOverheadDurations: { internalInit },
-                  },
-                ],
-              }) => internalInit || 0
-            ),
+            internal: {
+              overhead: reports.map(
+                ({
+                  processesData: [
+                    {
+                      extensionOverheadDurations: { internalInit },
+                    },
+                  ],
+                }) => internalInit || 0
+              ),
+              total: reports.map(
+                ({
+                  invocationsData: [
+                    {
+                      internalDurations: { initialization },
+                    },
+                  ],
+                }) => initialization || 0
+              ),
+            },
             total: reports.map(({ processesData: [{ initDuration }] }) => initDuration),
           },
           invocation: {
             first: {
               internal: {
-                request: reports.map(
+                requestOverhead: reports.map(
                   ({
                     invocationsData: [
                       {
@@ -63,7 +74,7 @@ module.exports = async (useCasesConfig, coreConfig) => {
                     ],
                   }) => internalRequest || 0
                 ),
-                response: reports.map(
+                responseOverhead: reports.map(
                   ({
                     invocationsData: [
                       {
@@ -71,6 +82,15 @@ module.exports = async (useCasesConfig, coreConfig) => {
                       },
                     ],
                   }) => internalResponse || 0
+                ),
+                total: reports.map(
+                  ({
+                    invocationsData: [
+                      {
+                        internalDurations: { invocation },
+                      },
+                    ],
+                  }) => invocation || 0
                 ),
               },
               total: reports.map(({ invocationsData: [{ duration }] }) => duration),
@@ -82,7 +102,7 @@ module.exports = async (useCasesConfig, coreConfig) => {
             },
             following: {
               internal: {
-                request: reports.map(
+                requestOverhead: reports.map(
                   ({
                     invocationsData: [
                       ,
@@ -92,7 +112,7 @@ module.exports = async (useCasesConfig, coreConfig) => {
                     ],
                   }) => internalRequest || 0
                 ),
-                response: reports.map(
+                responseOverhead: reports.map(
                   ({
                     invocationsData: [
                       ,
@@ -101,6 +121,16 @@ module.exports = async (useCasesConfig, coreConfig) => {
                       },
                     ],
                   }) => internalResponse || 0
+                ),
+                total: reports.map(
+                  ({
+                    invocationsData: [
+                      ,
+                      {
+                        internalDurations: { invocation },
+                      },
+                    ],
+                  }) => invocation || 0
                 ),
               },
               total: reports.map(({ invocationsData: [, { duration }] }) => duration),
@@ -116,8 +146,14 @@ module.exports = async (useCasesConfig, coreConfig) => {
         benchmarkVariantResult.results = {
           initialization: {
             internal: {
-              average: average(durationsData.initialization.internal),
-              median: median(durationsData.initialization.internal),
+              overhead: {
+                average: average(durationsData.initialization.internal.overhead),
+                median: median(durationsData.initialization.internal.overhead),
+              },
+              total: {
+                average: average(durationsData.initialization.internal.total),
+                median: median(durationsData.initialization.internal.total),
+              },
             },
             total: {
               average: average(durationsData.initialization.total),
@@ -127,13 +163,17 @@ module.exports = async (useCasesConfig, coreConfig) => {
           invocation: {
             first: {
               internal: {
-                request: {
-                  average: average(durationsData.invocation.first.internal.request),
-                  median: median(durationsData.invocation.first.internal.request),
+                requestOverhead: {
+                  average: average(durationsData.invocation.first.internal.requestOverhead),
+                  median: median(durationsData.invocation.first.internal.requestOverhead),
                 },
-                response: {
-                  average: average(durationsData.invocation.first.internal.response),
-                  median: median(durationsData.invocation.first.internal.response),
+                responseOverhead: {
+                  average: average(durationsData.invocation.first.internal.responseOverhead),
+                  median: median(durationsData.invocation.first.internal.responseOverhead),
+                },
+                total: {
+                  average: average(durationsData.invocation.first.internal.total),
+                  median: median(durationsData.invocation.first.internal.total),
                 },
               },
               total: {
@@ -155,13 +195,17 @@ module.exports = async (useCasesConfig, coreConfig) => {
             },
             following: {
               internal: {
-                request: {
-                  average: average(durationsData.invocation.following.internal.request),
-                  median: median(durationsData.invocation.following.internal.request),
+                requestOverhead: {
+                  average: average(durationsData.invocation.following.internal.requestOverhead),
+                  median: median(durationsData.invocation.following.internal.requestOverhead),
                 },
-                response: {
-                  average: average(durationsData.invocation.following.internal.response),
-                  median: median(durationsData.invocation.following.internal.response),
+                responseOverhead: {
+                  average: average(durationsData.invocation.following.internal.responseOverhead),
+                  median: median(durationsData.invocation.following.internal.responseOverhead),
+                },
+                total: {
+                  average: average(durationsData.invocation.following.internal.total),
+                  median: median(durationsData.invocation.following.internal.total),
                 },
               },
               total: {

--- a/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
@@ -12,22 +12,29 @@ describe('performance', function () {
   let results;
   before(async () => {
     const resultsMap = await runBenchmarks({
-      benchmarkVariants: new Set(['internal']),
+      benchmarkVariants: new Set(['internal', 'internalAndExternal']),
       useCases: new Set(['callback']),
     });
-    ({ results } = resultsMap.get('callback').get('internal'));
+    results = resultsMap.get('callback');
   });
 
   // TODO: Reduce acceptable durations once improvements are made
   it('should introduce reasonable initialization overhead', () => {
-    expect(results.initialization.total.median).to.be.below(200);
+    expect(results.get('internal').results.initialization.total.median).to.be.below(250);
+    expect(results.get('internalAndExternal').results.initialization.total.median).to.be.below(300);
   });
 
   it('should introduce reasonable first invocation overhead', () => {
-    expect(results.invocation.first.total.median).to.be.below(10);
+    expect(results.get('internal').results.invocation.first.total.median).to.be.below(10);
+    expect(results.get('internalAndExternal').results.invocation.first.total.median).to.be.below(
+      35
+    );
   });
 
   it('should introduce reasonable following invocation overhead', () => {
-    expect(results.invocation.following.total.median).to.be.below(10);
+    expect(results.get('internal').results.invocation.following.total.median).to.be.below(10);
+    expect(results.get('internalAndExternal').results.invocation.first.total.median).to.be.below(
+      35
+    );
   });
 });

--- a/node/packages/aws-lambda-sdk/test/fixtures/dev-mode-extension/extensions/dummy-dev-extension.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/dev-mode-extension/extensions/dummy-dev-extension.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const processStartTime = process.hrtime.bigint();
+
+(async () => {
+  const debugLog = (...args) => {
+    if (process.env.SLS_SDK_DEBUG) {
+      process._rawDebug('⚡ SDK:', ...args);
+    }
+  };
+  debugLog('External initialization');
+
+  let isInitializing = true;
+  let invocationStartTime;
+  let shutdownStartTime;
+
+  const http = require('http');
+
+  const baseUrl = `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-01-01/extension`;
+  const sandboxHostname = process.env.SLS_TEST_EXTENSION_HOSTNAME || 'sandbox';
+
+  const servers = new Set();
+
+  const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+  // Rotate current request data
+  // Each new "platform.start" or invoke event resets the object
+  const getCurrentRequestContext = (() => {
+    let current;
+    return (uniqueEventName) => {
+      if (!current) current = { logsQueue: [] };
+      if (!uniqueEventName) return current;
+      if (current[uniqueEventName]) current = { logsQueue: [] };
+      current[uniqueEventName] = true;
+      return current;
+    };
+  })();
+
+  let invocationEndDeferred;
+  let runtimeDoneDeferred;
+  let resolveRuntimeDoneDeferred;
+
+  const monitorLogs = async (extensionIndentifier) => {
+    let resolveInvocationEndDeferred;
+    const endInvocation = () => {
+      if (resolveInvocationEndDeferred) resolveInvocationEndDeferred();
+      invocationEndDeferred = resolveInvocationEndDeferred = null;
+    };
+
+    const runtimeDone = () => {
+      if (resolveRuntimeDoneDeferred) resolveRuntimeDoneDeferred();
+      runtimeDoneDeferred = resolveRuntimeDoneDeferred = null;
+    };
+
+    // Setup a logs listener server
+    servers.add(
+      http
+        .createServer((request, response) => {
+          if (request.method !== 'POST') throw new Error('Unexpected request method');
+
+          let body = '';
+          request.on('data', (data) => {
+            body += data;
+          });
+          request.on('end', () => {
+            response.writeHead(200, {});
+            response.end('OK');
+            const data = JSON.parse(body);
+
+            for (const event of data) {
+              switch (event.type) {
+                case 'platform.start':
+                  debugLog('platform log: start');
+                  getCurrentRequestContext('start');
+                  // eslint-disable-next-line no-loop-func
+                  invocationEndDeferred = new Promise((resolve) => {
+                    resolveInvocationEndDeferred = resolve;
+                  });
+                  if (!runtimeDoneDeferred) {
+                    // eslint-disable-next-line no-loop-func
+                    runtimeDoneDeferred = new Promise((resolve) => {
+                      resolveRuntimeDoneDeferred = resolve;
+                    });
+                  }
+                  break;
+                case 'platform.runtimeDone':
+                  debugLog('platform log: runtimeDone');
+                  invocationStartTime = process.hrtime.bigint();
+                  runtimeDone();
+                  if (event.record.status === 'success') continue;
+                  endInvocation();
+                  break;
+                case 'platform.report':
+                  debugLog('platform log: report');
+                  endInvocation();
+                  break;
+                default:
+              }
+            }
+          });
+        })
+        .listen(4243, sandboxHostname)
+    );
+
+    await new Promise((resolve, reject) => {
+      const eventTypes = ['platform'];
+      const putData = JSON.stringify({
+        destination: { protocol: 'HTTP', URI: `http://${sandboxHostname}:4243` },
+        types: eventTypes,
+        buffering: { timeoutMs: 25, maxBytes: 262144, maxItems: 1000 },
+        schemaVersion: '2021-03-18',
+      });
+      const request = http.request(
+        `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-08-15/logs`,
+        {
+          agent: keepAliveAgent,
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Lambda-Extension-Identifier': extensionIndentifier,
+            'Content-Length': Buffer.byteLength(putData),
+          },
+        },
+        (response) => {
+          if (response.statusCode === 200) {
+            resolve();
+          } else {
+            reject(
+              new Error(`Unexpected logs subscribe response status code: ${response.statusCode}`)
+            );
+          }
+        }
+      );
+      request.on('error', reject);
+      request.write(putData);
+      request.end();
+    });
+  };
+
+  const monitorEvents = async (extensionIndentifier) => {
+    // Events lifecycle handler
+    const waitForEvent = async () => {
+      debugLog('External ready for an event');
+      const event = await new Promise((resolve, reject) => {
+        if (isInitializing) {
+          isInitializing = false;
+          debugLog(
+            'Overhead duration: External initialization:',
+            `${Math.round(Number(process.hrtime.bigint() - processStartTime) / 1000000)}ms`
+          );
+        } else {
+          debugLog(
+            'Overhead duration: External invocation:',
+            `${Math.round(Number(process.hrtime.bigint() - invocationStartTime) / 1000000)}ms`
+          );
+        }
+        const request = http.request(
+          `${baseUrl}/event/next`,
+          {
+            agent: keepAliveAgent,
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              'Lambda-Extension-Identifier': extensionIndentifier,
+            },
+          },
+          (response) => {
+            debugLog('External received event/next response');
+            if (response.statusCode !== 200) {
+              reject(new Error(`Unexpected register response status code: ${response.statusCode}`));
+              return;
+            }
+            response.setEncoding('utf8');
+            let result = '';
+            response.on('data', (chunk) => {
+              result += String(chunk);
+            });
+            response.on('end', () => {
+              resolve(JSON.parse(result));
+            });
+          }
+        );
+        request.on('error', reject);
+        request.end();
+      });
+      debugLog('External event ', event.eventType);
+      switch (event.eventType) {
+        case 'SHUTDOWN':
+          shutdownStartTime = process.hrtime.bigint();
+          await Promise.resolve(invocationEndDeferred);
+          break;
+        case 'INVOKE':
+          if (!runtimeDoneDeferred) {
+            runtimeDoneDeferred = new Promise((resolve) => {
+              resolveRuntimeDoneDeferred = resolve;
+            });
+          }
+          getCurrentRequestContext('invoke');
+          await Promise.resolve(runtimeDoneDeferred).then(waitForEvent);
+          break;
+        default:
+          throw new Error(`unknown event: ${event.eventType}`);
+      }
+    };
+    await waitForEvent();
+  };
+
+  const monitorInternalTelemetry = () => {
+    servers.add(
+      http
+        .createServer((request, response) => {
+          request.on('data', () => {});
+          request.on('end', () => {
+            response.writeHead(200, '');
+            response.end('OK');
+          });
+        })
+        .listen(2772)
+    );
+  };
+
+  // Register extension
+  await new Promise((resolve, reject) => {
+    const postData = JSON.stringify({ events: ['INVOKE', 'SHUTDOWN'] });
+    const request = http.request(
+      `${baseUrl}/register`,
+      {
+        agent: keepAliveAgent,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Lambda-Extension-Name': 'dummy-dev-extension.js',
+          'Content-Length': Buffer.byteLength(postData),
+        },
+      },
+      (response) => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`Unexpected register response status code: ${response.statusCode}`));
+          return;
+        }
+
+        const extensionIdentifier = response.headers['lambda-extension-identifier'];
+        monitorInternalTelemetry();
+        resolve(
+          Promise.all([monitorEvents(extensionIdentifier), monitorLogs(extensionIdentifier)])
+        );
+      }
+    );
+    request.on('error', reject);
+    request.write(postData);
+    request.end();
+  });
+
+  for (const server of servers) server.close();
+  debugLog(
+    'Overhead duration: External shutdown:',
+    `${Math.round(Number(process.hrtime.bigint() - shutdownStartTime) / 1000000)}ms`
+  );
+  process.exit();
+})().catch((error) => {
+  // Ensure to crash extension process on unhandled rejection
+  process.nextTick(() => {
+    throw error;
+  });
+});

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1062,8 +1062,60 @@ describe('integration', function () {
       'multi-async',
       {
         variants: new Map([
-          ['v14', { configuration: { Runtime: 'nodejs14.x' } }],
-          ['v16', { configuration: { Runtime: 'nodejs16.x' } }],
+          [
+            'v14',
+            {
+              config: { configuration: { Runtime: 'nodejs14.x' } },
+              variants: new Map([
+                [
+                  'dev-mode',
+                  {
+                    configuration: {
+                      Environment: {
+                        Variables: {
+                          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
+                          SLS_ORG_ID: process.env.SLS_ORG_ID,
+                          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
+                          SLS_SDK_DEBUG: '1',
+                        },
+                      },
+                    },
+                    deferredConfiguration: () => ({
+                      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
+                    }),
+                  },
+                ],
+                ['regular', {}],
+              ]),
+            },
+          ],
+          [
+            'v16',
+            {
+              config: { configuration: { Runtime: 'nodejs16.x' } },
+              variants: new Map([
+                [
+                  'dev-mode',
+                  {
+                    configuration: {
+                      Environment: {
+                        Variables: {
+                          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
+                          SLS_ORG_ID: process.env.SLS_ORG_ID,
+                          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
+                          SLS_SDK_DEBUG: '1',
+                        },
+                      },
+                    },
+                    deferredConfiguration: () => ({
+                      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
+                    }),
+                  },
+                ],
+                ['regular', {}],
+              ]),
+            },
+          ],
         ]),
         config: {
           test: ({ invocationsData }) => {
@@ -1135,6 +1187,7 @@ describe('integration', function () {
 
   before(async () => {
     await createCoreResources(coreConfig);
+
     for (const testConfig of testVariantsConfig) {
       testConfig.deferredResult = processFunction(testConfig, coreConfig).catch((error) => ({
         // As we process result promises sequentially step by step in next turn, allowing them to

--- a/node/packages/aws-lambda-sdk/test/lib/create-core-resources.js
+++ b/node/packages/aws-lambda-sdk/test/lib/create-core-resources.js
@@ -131,7 +131,7 @@ module.exports = async (config, options = {}) => {
   config.accountId = (await awsRequest(STS, 'getCallerIdentity')).Account;
 
   await Promise.all([
-    createLayers(config, options.layerTypes || ['nodeInternal']),
+    createLayers(config, options.layerTypes || ['nodeInternal', 'nodeExternal']),
     createRole(config),
   ]);
 };

--- a/node/packages/aws-lambda-sdk/test/lib/process-function.js
+++ b/node/packages/aws-lambda-sdk/test/lib/process-function.js
@@ -5,7 +5,6 @@ const log = require('log').get('test');
 const { CloudWatchLogs } = require('@aws-sdk/client-cloudwatch-logs');
 const { Lambda } = require('@aws-sdk/client-lambda');
 const { TracePayload } = require('@serverless/sdk-schema/dist/trace');
-const { RequestResponse } = require('@serverless/sdk-schema/dist/request_response');
 const wait = require('timers-ext/promise/sleep');
 const basename = require('./basename');
 const awsRequest = require('../utils/aws-request');
@@ -228,21 +227,6 @@ const retrieveReports = async (testConfig) => {
         } else {
           startedMessage = payloadString;
           startedMessageType = 'trace';
-        }
-        continue;
-      }
-      if (message.startsWith('SERVERLESS_TELEMETRY.R.')) {
-        const payloadString = message.slice(message.indexOf('.R.') + 3);
-        if (payloadString.endsWith('\n')) {
-          const invocationData = getCurrentInvocationData();
-          const payload = normalizeProtoObject(
-            RequestResponse.decode(Buffer.from(payloadString.trim(), 'base64'))
-          );
-          if (payload.data.$case === 'responseData') invocationData.response = payload;
-          else invocationData.request = payload;
-        } else {
-          startedMessage = payloadString;
-          startedMessageType = getCurrentInvocationData().request ? 'response' : 'request';
         }
         continue;
       }

--- a/node/packages/aws-lambda-sdk/test/lib/process-function.js
+++ b/node/packages/aws-lambda-sdk/test/lib/process-function.js
@@ -24,7 +24,7 @@ const reportPattern = new RegExp(
 const handledOutcomes = new Set(['success', 'error:handled']);
 
 const create = async (testConfig, coreConfig) => {
-  const { configuration } = testConfig;
+  const { configuration, deferredConfiguration } = testConfig;
   const resultConfiguration = {
     Role: coreConfig.roleArn,
     Runtime: 'nodejs16.x',
@@ -42,6 +42,7 @@ const create = async (testConfig, coreConfig) => {
     },
     Timeout: 10,
     ...configuration,
+    ...deferredConfiguration?.(testConfig, coreConfig),
   };
   if (process.env.SERVERLESS_PLATFORM_STAGE === 'dev') {
     resultConfiguration.Environment.Variables.SERVERLESS_PLATFORM_STAGE = 'dev';

--- a/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
+++ b/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
@@ -24,18 +24,21 @@ require('../benchmark')({
     `${[
       [
         'name',
-        'init:internal',
+        'init:internal:overhead',
+        'init:internal:total',
         'init:total',
 
-        'first:internal:request',
-        'first:internal:response',
+        'first:internal:request-overhead',
+        'first:internal:response-overhead',
+        'first:internal:total',
         'first:total',
         'first:billed',
         'first:local',
         'first:maxMemoryUsed',
 
-        'following:internal:request',
-        'following:internal:response',
+        'following:internal:request-overhead',
+        'following:internal:response-overhead',
+        'following:internal:total',
         'following:total',
         'following:billed',
         'following:local',
@@ -49,18 +52,27 @@ require('../benchmark')({
           ([benchmarkVariantName, { results: benchmarkVariantResults }]) =>
             [
               JSON.stringify(`${functionVariantName}:${benchmarkVariantName}`),
-              Math.round(benchmarkVariantResults.initialization.internal.average),
+              Math.round(benchmarkVariantResults.initialization.internal.overhead.average),
+              Math.round(benchmarkVariantResults.initialization.internal.total.average),
               Math.round(benchmarkVariantResults.initialization.total.average),
 
-              Math.round(benchmarkVariantResults.invocation.first.internal.request.average),
-              Math.round(benchmarkVariantResults.invocation.first.internal.response.average),
+              Math.round(benchmarkVariantResults.invocation.first.internal.requestOverhead.average),
+              Math.round(
+                benchmarkVariantResults.invocation.first.internal.responseOverhead.average
+              ),
+              Math.round(benchmarkVariantResults.invocation.first.internal.total.average),
               Math.round(benchmarkVariantResults.invocation.first.total.average),
               Math.round(benchmarkVariantResults.invocation.first.billed.average),
               Math.round(benchmarkVariantResults.invocation.first.local.average),
               Math.round(benchmarkVariantResults.invocation.first.maxMemoryUsed.average),
 
-              Math.round(benchmarkVariantResults.invocation.following.internal.request.average),
-              Math.round(benchmarkVariantResults.invocation.following.internal.response.average),
+              Math.round(
+                benchmarkVariantResults.invocation.following.internal.requestOverhead.average
+              ),
+              Math.round(
+                benchmarkVariantResults.invocation.following.internal.responseOverhead.average
+              ),
+              Math.round(benchmarkVariantResults.invocation.following.internal.total.average),
               Math.round(benchmarkVariantResults.invocation.following.total.average),
               Math.round(benchmarkVariantResults.invocation.following.billed.average),
               Math.round(benchmarkVariantResults.invocation.following.local.average),

--- a/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
+++ b/node/packages/aws-lambda-sdk/test/scripts/benchmark.js
@@ -24,12 +24,14 @@ require('../benchmark')({
     `${[
       [
         'name',
+        'init:external:overhead',
         'init:internal:overhead',
         'init:internal:total',
         'init:total',
 
         'first:internal:request-overhead',
         'first:internal:response-overhead',
+        'first:external:response-overhead',
         'first:internal:total',
         'first:total',
         'first:billed',
@@ -38,6 +40,7 @@ require('../benchmark')({
 
         'following:internal:request-overhead',
         'following:internal:response-overhead',
+        'following:external:response-overhead',
         'following:internal:total',
         'following:total',
         'following:billed',
@@ -52,6 +55,7 @@ require('../benchmark')({
           ([benchmarkVariantName, { results: benchmarkVariantResults }]) =>
             [
               JSON.stringify(`${functionVariantName}:${benchmarkVariantName}`),
+              Math.round(benchmarkVariantResults.initialization.externalOverhead.average),
               Math.round(benchmarkVariantResults.initialization.internal.overhead.average),
               Math.round(benchmarkVariantResults.initialization.internal.total.average),
               Math.round(benchmarkVariantResults.initialization.total.average),
@@ -60,6 +64,7 @@ require('../benchmark')({
               Math.round(
                 benchmarkVariantResults.invocation.first.internal.responseOverhead.average
               ),
+              Math.round(benchmarkVariantResults.invocation.first.externalResponseOverhead.average),
               Math.round(benchmarkVariantResults.invocation.first.internal.total.average),
               Math.round(benchmarkVariantResults.invocation.first.total.average),
               Math.round(benchmarkVariantResults.invocation.first.billed.average),
@@ -71,6 +76,9 @@ require('../benchmark')({
               ),
               Math.round(
                 benchmarkVariantResults.invocation.following.internal.responseOverhead.average
+              ),
+              Math.round(
+                benchmarkVariantResults.invocation.following.externalResponseOverhead.average
               ),
               Math.round(benchmarkVariantResults.invocation.following.internal.total.average),
               Math.round(benchmarkVariantResults.invocation.following.total.average),

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -5,6 +5,7 @@ const path = require('path');
 const http = require('http');
 const isThenable = require('type/thenable/is');
 const requireUncached = require('ncjsm/require-uncached');
+const wait = require('timers-ext/promise/sleep');
 const normalizeObject = require('../../utils/normalize-proto-object');
 const pkgJson = require('../../../package');
 
@@ -20,11 +21,12 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
   const payload = options.payload || { test: true };
   const stringifiedPayload = JSON.stringify(payload);
   const outcome = await requireUncached(async () => {
-    await require('../../../internal-extension');
+    require('../../../internal-extension');
     const handlerModule = await require('../../../internal-extension/wrapper');
+    // Ensure tick gap between handler resolution and its invocation (reflects AWS env)
+    await wait();
     let result;
     let error;
-
     try {
       result = await new Promise((resolve, reject) => {
         const maybeThenable = handlerModule.handler(

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -881,11 +881,14 @@ describe('internal-extension/index.test.js', () => {
           }
         })
       ).to.deep.equal([
+        {
+          type: 'trace',
+          spans: [{ name: 'aws.lambda.initialization', tags: {} }],
+        },
         { type: 'request-response', data: { $case: 'requestData' } },
         {
           type: 'trace',
           spans: [
-            { name: 'aws.lambda.initialization', tags: {} },
             { name: 'express.middleware.query', tags: {} },
             { name: 'express.middleware.expressinit', tags: {} },
             { name: 'express.middleware.jsonparser', tags: {} },


### PR DESCRIPTION
Fix handling of telemetry requests with dev mode enabled

Additionally:
- Introduce dummy external extension to take payloads from internal, to enable better testing of dev mode.
- Update benchmarks to cover also external extension case and ensure performance check is run in CI