### PR TITLE
docs: Update docs for Nov 1st release

### DIFF
--- a/docs/product/upgrade-guide.md
+++ b/docs/product/upgrade-guide.md
@@ -14,14 +14,9 @@ things you will need to do to upgrade to the latest Serverless Console.
 ## Action Items
 - You MUST remove `console: true` from all `serverless.yml` files. Deployments
 with `console: true` in the `serverless.yml` will fail if you are on version
-older than 3.24.0 of the Serverless Framework. Deployments with `console: true`
-in the `serverless.yml` will succeed, but present a deprecation warning if you
-are on version 3.24.0 or newer of the Serverless Framework.
+older than 3.24.0 of the Serverless Framework.
 - You SHOULD remove `org: <org>` from all `severless.yml` files, if you are not
 also using Serverless Dashboard.
-- You MUST upgrade Serverless Framework to version 3.24.0 or new with
-`npm i serverless -g`. This version is required to upgrade to the new Serverless
-Console version.
 - You MUST visit https://console.serverless.com to reconnect your AWS account.
 
 ## FAQ

--- a/docs/product/upgrade-guide.md
+++ b/docs/product/upgrade-guide.md
@@ -6,28 +6,19 @@ menuOrder: 7
 -->
 # Upgrade Guide
 
-On **Tuesday, November 1st at 10AM PDT**, we will be releasing a new version
-of Serverless Console which will break existing deployments with the Serverless
-Console extension. There are a few things you will need to do before and after
-the release of the new Serverless Console.
+On **Tuesday, November 1st at 10AM PDT**, we released a new version of
+Serverless Console which breaks deployments with the Serverless Console
+extension on Serverless Framework version 3.23.0 and earlier. There are a few
+things you will need to do to upgrade to the latest Serverless Console.
 
-## Action items before November 1st at 10AM PDT:
-- You MUST remove `console: true` from all `serverless.yml` files. Deployments
-after November 1st at 10AM will fail if `console: true` is present in the
-`serverless.yml`. You can continue to deploy with `console: true` until then.
-You can also continue to use Serverless Console without change until then.
-
-- If you don’t also use Serverless Dashboard, then you SHOULD remove
-`org: <org>` from all `severless.yml` files.
-- Join the [Console community channel in Slack](https://serverless-contrib.slack.com/archives/C037D989FB5)
-for up to date changes. We are doing our best to release at this time, but if
-there are changes you’ll be able to get the latest in Slack.
-
-## Action items after November 1st at 10AM PDT:
+## Action Items
+- You MUST remove `console: true` from all `serverless.yml` files.
+- You SHOULD remove `org: <org>` from all `severless.yml` files, if you are not
+also using Serverless Dashboard.
 - You MUST upgrade Serverless Framework to version 3.24.0 or greater with
 `npm i serverless --global`.
-- You MUST run `serverless --console`, or visit console.serverless.com, to
-reconnect your AWS account after November 1st at 10AM.
+- You MUST run `serverless --console`, or visit https://console.serverless.com,
+to reconnect your AWS account.
 
 ## FAQ
 
@@ -38,27 +29,13 @@ performance and broaden the scope of observable resources. This means the new
 version of Serverless Console no longer depends on the Serverless Framework to
 add the Lambda extension via Layers to your lambda functions.
 
-### Can I keep using Serverless Console?
+Watch the [60 second video overview of the new Serverless Console](https://www.loom.com/share/bfedf4f4644f4e85b1adc5f4d66f414e)
+to learn more about the new features we are laucnhing.
 
-If you deploy your `serverless.yml` with `console: true` removed, you will no
-longer be able to monitor it in Serverless Console. Deployments with
-`console: true` will fail after November 1st. To keep using Serverless Console
-do not deploy with `console: true` prior to November 1st. Then follow the steps
-for "Action items after November 1st at 10AM PDT" to update to the latest
-version of Serverless Framework and Serverless Console.
+### What will happen if I don’t complete the action items?
 
-### What will happen if I don’t complete the action items before November 1st?
-
-If you have `console: true`, in your `serverless.yml`, then deployments will
-fail after Tuesday, November 1st at 10AM PDT. The deployment process depends
-on an API that will no longer be available.
-
-### What will happen if I complete these the action items before November 1st?
-
-Once you remove `console: true` from your `serverless.yml`, then the service
-will no longer be instrumented for Serverless Console and therefore you will not
-see the metrics, traces, and logs in Serverless Console. Once you complete the
-steps after November 1st, you'll regain access to metrics, traces, and logs.
+If you have `console: true` in your `serverless.yml`, then deployments will
+fail. The deployment process depends on an API that are no longer be available.
 
 ### Will my old data be available?
 
@@ -69,9 +46,7 @@ data will be made available as soon as you reconnect your AWS account.
 
 ### What do I need to do to regain access to Serverless Console?
 
-By completing the "Action Items after November 1st at 10AM PDT", access to
-Serverless Console will be restored. Unlike the current version of Serverless
-Console, you will no longer need to redeploy your service to enable monitoring.
-Instead, you'll be able to manage instrumentation from the web via Serverless
-Console.
+By completing the action items listed above, access to Serverless Console will
+be restored. Deployment is no longer required to add instrumentation to your
+services.
 

--- a/docs/product/upgrade-guide.md
+++ b/docs/product/upgrade-guide.md
@@ -12,13 +12,17 @@ extension on Serverless Framework version 3.23.0 and earlier. There are a few
 things you will need to do to upgrade to the latest Serverless Console.
 
 ## Action Items
-- You MUST remove `console: true` from all `serverless.yml` files.
+- You MUST remove `console: true` from all `serverless.yml` files. Deployments
+with `console: true` in the `serverless.yml` will fail if you are on version
+older than 3.24.0 of the Serverless Framework. Deployments with `console: true`
+in the `serverless.yml` will succeed, but present a deprecation warning if you
+are on version 3.24.0 or newer of the Serverless Framework.
 - You SHOULD remove `org: <org>` from all `severless.yml` files, if you are not
 also using Serverless Dashboard.
-- You MUST upgrade Serverless Framework to version 3.24.0 or greater with
-`npm i serverless --global`.
-- You MUST run `serverless --console`, or visit https://console.serverless.com,
-to reconnect your AWS account.
+- You MUST upgrade Serverless Framework to version 3.24.0 or new with
+`npm i serverless -g`. This version is required to upgrade to the new Serverless
+Console version.
+- You MUST visit https://console.serverless.com to reconnect your AWS account.
 
 ## FAQ
 


### PR DESCRIPTION
Updates the "Upgrade Guide" for Serverless Console with new language for the Nov 1st release.

The general content and messaging don't change; however, the existing content is written in the future tense for the Nov 1st release. Once we release on Nov 1st, the content has to be updated.