### PR TITLE
AWS Lambda SDK: Report `response` in all cases

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -4,7 +4,6 @@
 
 const ensurePlainFunction = require('type/plain-function/ensure');
 const isError = require('type/error/is');
-const isPlainObject = require('type/plain-object/is');
 const coerceToString = require('type/string/coerce');
 const traceProto = require('@serverless/sdk-schema/dist/trace');
 const requestResponseProto = require('@serverless/sdk-schema/dist/request_response');
@@ -42,7 +41,7 @@ const reportRequest = async (event, context) => {
 };
 
 const resolveResponseString = (response) => {
-  if (!isPlainObject(response)) return null;
+  if (response === undefined) return null;
   if (awsLambdaSpan.tags.get('aws.lambda.event_source') === 'aws.apigateway') {
     if (typeof response.body === 'string') {
       response = { ...response };
@@ -64,7 +63,6 @@ const resolveResponseString = (response) => {
 
 const reportResponse = async (response, context, endTime) => {
   const responseString = resolveResponseString(response);
-  if (!responseString) return;
   const payload = (serverlessSdk._lastResponse = {
     slsTags: {
       orgId: serverlessSdk.orgId,

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -33,7 +33,8 @@ const reportRequest = async (event, context) => {
     spanId: Buffer.from(awsLambdaSpan.id),
     requestId: context.awsRequestId,
     timestamp: toProtobufEpochTimestamp(traceSpans.awsLambdaInvocation.startTime),
-    data: { $case: 'requestData', requestData: JSON.stringify(event) },
+    body: JSON.stringify(event),
+    origin: 1,
   });
   const payloadBuffer = (serverlessSdk._lastRequestBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());
@@ -74,7 +75,8 @@ const reportResponse = async (response, context, endTime) => {
     spanId: Buffer.from(awsLambdaSpan.id),
     requestId: context.awsRequestId,
     timestamp: toProtobufEpochTimestamp(endTime),
-    data: { $case: 'responseData', responseData: responseString },
+    body: responseString,
+    origin: 2,
   });
   const payloadBuffer = (serverlessSdk._lastResponseBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.10.2",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.12.1",
+    "@serverless/sdk-schema": "^0.13.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.0",

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -906,6 +906,7 @@ describe('internal-extension/index.test.js', () => {
             },
           ],
         },
+        { type: 'request-response', origin: 2 },
         {
           type: 'trace',
           spans: [

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -112,7 +112,7 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
   expect(normalizeObject(outcome.request.output)).to.deep.equal(
     normalizeObject(outcome.request.input)
   );
-  expect(outcome.request.input.data.requestData).to.deep.equal(stringifiedPayload);
+  expect(outcome.request.input.body).to.deep.equal(stringifiedPayload);
 
   if (outcome.response.input) {
     expect(normalizeObject(outcome.response.output)).to.deep.equal(
@@ -238,9 +238,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.httpRouter.path).to.equal('/some-path/{param}');
 
-    expect(response.data.responseData).to.deep.equal(
-      JSON.stringify({ statusCode: 200, body: '"ok"' })
-    );
+    expect(response.body).to.deep.equal(JSON.stringify({ statusCode: 200, body: '"ok"' }));
   });
 
   it('should handle API Gateway v2 HTTP API, payload v1 event', async () => {
@@ -341,9 +339,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.httpRouter.path).to.equal('/v1');
 
-    expect(response.data.responseData).to.deep.equal(
-      JSON.stringify({ statusCode: 200, body: '"ok"' })
-    );
+    expect(response.body).to.deep.equal(JSON.stringify({ statusCode: 200, body: '"ok"' }));
   });
 
   it('should handle API Gateway v2 HTTP API, payload v2 event', async () => {
@@ -419,9 +415,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.httpRouter.path).to.equal('/v2');
 
-    expect(response.data.responseData).to.deep.equal(
-      JSON.stringify({ statusCode: 200, body: '"ok"' })
-    );
+    expect(response.body).to.deep.equal(JSON.stringify({ statusCode: 200, body: '"ok"' }));
   });
 
   it('should handle function url payload event', async () => {
@@ -488,9 +482,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
 
-    expect(response.data.responseData).to.deep.equal(
-      JSON.stringify({ statusCode: 200, body: '"ok"' })
-    );
+    expect(response.body).to.deep.equal(JSON.stringify({ statusCode: 200, body: '"ok"' }));
   });
 
   it('should handle SQS event', async () => {
@@ -725,7 +717,7 @@ describe('internal-extension/index.test.js', () => {
 
     expect(lambdaTags.aws.lambda.httpRouter.path).to.equal('/foo');
 
-    expect(JSON.parse(response.data.responseData).body).to.deep.equal(JSON.stringify('ok'));
+    expect(JSON.parse(response.body).body).to.deep.equal(JSON.stringify('ok'));
 
     expect(expressSpan.name).to.equal('express');
     expect(expressSpan.parentSpanId).to.deep.equal(invocationSpan.id);
@@ -850,7 +842,7 @@ describe('internal-extension/index.test.js', () => {
         payloads.map(([type, payload]) => {
           switch (type) {
             case 'request-response':
-              return { type, data: { $case: payload.data.$case } };
+              return { type, origin: payload.origin };
             case 'trace':
               return {
                 type,
@@ -865,7 +857,7 @@ describe('internal-extension/index.test.js', () => {
           type: 'trace',
           spans: [{ name: 'aws.lambda.initialization', input: undefined, output: undefined }],
         },
-        { type: 'request-response', data: { $case: 'requestData' } },
+        { type: 'request-response', origin: 1 },
         {
           type: 'trace',
           spans: [


### PR DESCRIPTION
_Depends on https://github.com/serverless/console/pull/286_

- Upgrade `@serverless/sdk-schema` to v0.13
- Report `response` in dev mode all cases