### PR TITLE
doc: Use correct URL for `trace-span.md` doc

### DIFF
--- a/node/packages/aws-lambda-sdk/docs/sdk.md
+++ b/node/packages/aws-lambda-sdk/docs/sdk.md
@@ -8,7 +8,7 @@ In other cases it can be required (or imported) from `@serverless/aws-lambda-sdk
 
 ### `serverlessSdk.traceSpans`
 
-_For detailed info on spans check [trace-spans.md](./trace-spans.md)_
+_For detailed info on spans check [trace-span.md](./trace-span.md)_
 
 - `awsLambda` - Root AWS lambda span
 - `awsLambdaInitialization` - Initialization span


### PR DESCRIPTION
This document currently points to `trace-spans.md`, but the filename is `trace-span.md`. This fixes the 404 error given when following the prior link.