### PR TITLE
AWS Lambda SDK: Fix capture of HTTP response body when it's a string

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
@@ -85,7 +85,10 @@ const install = (protocol, httpModule) => {
         let bodyBuffer = Buffer.from('');
         response.on('data', (chunk) => {
           if (!bodyBuffer) return;
-          bodyBuffer = Buffer.concat([bodyBuffer, chunk]);
+          bodyBuffer = Buffer.concat([
+            bodyBuffer,
+            typeof chunk === 'string' ? Buffer.from(chunk) : chunk,
+          ]);
           if (bodyBuffer.length > bodySizeLimit) bodyBuffer = null;
         });
         response.on('end', () => {


### PR DESCRIPTION
Fix to issue reported internally by @Danwakeem 

Apparently when issuing HTTP request via `http.request` API, the obtained response may emit data chunks in plain string format. So far implementation assumed it'll always be a buffer.

At this point this comes with no regression test, as it's unclear in what circumstances _string_ is propagated. Once we clarify that out, I'll prepare a corresponding test.