### PR TITLE
AWS Lambda SDK: Cleanup and tests improvements

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/trace-span/index.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/index.js
@@ -34,6 +34,9 @@ const toLong = (value) => {
   return new Long(data.low, data.high, true);
 };
 
+const toProtobufEpochTimestamp = (uptimeTimestamp) =>
+  toLong(resolveEpochTimestampString(uptimeTimestamp));
+
 const resolvePorotbufValue = (key, value) => {
   switch (key) {
     // enum cases
@@ -319,12 +322,6 @@ class TraceSpan {
     emitter.emit('close', this);
     return this;
   }
-  getStartTime() {
-    return toLong(resolveEpochTimestampString(this.startTime));
-  }
-  getEndTime() {
-    return toLong(resolveEpochTimestampString(this.endTime));
-  }
   destroy() {
     this.closeContext();
     this.parentSpan?.subSpans.delete(this);
@@ -359,8 +356,8 @@ class TraceSpan {
       traceId: Buffer.from(this.traceId),
       parentSpanId: this.parentSpan ? Buffer.from(this.parentSpan.id) : undefined,
       name: this.name,
-      startTimeUnixNano: toLong(resolveEpochTimestampString(this.startTime)),
-      endTimeUnixNano: this.endTime ? toLong(resolveEpochTimestampString(this.endTime)) : undefined,
+      startTimeUnixNano: toProtobufEpochTimestamp(this.startTime),
+      endTimeUnixNano: this.endTime ? toProtobufEpochTimestamp(this.endTime) : undefined,
       input: this.input || undefined,
       output: this.output || undefined,
       tags,
@@ -387,6 +384,8 @@ class TraceSpan {
     else this._output = ensureString(body);
   }
 }
+
+TraceSpan._toProtobufEpochTimestamp = toProtobufEpochTimestamp;
 
 Object.defineProperties(
   TraceSpan.prototype,

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -560,7 +560,7 @@ describe('integration', function () {
                   });
                 },
               },
-              invoke: async (testConfig) => {
+              invoke: async function self(testConfig) {
                 const startTime = process.hrtime.bigint();
                 const response = await fetch(
                   `https://${testConfig.restApiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test/some-path/some-param`,
@@ -573,6 +573,10 @@ describe('integration', function () {
                   }
                 );
                 if (response.status !== 200) {
+                  if (response.status === 404) {
+                    await wait(1000);
+                    return self(testConfig);
+                  }
                   throw new Error(`Unexpected response status: ${response.status}`);
                 }
                 const payload = { raw: await response.text() };
@@ -616,7 +620,7 @@ describe('integration', function () {
                   await awsRequest(ApiGatewayV2, 'deleteApi', { ApiId: testConfig.apiId });
                 },
               },
-              invoke: async (testConfig) => {
+              invoke: async function self(testConfig) {
                 const startTime = process.hrtime.bigint();
                 const response = await fetch(
                   `https://${testConfig.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test`,
@@ -629,6 +633,10 @@ describe('integration', function () {
                   }
                 );
                 if (response.status !== 200) {
+                  if (response.status === 404) {
+                    await wait(1000);
+                    return self(testConfig);
+                  }
                   throw new Error(`Unexpected response status: ${response.status}`);
                 }
                 const payload = { raw: await response.text() };
@@ -669,7 +677,7 @@ describe('integration', function () {
                   await awsRequest(ApiGatewayV2, 'deleteApi', { ApiId: testConfig.apiId });
                 },
               },
-              invoke: async (testConfig) => {
+              invoke: async function self(testConfig) {
                 const startTime = process.hrtime.bigint();
                 const response = await fetch(
                   `https://${testConfig.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test`,
@@ -682,6 +690,10 @@ describe('integration', function () {
                   }
                 );
                 if (response.status !== 200) {
+                  if (response.status === 404) {
+                    await wait(1000);
+                    return self(testConfig);
+                  }
                   throw new Error(`Unexpected response status: ${response.status}`);
                 }
                 const payload = { raw: await response.text() };
@@ -766,7 +778,7 @@ describe('integration', function () {
                   });
                 },
               },
-              invoke: async (testConfig) => {
+              invoke: async function self(testConfig) {
                 const startTime = process.hrtime.bigint();
                 const response = await fetch(`${testConfig.functionUrl}/test?foo=bar`, {
                   method: 'POST',
@@ -776,6 +788,10 @@ describe('integration', function () {
                   },
                 });
                 if (response.status !== 200) {
+                  if (response.status === 404) {
+                    await wait(1000);
+                    return self(testConfig);
+                  }
                   throw new Error(`Unexpected response status: ${response.status}`);
                 }
                 const payload = { raw: await response.text() };
@@ -988,7 +1004,7 @@ describe('integration', function () {
             await awsRequest(ApiGatewayV2, 'deleteApi', { ApiId: testConfig.apiId });
           },
         },
-        invoke: async (testConfig) => {
+        invoke: async function self(testConfig) {
           const startTime = process.hrtime.bigint();
           const response = await fetch(
             `https://${testConfig.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test`,
@@ -1001,6 +1017,10 @@ describe('integration', function () {
             }
           );
           if (response.status !== 200) {
+            if (response.status === 404) {
+              await wait(1000);
+              return self(testConfig);
+            }
             throw new Error(`Unexpected response status: ${response.status}`);
           }
           const payload = { raw: await response.text() };


### PR DESCRIPTION
- Cleanup support for `timestamp` on request and response payloads (so no public API is affected)
- Workaround occasional race condition on AWS side, where deployed endpoints are not available right away (remedy for https://github.com/serverless/console/actions/runs/3291396523/jobs/5425513617)