### PR TITLE
AWS Lambda SDK: Do not attempt to set AWS SDK request id when there's no request

### DIFF
--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -58,7 +58,9 @@ module.exports.install = (client) => {
         })();
         await deferredRegion;
         if (error) {
-          if (error.$metadata) traceSpan.tags.set('aws.sdk.request_id', error.$metadata.requestId);
+          if (error.$metadata && error.$metadata.requestId) {
+            traceSpan.tags.set('aws.sdk.request_id', error.$metadata.requestId);
+          }
           if (!traceSpan.endTime) traceSpan.close();
           throw error;
         } else {


### PR DESCRIPTION
When played locally, approached one issue when trying to run AWS SDK method not authenticated.

I think it's near impossible to manage to get unauthenticated AWS SDK call in lambda environment, still maybe there are other kind of errors which may prevent starting the HTTP requests. This patch ensures we do not crash in such case