### PR TITLE
AWS Lambda SDK: Fix handling of deferred spans, started before handler invocation

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/trace-span/index.js
+++ b/node/packages/aws-lambda-sdk/lib/trace-span/index.js
@@ -214,14 +214,6 @@ class TraceSpan {
           { code: 'FUTURE_SPAN_START_TIME' }
         );
       }
-      if (this.parentSpan && startTime < this.parentSpan.startTime) {
-        throw Object.assign(
-          new Error(
-            'Cannot intialize span: Start time cannot be older than start time of parent span'
-          ),
-          { code: 'PAST_PARENT_SPAN_START_TIME' }
-        );
-      }
     }
     this.startTime = startTime || defaultStartTime;
     this.name = ensureSpanName(name);

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/delayed-http-request.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/delayed-http-request.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const http = require('http');
+
+const TEST_SERVER_PORT = 3177;
+
+http
+  .createServer((request, response) => {
+    request.on('data', () => {});
+    request.on('end', () => {
+      response.writeHead(200, {});
+      response.end('"ok"');
+    });
+  })
+  .listen(TEST_SERVER_PORT);
+
+const url = `http://localhost:${TEST_SERVER_PORT}/?foo=bar`;
+
+module.exports.handler = async () => {
+  setTimeout(() => {
+    http
+      .request(url, { headers: { someHeader: 'bar' } }, (response) => {
+        let body = '';
+        response.on('data', (data) => {
+          body += data;
+        });
+        response.on('end', () => {
+          console.log('Body', body);
+        });
+      })
+      .end();
+  }, 50).unref();
+  return 'ok';
+};


### PR DESCRIPTION
Fixes #322 

There are situations where some work is scheduled for later, and invocation is closed.
Then when a new invocation starts, the engine first frees the event loop, and following that invocation handler is invoked.
This means that scheduled event loops may run before the handler, and that's the point where root `aws.lambda` is closed and not reopened yet. Trying to create new spans at that point leads to crashes (as reported at #322)

This patch addresses that. It's now ensured that there's no time gap with the root span closed. Right after it's closed and trace payloads generated, we reopen it to welcome such deferred spans before the following invocation happens

It's important to note that such _deferred_ spans will resolve as direct children of `aws.lambda` and not `aws.lambda.invocation` span (as `aws.lambda.invocation` covers handler invocation). It's not a situation that was possible before.
