### PR TITLE
SDK: Instrument `console.error`

### DIFF
--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -45,5 +45,6 @@ export interface SdkOptions {
   disableHttpMonitoring?: boolean;
   disableRequestResponseMonitoring?: boolean;
   disableExpressMonitoring?: boolean;
+  disableNodeConsoleMonitoring?: boolean;
   traceMaxCapturedBodySizeKb?: number;
 }

--- a/node/packages/sdk/README.md
+++ b/node/packages/sdk/README.md
@@ -60,7 +60,7 @@ Required setting. Id of your organization in Serverless Console.
 
 ##### `SLS_DISABLE_HTTP_MONITORING` (or `options.disableHttpMonitoring`)
 
-Disable tracing of HTTP and HTTPS requests
+Disable tracing of HTTP and HTTPS requests. See [HTTP instrumentation](docs/instrumentation/http.md)
 
 ##### `SLS_DISABLE_REQUEST_RESPONSE_MONITORING` (or `options.disableRequestResponseMonitoring`)
 
@@ -68,7 +68,7 @@ Disable tracing of HTTP and HTTPS requests
 
 ##### `SLS_DISABLE_EXPRESS_MONITORING` (or `options.disableExpressMonitoring`)
 
-Disable automated express monitoring
+Disable automated express monitoring. See [express app instrumentation](docs/instrumentation/express-app.md)
 
 ##### `SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB` (or `options.traceMaxCapturedBodySizeKb`)
 

--- a/node/packages/sdk/README.md
+++ b/node/packages/sdk/README.md
@@ -82,6 +82,7 @@ _Note: instrumentation is enabled via environment specific SDK instance, relying
 
 - [HTTP(s) requests](docs/instrumentation/http.md)
 - [express app](docs/instrumentation/express-app.md)
+- [Node.js console](docs/instrumentation/node-console.md)
 
 ### API
 

--- a/node/packages/sdk/docs/instrumentation/node-console.md
+++ b/node/packages/sdk/docs/instrumentation/node-console.md
@@ -1,0 +1,5 @@
+# Node.js [`console`](https://nodejs.org/api/console.html) instrumentation
+
+_Disable with `SLS_DISABLE_NODE_CONSOLE_MONITORING` environment variable_
+
+All `console.error` invocations are monitored and propagated as [captured errors](../sdk.md#captureerrorerror-options) to the Serverless Console

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -62,6 +62,9 @@ serverlessSdk._initialize = (options = {}) => {
   serverlessSdk._settings.disableExpressMonitoring = Boolean(
     process.env.SLS_DISABLE_EXPRESS_MONITORING || options.disableExpressMonitoring
   );
+  serverlessSdk._settings.disableNodeConsoleMonitoring = Boolean(
+    process.env.SLS_DISABLE_NODE_CONSOLE_MONITORING || options.disableNodeConsoleMonitoring
+  );
   serverlessSdk._settings.traceMaxCapturedBodySizeKb =
     coerceToNaturalNumber(process.env.SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB) ||
     coerceToNaturalNumber(options.traceMaxCapturedBodySizeKb) ||
@@ -76,6 +79,12 @@ serverlessSdk._initialize = (options = {}) => {
     // Auto generate AWS SDK request spans
     require('./lib/instrumentation/express').install();
   }
+
+  if (!settings.disableNodeConsoleMonitoring) {
+    // Auto capture `console.error` invocations
+    require('./lib/instrumentation/node-console').install();
+  }
+
   if (serverlessSdk._initializeExtension) serverlessSdk._initializeExtension(options);
 
   return serverlessSdk;

--- a/node/packages/sdk/lib/instrumentation/node-console.js
+++ b/node/packages/sdk/lib/instrumentation/node-console.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const isError = require('type/error/is');
+
+const nodeConsole = console;
+
+let isInstalled = false;
+let uninstall;
+
+module.exports.install = () => {
+  if (isInstalled) return;
+  isInstalled = true;
+
+  const original = { error: nodeConsole.error };
+
+  nodeConsole.error = function (...args) {
+    try {
+      const error = args.find(isError);
+      if (!error) return;
+      serverlessSdk.captureError(error);
+    } finally {
+      original.error.apply(this, args);
+    }
+  };
+
+  uninstall = () => {
+    nodeConsole.error = original.error;
+  };
+};
+
+module.exports.uninstall = () => {
+  if (!isInstalled) return;
+  isInstalled = false;
+  uninstall();
+};
+
+const serverlessSdk = require('../..');


### PR DESCRIPTION
Automatically record as captured error first error instance as passed to `console.error()`