### PR TITLE
Updated proto schemas to better match the ingest process

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -12,6 +12,28 @@ message AwsTags {
   // The AWS SDK Tags. These are only added when instrumented code
   // makes a call to one of the AWS SDK functions
   optional AwsSdkTags sdk = 101;
+
+  // Account Id is added to all schemas originating from aws during ingest as part of our data enrichment process
+  optional string account_id = 102;
+  // Region is added to all schemas originating from aws during ingest as part of our data enrichment process
+  optional string region = 103;
+  // RequestId is added to all schemas originating from aws lambda during ingest as part of our data enrichment process
+  optional string request_id = 104;
+  // ResourceName is added to all schemas originating from aws lambda during ingest as part of our data enrichment process
+  optional string resource_name = 105;
+
+  // The monotonically increasing sequence id for a LogEvent originating from aws lambda.
+  // This is used to determine the ordering of messages in a given stream of logs.
+  // If this is a LogEvent coming from Cloudwatch Logs, it will be provided
+  // otherwise it is the responsibility of the log producer to generate
+  // a sequence id.
+  optional string sequence_id = 3;
+
+  // The Cloudwatch Log Group name for logs originating from aws lambda.
+  optional string log_group = 4;
+
+  // The Cloudwatch Log Group Stream id for logs originating from aws lambda.
+  optional string log_stream = 5;
 }
 
 message AwsApiGatewayTags {

--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -20,6 +20,16 @@ message Tags {
 
   // These tags are used when an http library is making a https request
   optional serverless.instrumentation.tags.v1.HttpTags https = 107;
+
+  // These sls tags are added at ingest time to each span so that is why this is marked as optional here
+  optional serverless.instrumentation.tags.v1.SlsTags sls_tags = 108;
+
+  // Environment is added to all schemas during ingest as part of our data enrichment process
+  optional string environment = 109;
+  // Namespace is added to all schemas during ingest as part of our data enrichment process
+  optional string namespace = 110;
+  // OrgId is added to all schemas during ingest as part of our data enrichment process
+  optional string org_id = 111;
 }
 
 message SlsTags {

--- a/proto/serverless/instrumentation/v1/log.proto
+++ b/proto/serverless/instrumentation/v1/log.proto
@@ -19,38 +19,27 @@ message LogPayload {
 }
 
 message LogEvent {
-
-    // The LogEvent's body.
-    string message = 1;
+    reserved 1, 3, 4, 5, 6, 7;
+    reserved "message", "sequence_id", "log_group", "log_stream", "account_id", "request_id";
 
     // The timestamp of when the LogEvent was created.
     fixed64 timestamp = 2;
-
-    // The monotonically increasing sequence id for a LogEvent. This is used
-    // to determine the ordering of messages in a given stream of logs.
-    // If this is a LogEvent coming from Cloudwatch Logs, it will be provided
-    // otherwise it is the responsibility of the log producer to generate
-    // a sequence id.
-    string sequence_id = 3;
-
-    // The Cloudwatch Log Group name.
-    optional string log_group = 4;
-
-    // The Cloudwatch Log Group Stream id.
-    optional string log_stream = 5;
-
-    // The Owner Account Id of the Cloudwatch Log Group.
-    optional string account_id = 6;
-
-    // The Lambda request Id that the log's are linked to.
-    // When ingesting LogEvents, ingest will attempt to infer
-    // the request_id from the payload and attach it. If it is not
-    // able to, then it will attempt to reconcile later.
-    optional string request_id = 7;
 
     // The Trace Id that the log's are linked to.
     // When ingesting LogEvents, ingest will attempt to infer
     // the request_id from the payload and attach it. If it is not
     // able to, then it will attempt to reconcile later.
     optional string trace_id = 8;
+
+    // The LogEvent's body.
+    string body = 9;
+
+    // The calculated severity text value for a log
+    string severity_text = 10;
+
+    // The calculated severity text value for a log
+    uint64 severity_number = 11;
+
+    // A message containing any number of Tagsets
+    optional serverless.instrumentation.tags.v1.Tags tags = 12;
 }

--- a/proto/serverless/instrumentation/v1/request_response.proto
+++ b/proto/serverless/instrumentation/v1/request_response.proto
@@ -26,4 +26,7 @@ message RequestResponse {
     string request_data = 5;
     string response_data = 6;
   };
+
+  // A message containing any number of Tagsets
+  optional serverless.instrumentation.tags.v1.Tags tags = 7;
 }


### PR DESCRIPTION
## Description
There are some things we need to do on ingest to enrich the logs and req_res data so it is easier to search and more consistent.

This PR does a few things in the name of consistency 👇 

- Adds the standard `aws` fields we need so we can consistently access logs/req_res/spans (accountId, region, requestId, resourceName, logGroup, logStream, sequenceId)
- Adds `slsTags` to the `tags` section so we can copy this object to app spans in a trace payload
- Changes the log format to match what we want to write to opensearch
- Updates req_res proto to include tags so we can tag req_res data the same way we are tagging logs and spans
