### PR TITLE
AWS Lambda SDK: Do not crash in case of AWS SDK v2 double resolution setup

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+const { Lambda } = require('aws-sdk');
+
+const lambda = new Lambda();
+
+module.exports.handler = async () => {
+  await lambda.listFunctions({}, () => {}).promise();
+  return 'ok';
+};

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1056,6 +1056,27 @@ describe('integration', function () {
       },
     ],
     [
+      'aws-sdk-v2-doubled-resolution',
+      {
+        test: ({ invocationsData }) => {
+          for (const [
+            index,
+            {
+              trace: { spans },
+            },
+          ] of invocationsData.entries()) {
+            spans.shift();
+            if (!index) spans.shift();
+            spans.shift();
+            expect(spans.map(({ name }) => name)).to.deep.equal([
+              'aws.sdk.lambda.listfunctions',
+              'aws.sdk.lambda.listfunctions',
+            ]);
+          }
+        },
+      },
+    ],
+    [
       'express',
       {
         hooks: {


### PR DESCRIPTION
If AWS SDK v2 request is set up with two response observers (e.g. via _callback_ and _promise_ as `lambda.listFunctions({}, () => {}).promise()`), then AWS internally starts two requests, and `complete` event for each request is emitted twice, first with the result of first request and the second time with the result for the second.

https://github.com/aws/aws-sdk-js/issues/3347

This behavior results in an error on our instrumentation side, as `aws.sdk.request_id` is attempted to set twice with two different values.

This patch prevents that and ensures a warning is shown to the user.

Thankfully design issue of AWS SDK v2 is not repeated with AWS SDK v3, where passing a callback effectively prevents _promise_ from being returned.