### PR TITLE
bug: Response uses platform.runtimeDone timestamp

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -259,6 +259,14 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 				var telemetry *schema.LambdaTelemetry
 				if metadata[index] != nil {
 					meta := metadata[index]
+					// Update time based on meta.Time value so it matched the platform.* event timestamp
+					if meta.Time != "" {
+						metaTime, err := time.Parse("2006-01-02T15:04:05.000Z", meta.Time)
+						if err == nil {
+							epoch := uint64(metaTime.UnixNano())
+							devModePayload.Timestamp = &epoch
+						}
+					}
 					if meta.LogType == "platform.initReport" {
 						jsonString, _ := json.Marshal(meta.Record)
 						reportData := InitReportRecord{}

--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -259,8 +259,9 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 				var telemetry *schema.LambdaTelemetry
 				if metadata[index] != nil {
 					meta := metadata[index]
-					// Update time based on meta.Time value so it matched the platform.* event timestamp
-					if meta.Time != "" {
+					// Update the response payload so that it uses the
+					// time from the platform.runtimeDone event
+					if meta.Time != "" && devModePayload.Origin == schema.RequestResponse_ORIGIN_RESPONSE {
 						metaTime, err := time.Parse("2006-01-02T15:04:05.000Z", meta.Time)
 						if err == nil {
 							epoch := uint64(metaTime.UnixNano())


### PR DESCRIPTION
## Description
Updated the response payload to use the `platform.runtimeDone` timestamp instead of the one generated by the internal SDK.