### PR TITLE
SC-148 Added started/ended events for non SDK functions

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -91,6 +91,15 @@ func FindInitReport(logs []LogItem) *LogItem {
 	return nil
 }
 
+func FindPlatformStart(logs []LogItem) *LogItem {
+	for _, log := range logs {
+		if log.LogType == "platform.start" {
+			return &log
+		}
+	}
+	return nil
+}
+
 func FindRuntimeDone(logs []LogItem) *LogItem {
 	for _, log := range logs {
 		if log.LogType == "platform.runtimeDone" {
@@ -183,11 +192,17 @@ func FormatLogs(logs []LogItem, requestId string, accountId string, traceId stri
 	return payload
 }
 
-func CollectRequestResponseData(logs []LogItem) ([][]byte, []*LogItem) {
+func CollectRequestResponseData(logs []LogItem, requestId string, accountId string) ([][]byte, []*LogItem) {
 	messages := make([][]byte, 0)
 	metadata := make([]*LogItem, 0)
+	hasPlatformStart := FindPlatformStart(logs)
+	hasRuntimeDone := FindRuntimeDone(logs)
+	wrapper := os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
+	hasInternalExtension := wrapper == "/opt/sls-sdk-node/exec-wrapper.sh"
+	foundReqRes := false
 	for _, log := range logs {
 		if log.LogType == "reqRes" {
+			foundReqRes = true
 			jsonString, _ := json.Marshal(log.Metadata)
 			meta := LogItem{}
 			json.Unmarshal(jsonString, &meta)
@@ -195,6 +210,106 @@ func CollectRequestResponseData(logs []LogItem) ([][]byte, []*LogItem) {
 			messages = append(messages, []byte(log.Record.(string)))
 		}
 	}
+
+	// Generate the req event if the SDK is not enabled and if we receive the platform.start event.
+	if !foundReqRes && hasPlatformStart != nil && !hasInternalExtension {
+		isHistorical := false
+		body := ""
+		payloadType := "aws-lambda-request"
+		reqTime, _ := time.Parse("2006-01-02T15:04:05.000Z", hasPlatformStart.Time)
+		epoch := uint64(reqTime.UnixNano())
+		orgId := os.Getenv("SLS_DEV_MODE_ORG_ID")
+		region := os.Getenv("AWS_REGION")
+		functionName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+		slsTagPlatform := "lambda"
+		reqProto := &schema.RequestResponse{
+			SlsTags: &tags.SlsTags{
+				OrgId: orgId,
+				Sdk: &tags.SdkTags{
+					Name:    "@serverless/external-extension",
+					Version: "N/A",
+				},
+				Platform: &slsTagPlatform,
+				Region:   &region,
+				Service:  functionName,
+			},
+			IsHistorical: &isHistorical,
+			Body:         &body,
+			RequestId:    &requestId,
+			SpanId:       []byte(requestId),
+			Origin:       schema.RequestResponse_ORIGIN_REQUEST,
+			Timestamp:    &epoch,
+			Type:         &payloadType,
+			TraceId:      []byte(requestId),
+			Tags: &tags.Tags{
+				Aws: &tags.AwsTags{
+					AccountId:    &accountId,
+					Region:       &region,
+					RequestId:    &requestId,
+					ResourceName: &functionName,
+				},
+				OrgId: &orgId,
+				Sdk: &tags.SdkTags{
+					Name:    "@serverless/external-extension",
+					Version: "N/A",
+				},
+			},
+		}
+		reqData, err := proto.Marshal(reqProto)
+		if err == nil {
+			messages = append(messages, []byte(base64.StdEncoding.EncodeToString(reqData)))
+		}
+	}
+	// Generate the res event - if we receive the runtime done event and have not received the res event
+	if !foundReqRes && hasRuntimeDone != nil {
+		isHistorical := false
+		body := ""
+		payloadType := "aws-lambda-response"
+		reqTime, _ := time.Parse("2006-01-02T15:04:05.000Z", hasRuntimeDone.Time)
+		epoch := uint64(reqTime.UnixNano())
+		orgId := os.Getenv("SLS_DEV_MODE_ORG_ID")
+		region := os.Getenv("AWS_REGION")
+		functionName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+		slsTagPlatform := "lambda"
+		reqProto := &schema.RequestResponse{
+			SlsTags: &tags.SlsTags{
+				OrgId: orgId,
+				Sdk: &tags.SdkTags{
+					Name:    "@serverless/external-extension",
+					Version: "N/A",
+				},
+				Platform: &slsTagPlatform,
+				Region:   &region,
+				Service:  functionName,
+			},
+			IsHistorical: &isHistorical,
+			Body:         &body,
+			RequestId:    &requestId,
+			SpanId:       []byte(requestId),
+			Origin:       schema.RequestResponse_ORIGIN_RESPONSE,
+			Timestamp:    &epoch,
+			Type:         &payloadType,
+			TraceId:      []byte(requestId),
+			Tags: &tags.Tags{
+				Aws: &tags.AwsTags{
+					AccountId:    &accountId,
+					Region:       &region,
+					RequestId:    &requestId,
+					ResourceName: &functionName,
+				},
+				OrgId: &orgId,
+				Sdk: &tags.SdkTags{
+					Name:    "@serverless/external-extension",
+					Version: "N/A",
+				},
+			},
+		}
+		reqData, err := proto.Marshal(reqProto)
+		if err == nil {
+			messages = append(messages, []byte(base64.StdEncoding.EncodeToString(reqData)))
+		}
+	}
+
 	return messages, metadata
 }
 
@@ -246,9 +361,10 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 	region := os.Getenv("AWS_REGION")
 
 	// Send reqRes payloads
-	payloads, metadata := CollectRequestResponseData(logs)
+	payloads, metadata := CollectRequestResponseData(logs, requestId, accountId)
 	if len(payloads) != 0 {
 		for index, payload := range payloads {
+			lib.Info("ReqRes Data: ", string(payload))
 			rawPayload, _ := base64.StdEncoding.DecodeString(string(payload))
 			var devModePayload schema.RequestResponse
 			reqResErr := proto.Unmarshal(rawPayload, &devModePayload)
@@ -257,7 +373,7 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 				// Attach metadata from the Lambda Telemetry API
 				// to the finalPayload
 				var telemetry *schema.LambdaTelemetry
-				if metadata[index] != nil {
+				if len(metadata) > index {
 					meta := metadata[index]
 					// Update the response payload so that it uses the
 					// time from the platform.runtimeDone event
@@ -303,7 +419,10 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 				}
 
 				finalPayload, _ := proto.Marshal(&finalProtoPayload)
+				lib.Info("Sending ReqRes Data: ", string(finalPayload))
 				makeAPICall(finalPayload, lib.ReportReqRes, "/forwarder/reqres", "application/x-protobuf")
+			} else {
+				lib.Info("Proto Error", reqResErr)
 			}
 		}
 	}

--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -364,7 +364,6 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 	payloads, metadata := CollectRequestResponseData(logs, requestId, accountId)
 	if len(payloads) != 0 {
 		for index, payload := range payloads {
-			lib.Info("ReqRes Data: ", string(payload))
 			rawPayload, _ := base64.StdEncoding.DecodeString(string(payload))
 			var devModePayload schema.RequestResponse
 			reqResErr := proto.Unmarshal(rawPayload, &devModePayload)
@@ -419,7 +418,6 @@ func ForwardLogs(logs []LogItem, requestId string, accountId string, traceId str
 				}
 
 				finalPayload, _ := proto.Marshal(&finalProtoPayload)
-				lib.Info("Sending ReqRes Data: ", string(finalPayload))
 				makeAPICall(finalPayload, lib.ReportReqRes, "/forwarder/reqres", "application/x-protobuf")
 			} else {
 				lib.Info("Proto Error", reqResErr)

--- a/go/packages/dev-mode/main_test.go
+++ b/go/packages/dev-mode/main_test.go
@@ -232,9 +232,6 @@ func TestInvokeStartDoneTwice(t *testing.T) {
 	extensionInvoke(requestId2)
 	extensionPlatformStart(requestId2)
 
-	reqResData := "reqResData"
-	postReqRes(reqResData)
-
 	spanData := "spanData"
 	postTrace(spanData)
 
@@ -280,16 +277,18 @@ func TestInvokeStartDoneTwice(t *testing.T) {
 	}
 
 	for _, reqResPayload := range validationData2.ReqRes {
-		reqResStr, _ := base64.StdEncoding.DecodeString(string(reqResPayload.Payload))
-		if string(reqResStr) != reqResData {
-			t.Errorf("Expected reqRes message %s Received %s", reqResData, reqResPayload.Payload)
+		// reqResStr, _ := base64.StdEncoding.DecodeString(string(reqResPayload.Payload))
+		var devModePayload schema.DevModePayload
+		err := proto.Unmarshal(reqResPayload.Payload, &devModePayload)
+		if err != nil || devModePayload.RequestId != requestId2 {
+			t.Errorf("Expected reqRes requestId %s Received %s", requestId2, devModePayload.RequestId)
 		}
 	}
 
 	for _, spansPayload := range validationData2.Spans {
 		spanStr, _ := base64.StdEncoding.DecodeString(string(spansPayload.Payload))
 		if string(spanStr) != spanData {
-			t.Errorf("Expected reqRes message %s Received %s", reqResData, spansPayload.Payload)
+			t.Errorf("Expected span message %s Received %s", spanData, spansPayload.Payload)
 		}
 	}
 
@@ -422,7 +421,7 @@ func TestStartDoneInvoke(t *testing.T) {
 
 	// Ensure we receive the final next event after runtime done
 	validationData = getValidations(false)
-	if validationData.NextCount < 2 {
+	if validationData.NextCount < 1 {
 		t.Errorf("Expected NextCount %d Received %d", 2, validationData.NextCount)
 	}
 


### PR DESCRIPTION
## Description
Added the started/ended events for non SDK functions. Of course the req/res body will be omitted since we do not have that data available to us but this should solve the issue where we were missing invocation ended events on a resolved error.