### PR TITLE
Optional telemetry data on dev mode proto

### DIFF
--- a/go/packages/dev-mode/README.md
+++ b/go/packages/dev-mode/README.md
@@ -18,7 +18,6 @@ After the layer is deployed you can attach this layer to any lambda function, ju
 | `SLS_DEV_MODE_ORG_ID` | This is the id of the org that you will be publishing to | `true` |
 | `SLS_PUBLISH_ENDPOINT` | This is endpoint that you want logs to be forwarded to. This is helpful if you are trying to send logs to dev. | `false` |
 
-
 ## Testing
 This app is reusing unit tests from our node extension so the unit tests live in `../node/packages/aws-lambda-otel-extension/test/unit/external/index.test.ts`
 

--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -17,10 +17,24 @@ message DevModePayload {
   // The lambda request id where this payload originated from
   string request_id = 3;
 
+  // Extracted Lambda Telemetry API data
+  optional LambdaTelemetry telemetry = 6;
+
   oneof payload {
     // The set of lambda traces that were generated via an internal extension
     TracePayload trace = 4;
     // The req or response data from the instrumented lambda function
     RequestResponse request_response = 5;
   }
+}
+
+// Lambda Telemetry API data. This data is only available for lambda functions that
+// have access to the telemetry API so it will not be included in all regions.
+message LambdaTelemetry {
+  // Init duration as reported by the metrics on the platform.initReport event
+  optional uint32 init_duration = 1;
+  // Internal runtime duration as reported by the metrics on the platform.runtimeDone event
+  optional uint32 internal_duration = 2;
+  // Internal runtime duration as reported by the responseLatency span on the platform.runtimeDone event
+  optional uint32 internal_response_latency = 3;
 }

--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -31,10 +31,10 @@ message DevModePayload {
 // Lambda Telemetry API data. This data is only available for lambda functions that
 // have access to the telemetry API so it will not be included in all regions.
 message LambdaTelemetry {
-  // Init duration as reported by the metrics on the platform.initReport event
-  optional uint32 init_duration = 1;
-  // Internal runtime duration as reported by the metrics on the platform.runtimeDone event
-  optional uint32 internal_duration = 2;
-  // Internal runtime duration as reported by the responseLatency span on the platform.runtimeDone event
-  optional uint32 internal_response_latency = 3;
+  // Init duration in milliseconds as reported by the metrics on the platform.initReport event
+  optional uint32 init_duration_ms = 1;
+  // Internal runtime duration in milliseconds as reported by the metrics on the platform.runtimeDone event
+  optional uint32 internal_duration_ms = 2;
+  // Internal runtime duration in milliseconds as reported by the responseLatency span on the platform.runtimeDone event
+  optional uint32 internal_response_latency_ms = 3;
 }

--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -34,7 +34,7 @@ message LambdaTelemetry {
   // Init duration in milliseconds as reported by the metrics on the platform.initReport event
   optional uint32 init_duration_ms = 1;
   // Internal runtime duration in milliseconds as reported by the metrics on the platform.runtimeDone event
-  optional uint32 internal_duration_ms = 2;
+  optional uint32 runtime_duration_ms = 2;
   // Internal runtime duration in milliseconds as reported by the responseLatency span on the platform.runtimeDone event
-  optional uint32 internal_response_latency_ms = 3;
+  optional uint32 runtime_response_latency_ms = 3;
 }


### PR DESCRIPTION
## Description
Adding a place on the dev mode proto payload so we can add some supporting data from the lambda telemetry API.