### PR TITLE
AWS Lambda SDK: Improve SDK error messaging

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
@@ -33,7 +33,7 @@ module.exports = async (name, body) => {
         (response) => {
           if (response.statusCode !== 200) {
             process.stderr.write(
-              'Serverless SDK Error: Cannot propagate telemetry, ' +
+              'Serverless SDK Warning: Cannot propagate telemetry, ' +
                 `server responded with "${response.statusCode}" status code\n`
             );
           }
@@ -46,7 +46,7 @@ module.exports = async (name, body) => {
       request.end();
     });
   } catch (error) {
-    process.stderr.write(`Serverless SDK Error: Cannot propagate telemetry: ${error.message}\n`);
+    process.stderr.write(`Serverless SDK Warning: Cannot propagate telemetry: ${error.message}\n`);
   } finally {
     if (requestSocket) requestSocket.unref();
   }

--- a/node/packages/aws-lambda-sdk/internal-extension/index.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/index.js
@@ -11,7 +11,7 @@ if (!process.env._HANDLER.includes('.') || process.env._HANDLER.includes('..')) 
 }
 if (!process.env.SLS_ORG_ID) {
   process.stderr.write(
-    'Serverless SDK Error: Cannot instrument function: Missing "SLS_ORG_ID" environment variable\n'
+    'Serverless SDK Warning: Cannot instrument function: Missing "SLS_ORG_ID" environment variable\n'
   );
   return;
 }

--- a/node/packages/aws-lambda-sdk/trace-spans/aws-lambda.js
+++ b/node/packages/aws-lambda-sdk/trace-spans/aws-lambda.js
@@ -14,7 +14,9 @@ const arch = (() => {
     case 'arm64':
       return 'arm64';
     default:
-      process.stderr.write(`Serverless SDK Error: Unrecognized architecture: "${process.arch}"\n`);
+      process.stderr.write(
+        `Serverless SDK Warning: Unrecognized architecture: "${process.arch}"\n`
+      );
       return null;
   }
 })();


### PR DESCRIPTION
"Error" suggests lambda failure, while in those cases we do not influence the Lambda process. 

Replace "Error" term with "Warning" to not alarm users there's something wrong with their lambdas