### PR TITLE
SDK Schema: Support Node.js v12

### DIFF
--- a/node/packages/sdk-schema/tsconfig.rollup.json
+++ b/node/packages/sdk-schema/tsconfig.rollup.json
@@ -4,7 +4,8 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "target": "es2019"
   },
   "include": ["out/**/*"],
   "exclude": ["src/output", "dist"],


### PR DESCRIPTION
We've learned that AWS Lambda until May 2023 will support Node.js v12 runtime.
 
To enable such support on our extension side. The generated SDK schemas need to work in Node.js v12