### PR TITLE
AWS Lambda SDK: Improve HTTP requests handing

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/http.js
@@ -110,10 +110,10 @@ const install = (protocol, httpModule) => {
   const originalRequest = httpModule.request;
   const originalGet = httpModule.get;
 
-  const request = function request(url, options, cb) {
+  const request = function request(...args) {
     const startTime = process.hrtime.bigint();
     serverlessSdk._debugLog('HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
-    const args = [url, options, cb];
+    let [url, options] = args;
 
     let cbIndex = 2;
     if (typeof url === 'string') {

--- a/node/packages/aws-lambda-sdk/lib/trace-span/index.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/index.js
@@ -312,7 +312,7 @@ class TraceSpan {
       if (leftoverSpans.length) {
         process.stderr.write(
           "Serverless SDK Warning: Following trace spans didn't end before end of " +
-            `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}`
+            `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}\n`
         );
       }
       asyncLocalStorage.enterWith(this);


### PR DESCRIPTION
- Reorganize HTTP requests arguments slightly handling (in its decorator) - Apparently, this fixes the issue where Sentry request (if the Sentry layer is involved) hangs. Why it fixes.. remains a mystery to me. I've tried to reproduce it locally, without success, and debugging in a Lambda environment is not an easy thing.
- Fix issue where warning log ending without new line makes Telemetry log jumping into seme line (and most likely being hidden from ingestion service)
- Improve error reporting in ESBuild script

Fixes SC-46