### PR TITLE
AWS Lambda SDK: Fix handling of `undefined` lambda responses

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -73,7 +73,7 @@ const reportResponse = async (response, context, endTime) => {
     spanId: Buffer.from(awsLambdaSpan.id),
     requestId: context.awsRequestId,
     timestamp: toProtobufEpochTimestamp(endTime),
-    body: responseString,
+    body: responseString || undefined,
     origin: 2,
   });
   const payloadBuffer = (serverlessSdk._lastResponseBuffer =

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/callback-no-result.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/callback-no-result.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.handler = (event, context, callback) => callback();

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -267,6 +267,22 @@ describe('integration', function () {
     }
   };
 
+  const devModeConfiguration = {
+    configuration: {
+      Environment: {
+        Variables: {
+          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
+          SLS_ORG_ID: process.env.SLS_ORG_ID,
+          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
+          SLS_SDK_DEBUG: '1',
+        },
+      },
+    },
+    deferredConfiguration: () => ({
+      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
+    }),
+  };
+
   const useCasesConfig = new Map([
     [
       'esm-callback/index',
@@ -1085,24 +1101,7 @@ describe('integration', function () {
             {
               config: { configuration: { Runtime: 'nodejs12.x' } },
               variants: new Map([
-                [
-                  'dev-mode',
-                  {
-                    configuration: {
-                      Environment: {
-                        Variables: {
-                          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
-                          SLS_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_SDK_DEBUG: '1',
-                        },
-                      },
-                    },
-                    deferredConfiguration: () => ({
-                      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
-                    }),
-                  },
-                ],
+                ['dev-mode', devModeConfiguration],
                 ['regular', {}],
               ]),
             },
@@ -1112,24 +1111,7 @@ describe('integration', function () {
             {
               config: { configuration: { Runtime: 'nodejs14.x' } },
               variants: new Map([
-                [
-                  'dev-mode',
-                  {
-                    configuration: {
-                      Environment: {
-                        Variables: {
-                          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
-                          SLS_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_SDK_DEBUG: '1',
-                        },
-                      },
-                    },
-                    deferredConfiguration: () => ({
-                      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
-                    }),
-                  },
-                ],
+                ['dev-mode', devModeConfiguration],
                 ['regular', {}],
               ]),
             },
@@ -1139,24 +1121,7 @@ describe('integration', function () {
             {
               config: { configuration: { Runtime: 'nodejs16.x' } },
               variants: new Map([
-                [
-                  'dev-mode',
-                  {
-                    configuration: {
-                      Environment: {
-                        Variables: {
-                          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
-                          SLS_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_DEV_MODE_ORG_ID: process.env.SLS_ORG_ID,
-                          SLS_SDK_DEBUG: '1',
-                        },
-                      },
-                    },
-                    deferredConfiguration: () => ({
-                      Layers: [coreConfig.layerInternalArn, coreConfig.layerExternalArn],
-                    }),
-                  },
-                ],
+                ['dev-mode', devModeConfiguration],
                 ['regular', {}],
               ]),
             },

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1191,6 +1191,20 @@ describe('integration', function () {
         },
       },
     ],
+    [
+      'callback-no-result',
+      {
+        variants: new Map([
+          ['v12', { config: { configuration: { Runtime: 'nodejs12.x' } } }],
+          ['v14', { config: { configuration: { Runtime: 'nodejs14.x' } } }],
+          ['v16', { config: { configuration: { Runtime: 'nodejs16.x' } } }],
+        ]),
+        config: Object.assign({
+          isCustomResponse: true,
+          devModeConfiguration,
+        }),
+      },
+    ],
   ]);
 
   const testVariantsConfig = resolveTestVariantsConfig(useCasesConfig);
@@ -1216,7 +1230,11 @@ describe('integration', function () {
       const { expectedOutcome } = testConfig;
       const { invocationsData } = testResult;
       if (expectedOutcome === 'success' || expectedOutcome === 'error:handled') {
-        if (expectedOutcome === 'success' && !testConfig.isAsyncInvocation) {
+        if (
+          expectedOutcome === 'success' &&
+          !testConfig.isAsyncInvocation &&
+          !testConfig.isCustomResponse
+        ) {
           for (const { responsePayload } of invocationsData) {
             expect(responsePayload.raw).to.equal('"ok"');
           }


### PR DESCRIPTION
Regression introduced with #287 

Ensured proper test coverage for this case