### PR TITLE
AWS Lambda SDK: Improve handling of requests going to dev mode

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -89,6 +89,7 @@ const reportTrace = () => {
       sdk: { name: pkgJson.name, version: pkgJson.version },
     },
     spans: Array.from(awsLambdaSpan.spans).map((span) => span.toProtobufObject()),
+    events: [],
   });
   const payloadBuffer = (serverlessSdk._lastTraceBuffer =
     traceProto.TracePayload.encode(payload).finish());

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -89,7 +89,12 @@ const reportTrace = () => {
       service: process.env.AWS_LAMBDA_FUNCTION_NAME,
       sdk: { name: pkgJson.name, version: pkgJson.version },
     },
-    spans: Array.from(awsLambdaSpan.spans).map((span) => span.toProtobufObject()),
+    spans: Array.from(awsLambdaSpan.spans).map((span) => {
+      const spanPayload = span.toProtobufObject();
+      delete spanPayload.input;
+      delete spanPayload.output;
+      return spanPayload;
+    }),
     events: [],
   });
   const payloadBuffer = (serverlessSdk._lastTraceBuffer =

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -11,6 +11,7 @@ const resolveEventTags = require('./lib/resolve-event-tags');
 const resolveResponseTags = require('./lib/resolve-response-tags');
 const sendTelemetry = require('./lib/send-telemetry');
 const flushSpans = require('./lib/auto-send-spans').flush;
+const invocationContextAccessor = require('./lib/invocation-context-accessor');
 const pkgJson = require('../package');
 
 const serverlessSdk = global.serverlessSdk || require('../');
@@ -117,6 +118,7 @@ module.exports = (originalHandler, options = {}) => {
     let originalDone;
     try {
       serverlessSdk._debugLog('Invocation: start');
+      invocationContextAccessor.set(context);
       let isResolved = false;
       let responseStartTime;
       const invocationId = ++currentInvocationId;

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -30,6 +30,7 @@ const sendSpans = () => {
       span.output = null;
       return result;
     }),
+    events: [],
   };
   pendingSpans.length = 0;
   serverlessSdk._deferredTelemetryRequests.push(

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -27,12 +27,7 @@ const sendSpans = () => {
       service: process.env.AWS_LAMBDA_FUNCTION_NAME,
       sdk: { name: '@serverless/aws-lambda-sdk', version: serverlessSdk.version },
     },
-    spans: pendingSpans.map((span) => {
-      const result = span.toProtobufObject();
-      span.input = null;
-      span.output = null;
-      return result;
-    }),
+    spans: pendingSpans.map((span) => span.toProtobufObject()),
     events: [],
   };
   pendingSpans.length = 0;
@@ -48,7 +43,7 @@ serverlessSdk._traceSpanEmitter.on('close', (traceSpan) => {
     const context = invocationContextAccessor.value;
     timeoutId = setTimeout(
       sendSpans,
-      Math.min(100, Math.max(0, context ? context.getRemainingTimeInMillis() - 50 : 100))
+      Math.min(50, Math.max(0, context ? context.getRemainingTimeInMillis() - 50 : 50))
     );
   }
 });

--- a/node/packages/aws-lambda-sdk/instrument/lib/invocation-context-accessor.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/invocation-context-accessor.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.set = (context) => (module.exports.value = context);

--- a/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
@@ -9,12 +9,13 @@ if (!serverlessSdk._isDevMode) {
 }
 
 const http = require('http');
+const limit = require('ext/promise/limit').bind(Promise);
 
 const keepAliveAgent = new http.Agent({ keepAlive: true });
 
 const telemetryServerUrl = 'http://localhost:2773/';
 
