### PR TITLE
Moved sdk to root tags

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -8,6 +8,8 @@ import "serverless/instrumentation/tags/v1/common.proto";
 option go_package = ".;protoc";
 
 message Tags {
+  reserved 108;
+  reserved "sls_tags";
   // ============================================ //
   // Defined TagSets start at field number 100  //
   // ========================================== //
@@ -21,8 +23,8 @@ message Tags {
   // These tags are used when an http library is making a https request
   optional serverless.instrumentation.tags.v1.HttpTags https = 107;
 
-  // These sls tags are added at ingest time to each span so that is why this is marked as optional here
-  optional serverless.instrumentation.tags.v1.SlsTags sls_tags = 108;
+  // These sdk tags are added at ingest time so we know where the data was generated from
+  optional serverless.instrumentation.tags.v1.SdkTags sdk = 109;
 
   // Environment is added to all schemas during ingest as part of our data enrichment process
   optional string environment = 109;
@@ -42,14 +44,7 @@ message SlsTags {
   // The region that instrumentation was performed in. This is used to determine which Serverless Ingest API to use.
   optional string region = 4;
 
-  message SdkTags {
-    // The Name of the Serverless SDK used to instrument.
-    string name = 1;
-    // The version of the Serverless SDK used to instrument.
-    string version = 2;
-  }
-
-  SdkTags sdk = 5;
+  serverless.instrumentation.tags.v1.SdkTags sdk = 5;
 
   // An optional environment that can be attached. If there is an applicable
   // environment tag this will be attached in a data enrichment process during
@@ -59,4 +54,11 @@ message SlsTags {
   // namespace tag this will be attached in a data enrichment process during
   // ingestion.
   optional string namespace = 17;
+}
+
+message SdkTags {
+  // The Name of the Serverless SDK used to instrument.
+  string name = 1;
+  // The version of the Serverless SDK used to instrument.
+  string version = 2;
 }

--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -24,7 +24,7 @@ message Tags {
   optional serverless.instrumentation.tags.v1.HttpTags https = 107;
 
   // These sdk tags are added at ingest time so we know where the data was generated from
-  optional serverless.instrumentation.tags.v1.SdkTags sdk = 109;
+  optional serverless.instrumentation.tags.v1.SdkTags sdk = 112;
 
   // Environment is added to all schemas during ingest as part of our data enrichment process
   optional string environment = 109;

--- a/proto/serverless/instrumentation/v1/request_response.proto
+++ b/proto/serverless/instrumentation/v1/request_response.proto
@@ -36,4 +36,7 @@ message RequestResponse {
 
   // Type is used to determine the kind of document that is being send via a livestream
   optional string type = 9;
+
+  // The timestamp of when the req/res data was generated.
+  optional fixed64 timestamp = 10;
 }


### PR DESCRIPTION
## Description
We were wanted to trim down what is saved in opensearch to only things that are relevant. So we are replacing `slsTags` with `sdk`. I had also noticed that req/res payloads do not include a timestamp so I went ahead and added that 🤷 