### PR TITLE
SDK Schema: Move span `input` and `output` data to top level properties

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -147,8 +147,8 @@ message AwsLambdaInvocationTags {
 
 message AwsSdkTags {
   // Retrieving AWS Account id is not straightforward therefore we it's not pursued at this point
-  reserved 1;
-  reserved "account_id";
+  reserved 1, 8, 9;
+  reserved "account_id", "request_body", "response_body";
 
   // The AWS Region this SDK call is being made against.
   optional string region = 2;
@@ -162,10 +162,6 @@ message AwsSdkTags {
   optional string request_id = 6;
   // An optional error returned from the AWS APIs.
   optional string error = 7;
-  // Request body
-  optional string request_body = 8;
-  // Response body
-  optional string response_body = 9;
 
   optional AwsSdkDynamodbTags dynamodb = 100;
   optional AwsSdkSqsTags sqs = 101;

--- a/proto/serverless/instrumentation/tags/v1/common.proto
+++ b/proto/serverless/instrumentation/tags/v1/common.proto
@@ -6,8 +6,8 @@ option go_package = ".;protoc";
 
 // Generic tagset intended to describe incoming or outgoing HTTP requests
 message HttpTags {
-  reserved 5, 7, 10, 11;
-  reserved "query", "request_headers", "response_headers", "response_header_names";
+  reserved 5, 7, 10, 11, 13, 14;
+  reserved "query", "request_headers", "response_headers", "response_header_names", "request_body", "response_body";
 
   // The method of the HTTP Request
   string method = 1;
@@ -21,15 +21,10 @@ message HttpTags {
   repeated string query_parameter_names = 6;
   // Request header names
   repeated string request_header_names = 8;
-  // Request body
-  optional string request_body = 13;
 
   // The Response Status Code.
   optional uint32 status_code = 9;
   // Eventual request error code
   optional string error_code = 12;
-  // Response body
-  optional string response_body = 14;
-
 }
 

--- a/proto/serverless/instrumentation/v1/trace.proto
+++ b/proto/serverless/instrumentation/v1/trace.proto
@@ -14,7 +14,6 @@ option go_package = ".;protoc";
 message TracePayload {
     serverless.instrumentation.tags.v1.SlsTags sls_tags = 1;
 
-
     // A list of Spans to be ingest. Ingest does not impose a limit on the
     // number of Spans in a single payload. It is the responsibility of the
     // Span producers to limit the size of payloads based on their own requirements.
@@ -47,6 +46,11 @@ message Span {
     // An important invariant to keep in mind is that the root span will always have
     // the latest end time.
     fixed64 end_time_unix_nano = 6;
+
+    // Eventual input body (e.g. HTTP request body)
+    optional string input = 8;
+    // Eventual output body (e.g. HTTP response body)
+    optional string output = 9;
 
     // A message containing any number of Tagsets
     serverless.instrumentation.tags.v1.Tags tags = 7;


### PR DESCRIPTION
BREAKING CHANGE:
- `http.request_body`, `http.response_body`, `aws.sdk.request_body` and `aws.sdk.response_body` tags are removed in favor of top level `input and `output` properties