-module.exports = async (name, body) => {
+module.exports = limit(10, async (name, body) => {
   let requestSocket;
   const requestStartTime = process.hrtime.bigint();
   serverlessSdk._debugLog('Telemetry send', name);
@@ -56,4 +57,4 @@ module.exports = async (name, body) => {
       Number(process.hrtime.bigint() - requestStartTime) / 1000000
     )}ms`
   );
-};
+});

--- a/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/send-telemetry.js
@@ -37,7 +37,8 @@ module.exports = async (name, body) => {
                 `server responded with "${response.statusCode}" status code\n`
             );
           }
-          resolve();
+          response.on('data', () => {});
+          response.on('end', resolve);
         }
       );
       request.on('error', reject);

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.11.4",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk-schema": "^0.13.1",
+    "@serverless/sdk-schema": "^0.14.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",
     "long": "^5.2.1",

--- a/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
+++ b/node/packages/aws-lambda-sdk/test/benchmark/performance.test.js
@@ -25,16 +25,16 @@ describe('performance', function () {
   });
 
   it('should introduce reasonable first invocation overhead', () => {
-    expect(results.get('internal').results.invocation.first.total.median).to.be.below(11);
+    expect(results.get('internal').results.invocation.first.total.median).to.be.below(15);
     expect(results.get('internalAndExternal').results.invocation.first.total.median).to.be.below(
-      40
+      90
     );
   });
 
   it('should introduce reasonable following invocation overhead', () => {
     expect(results.get('internal').results.invocation.following.total.median).to.be.below(10);
     expect(results.get('internalAndExternal').results.invocation.first.total.median).to.be.below(
-      40
+      90
     );
   });
 });

--- a/node/packages/aws-lambda-sdk/test/fixtures/dev-mode-extension/extensions/dummy-dev-extension.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/dev-mode-extension/extensions/dummy-dev-extension.js
@@ -211,9 +211,11 @@ const processStartTime = process.hrtime.bigint();
     servers.add(
       http
         .createServer((request, response) => {
+          debugLog('External: telemetry request');
           request.on('data', () => {});
           request.on('end', () => {
             response.writeHead(200, '');
+            debugLog('External: telemetry response');
             response.end('OK');
           });
         })

--- a/node/packages/aws-lambda-sdk/test/lib/build-dummy-dev-mode-extension.js
+++ b/node/packages/aws-lambda-sdk/test/lib/build-dummy-dev-mode-extension.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const path = require('path');
+const fsp = require('fs').promises;
+const mkdir = require('fs2/mkdir');
+const resolveDirZipBuffer = require('../utils/resolve-dir-zip-buffer');
+
+const zipFilename = path.resolve(__dirname, '../../dist/dummy-dev-mode.zip');
+const extensionDirname = path.resolve(__dirname, '../fixtures/dev-mode-extension');
+
+module.exports = async () => {
+  await mkdir(path.dirname(zipFilename), { intermediate: true, silent: true });
+  await fsp.writeFile(zipFilename, await resolveDirZipBuffer(extensionDirname));
+};

--- a/node/packages/aws-lambda-sdk/test/scripts/build-dummy-dev-mode-extension.js
+++ b/node/packages/aws-lambda-sdk/test/scripts/build-dummy-dev-mode-extension.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('essentials');
+require('log-node')();
+
+require('../lib/build-dummy-dev-mode-extension')();


### PR DESCRIPTION
- Wait for responses to be fulfilled before giving the green light for the invocation to end. Unfinished responses were likely to group in frozen lambdas, and possibly they contributed to `EMFILE` errors observed in some scenarios (it's what I observed when doing some local testing)
- Reduce the number of requests in case of a large number of spans being created - so far, we've sent on the spot all spans that ended in the given event loop. With the new approach, we send all spans that end every 50ms.
-  Limit the number of concurrent requests. This may help in real edge cases if, for some reason, dev-mode has issues in processing our requests fast (ideally, it should never happen)
- Fix filtering of `input` and `output` on traces. This data should only go in dev mode. While it's unlikely that issue happened, so far, logic had one issue which could have caused the `output` being written in traces in CW logs

Additionally:
- Upgraded internals to `@serverless/sdk-schema` v0.14
- Improve tests so internal refactoring does not break them
- Improve handling of dummy dev extension, which helps in local testing