### PR TITLE
doc: Update manual instrumentation example for AWS SDK and Express

### DIFF
--- a/node/packages/aws-lambda-sdk/docs/monitoring.md
+++ b/node/packages/aws-lambda-sdk/docs/monitoring.md
@@ -4,11 +4,7 @@
 
 _DIsable with `SLS_DISABLE_REQUEST_MONITORING` and `SLS_DISABLE_RESPONSE_MONITORING` environment variables respectively_
 
-SDK reads and writes to logs request (lambda event) and response data. This data is written with a log line looking as:
-
-```
-SERVERLESS_TELEMETRY.R.<base64 encoded payload>
-```
+SDK reads and writes to logs request (lambda event) and response data. This data is written along with the Trace.
 
 ## HTTP(S) requests
 
@@ -43,13 +39,13 @@ However if AWS SDK is bundled or imported via ESM import, then instrumentation n
 import AWS from 'aws-sdk';
 
 // Instrument AWS SDK v2:
-serverlessSdk.instrument.awsSdkV2(AWS);
+serverlessSdk.instrumentation.awsSdkV2.install(AWS);
 
 import { Lambda } from '@aws/client-lambda';
 const lambda = new Lambda({ region: process.env.AWS_REGION });
 
 // Instrument AWS SDK v3 Client
-serverlessSdk.instrument.awsSdkV3Client(lambda);
+serverlessSdk.instrumentation.awsSdkV3Client.install(lambda);
 ```
 
 Covered AWS SDK requests are reflected in `aws.sdk.<service-name>` spans
@@ -120,7 +116,7 @@ import express from 'express';
 
 const app = express();
 
-serverlessSdk.instrument.expressApp(express);
+serverlessSdk.instrumentation.expressApp.install(express);
 ```
 
 Handling of express route is covered in context of main `express` span. Additionally middleware jobs are recorded as following spans:

--- a/node/packages/aws-lambda-sdk/docs/sdk.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk.md
@@ -14,12 +14,13 @@ _For detailed info on spans check [trace-spans.md](./trace-spans.md)_
 - `awsLambdaInitialization` - Initialization span
 - `awsLambdaInvocation` - Invocation span (not available at _initialization_ phase)
 
-### `serverlessSdk.instrument`
+### `serverlessSdk.instrumentation`
 
 Most of the instrumentation is setup automatically, still there are scenarios when it's difficult to ensure that (e.g. when target modules are imported as ESM, or come from bundles). In such case instrumentation need to be set manually, and then following utilities should be used:
 
-- `awsSdkV2(AWS)` - Instrument AWS SDK v2 (takes instance of SDK as the argument)
-- `awsSdkV3Client(client)` - Instrument AWS SDK v3 client
+- `awsSdkV2.install(AWS)` - Instrument AWS SDK v2 (takes instance of SDK as the argument)
+- `awsSdkV3Client.install(client)` - Instrument AWS SDK v3 client
+- `expressApp.install(express)` - Instrument Express
 
 ### `serverlessSdk.createTraceSpan(name[, options])`
 


### PR DESCRIPTION
I noticed yesterday while setting up the AWS SDK v3 instrumentation, the docs didn't match what we expose in the SDK. Updated docs to match.