### PR TITLE
bug: Matched invocation start/end time

### DIFF
--- a/node/packages/aws-lambda-sdk/CHANGELOG.md
+++ b/node/packages/aws-lambda-sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.10.2](https://github.com/serverless/console/compare/@serverless/aws-lambda-sdk@0.10.1...@serverless/aws-lambda-sdk@0.10.2) (2022-10-24)
+
+### Features
+
+- Added timestamp to req/res payloads ([#280](https://github.com/serverless/console/issues/280)) ([ffc1dcd](https://github.com/serverless/console/commit/ffc1dcd423dee1bf9d6142df17a8d9b23a451049))
+
+### Bug Fixes
+
+- Matched invocation start/end time ([1080d28](https://github.com/serverless/console/commit/1080d286132430804f48bfe01ba7fab676135124))
+
 ### [0.10.1](https://github.com/serverless/console/compare/@serverless/aws-lambda-sdk@0.10.0...@serverless/aws-lambda-sdk@0.10.1) (2022-10-21)
 
 ## [0.10.0](https://github.com/serverless/console/compare/@serverless/aws-lambda-sdk@0.9.1...@serverless/aws-lambda-sdk@0.10.0) (2022-10-20)

--- a/node/packages/aws-lambda-sdk/lib/trace-span/index.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/index.js
@@ -319,6 +319,12 @@ class TraceSpan {
     emitter.emit('close', this);
     return this;
   }
+  getStartTime() {
+    return toLong(resolveEpochTimestampString(this.startTime));
+  }
+  getEndTime() {
+    return toLong(resolveEpochTimestampString(this.endTime));
+  }
   destroy() {
     this.closeContext();
     this.parentSpan?.subSpans.delete(this);

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/aws-lambda-sdk",
   "repository": "serverless/console",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "Serverless, Inc.",
   "dependencies": {
     "@serverless/sdk-schema": "^0.12.1",


### PR DESCRIPTION
## Description
When I was trying out #280 as a custom build before cutting the release I realized that since the `resolveEpochTimestampString` would be initialized in two places they would have a different `diff` time they were comparing against which results the req/res times being slightly off from the `aws.lambda.invocation` start/end times.

This PR fixes that by adding a `getStartTime` and `getEndTime` method to the `TraceSpan` class so we can get the exact start/end time of a `TraceSpan`. This also resolves the comment I mentioned in the last PR where we were duplicating code 😉 