### PR TITLE
chore: Release v0.12.0

### DIFF
--- a/node/packages/sdk-schema/CHANGELOG.md
+++ b/node/packages/sdk-schema/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.11.1](https://github.com/serverless/console/compare/@serverless/sdk-schema@0.11.0...@serverless/sdk-schema@0.11.1) (2022-10-20)
+
+### Features
+
+- Updated logs schema to support ingest process a bit better ([f217ea2](https://github.com/serverless/console/commit/f217ea24e86352b7d5ac1f877180b8037778bcec))
+
 ## [0.11.0](https://github.com/serverless/console/compare/@serverless/sdk-schema@0.10.1...@serverless/sdk-schema@0.11.0) (2022-10-20)
 
 ### ⚠ BREAKING CHANGES

--- a/node/packages/sdk-schema/CHANGELOG.md
+++ b/node/packages/sdk-schema/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.11.1](https://github.com/serverless/console/compare/@serverless/sdk-schema@0.11.0...@serverless/sdk-schema@0.11.1) (2022-10-20)
+### [0.12.0](https://github.com/serverless/console/compare/@serverless/sdk-schema@0.11.0...@serverless/sdk-schema@0.11.1) (2022-10-20)
 
-### Features
+### ⚠ BREAKING CHANGES
 
 - Updated logs schema to support ingest process a bit better ([f217ea2](https://github.com/serverless/console/commit/f217ea24e86352b7d5ac1f877180b8037778bcec))
 

--- a/node/packages/sdk-schema/package.json
+++ b/node/packages/sdk-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/sdk-schema",
   "repository": "serverless/console",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/node/packages/sdk-schema/package.json
+++ b/node/packages/sdk-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/sdk-schema",
   "repository": "serverless/console",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/proto/README.md
+++ b/proto/README.md
@@ -12,6 +12,6 @@
 
 1. From `./proto` run `buf build && buf generate`
 1. From `./node` run `npm install`
-2. From `./node/packages/sdk-schema` run `npm build`
+2. From `./node/packages/sdk-schema` run `npm run build`
 
 You now have a built package that you can either link locally or publish.


### PR DESCRIPTION
## Description
Releasing v0.12.0 so we can update our node ingest service to use the new log schema. I was still doing some research so I didn't know we needed this. Sorry gang 😅 

> Update: realized this is a breaking change for the log payload so I marked it that way 😎 