### PR TITLE
AWS Lambda SDK: Initialize original handler at AWS intended processing point

### DIFF
--- a/node/packages/aws-lambda-sdk/internal-extension/index.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/index.js
@@ -31,27 +31,6 @@ try {
   const handlerModuleName = path.resolve(handlerModuleDirname, handlerModuleBasename);
 
   const nodeVersionMajor = Number(process.version.split('.')[0].slice(1));
-  const isAsyncLoader = nodeVersionMajor >= 16;
-
-  const importEsm = (() => {
-    if (isAsyncLoader) {
-      return async (p) => {
-        return await import(p);
-      };
-    }
-    try {
-      // eslint-disable-next-line import/no-unresolved
-      return require(path.resolve(process.env.LAMBDA_RUNTIME_DIR, 'deasync')).deasyncify(
-        async (p) => {
-          return await import(p);
-        }
-      );
-    } catch (error) {
-      // No ESM support (Node.js v12)
-      return null;
-    }
-  })();
-
   const doesModuleExist = (filename) => {
     try {
       require.resolve(filename);
@@ -69,82 +48,38 @@ try {
     }
   };
 
-  EvalError.$serverlessAwsLambdaInitializationStartTime = processStartTime;
-
-  (() => {
-    try {
-      require.resolve('@serverless/aws-lambda-sdk');
-    } catch {
-      return require('../');
-    }
-
-    // eslint-disable-next-line import/no-unresolved
-    return require('@serverless/aws-lambda-sdk');
-  })()._initialize();
-
-  let hasInitializationFailed = false;
-  const startTime = process.hrtime.bigint();
-
-  const handlerModule = (() => {
-    try {
-      if (importEsm) {
-        // Handle eventual ESM handler modules
-        if (doesModuleExist(`${handlerModuleName}.mjs`)) {
-          return importEsm(`${handlerModuleName}.mjs`);
-        }
-        if (doesModuleExist(`${handlerModuleName}.js`)) {
-          const fs = require('fs');
-          let currentDirname = handlerModuleDirname;
-          while (!currentDirname.endsWith('/node_modules') && currentDirname !== '/') {
-            if (fs.existsSync(path.resolve(currentDirname, 'package.json'))) {
-              if (isEsmContext(currentDirname)) return importEsm(`${handlerModuleName}.js`);
-              break;
-            }
-            currentDirname = path.dirname(currentDirname);
+  const handlerModuleInstruction = (() => {
+    if (nodeVersionMajor > 12) {
+      // Handle eventual ESM handler modules
+      if (doesModuleExist(`${handlerModuleName}.mjs`)) return `esm@${handlerModuleName}.mjs`;
+      if (doesModuleExist(`${handlerModuleName}.js`)) {
+        const fs = require('fs');
+        let currentDirname = handlerModuleDirname;
+        while (!currentDirname.endsWith('/node_modules') && currentDirname !== '/') {
+          if (fs.existsSync(path.resolve(currentDirname, 'package.json'))) {
+            if (isEsmContext(currentDirname)) return `esm@${handlerModuleName}.js`;
+            break;
           }
+          currentDirname = path.dirname(currentDirname);
         }
       }
-
-      if (doesModuleExist(handlerModuleName)) return require(handlerModuleName);
-      return require('module').createRequire(handlerModuleName)(handlerModuleBasename);
-    } catch (error) {
-      hasInitializationFailed = true;
-      EvalError.$serverlessHandlerModuleInitializationError = error;
-      return null;
     }
+
+    if (doesModuleExist(handlerModuleName)) return `cjs@${handlerModuleName}`;
+    return null;
   })();
-  const handlerLoadDuration = process.hrtime.bigint() - startTime;
 
-  if (!hasInitializationFailed) {
-    let handlerContext = handlerModule;
-    if (handlerContext == null) return;
+  if (!handlerModuleInstruction) return;
 
-    if (isAsyncLoader && typeof handlerContext.then === 'function') {
-      EvalError.$serverlessHandlerDeferred = handlerContext;
-    } else {
-      const handlerPropertyPathTokens = handlerBasename
-        .slice(handlerModuleBasename.length + 1)
-        .split('.');
-      const handlerFunctionName = handlerPropertyPathTokens.pop();
-      while (handlerPropertyPathTokens.length) {
-        handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
-        if (handlerContext == null) return;
-      }
-      const handlerFunction = handlerContext[handlerFunctionName];
-      if (typeof handlerFunction !== 'function') return;
-
-      EvalError.$serverlessHandlerFunction = handlerFunction;
-    }
-  }
+  EvalError.$serverlessAwsLambdaInitializationStartTime = processStartTime;
+  EvalError.$serverlessHandlerModuleInstruction = handlerModuleInstruction;
 
   process.env._ORIGIN_HANDLER = process.env._HANDLER;
   process.env._HANDLER = '/opt/sls-sdk-node/wrapper.handler';
 
   debugLog(
     'Overhead duration: Internal initialization:',
-    `${Math.round(
-      Number(process.hrtime.bigint() - processStartTime - handlerLoadDuration) / 1000000
-    )}ms`
+    `${Math.round(Number(process.hrtime.bigint() - processStartTime) / 1000000)}ms`
   );
 } catch (error) {
   process._rawDebug(

--- a/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
@@ -7,61 +7,96 @@
 process.env._HANDLER = process.env._ORIGIN_HANDLER;
 delete process.env._ORIGIN_HANDLER;
 
-if (!EvalError.$serverlessHandlerFunction && !EvalError.$serverlessHandlerDeferred) {
-  const handlerError = EvalError.$serverlessHandlerModuleInitializationError;
-  delete EvalError.$serverlessHandlerModuleInitializationError;
-  throw handlerError;
-}
+const handlerModuleInstruction = EvalError.$serverlessHandlerModuleInstruction;
+delete EvalError.$serverlessHandlerModuleInstruction;
 
-try {
-  const instrument = require('../instrument');
+const path = require('path');
 
-  if (EvalError.$serverlessHandlerDeferred) {
-    const handlerDeferred = EvalError.$serverlessHandlerDeferred;
-    delete EvalError.$serverlessHandlerDeferred;
-    module.exports = handlerDeferred.then((handlerModule) => {
-      try {
-        if (handlerModule == null) return handlerModule;
-
-        const path = require('path');
-
-        const handlerBasename = path.basename(process.env._HANDLER);
-        const handlerModuleBasename = handlerBasename.slice(0, handlerBasename.indexOf('.'));
-
-        const handlerPropertyPathTokens = handlerBasename
-          .slice(handlerModuleBasename.length + 1)
-          .split('.');
-        const handlerFunctionName = handlerPropertyPathTokens.pop();
-        let handlerContext = handlerModule;
-        while (handlerPropertyPathTokens.length) {
-          handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
-          if (handlerContext == null) return handlerModule;
-        }
-        const handlerFunction = handlerContext[handlerFunctionName];
-        if (typeof handlerFunction !== 'function') return handlerModule;
-
-        return { handler: instrument(handlerFunction) };
-      } catch (error) {
-        process._rawDebug(
-          'Fatal Serverless SDK Error: ' +
-            'Please report at https://github.com/serverless/console/issues: ' +
-            'Async handler setup failed'
-        );
-        throw error;
-      }
-    });
-    return;
+// 1. Initialize SDK instrumentation
+(() => {
+  try {
+    require.resolve('@serverless/aws-lambda-sdk');
+  } catch {
+    return require('../');
   }
 
-  const originalHandler = EvalError.$serverlessHandlerFunction;
-  delete EvalError.$serverlessHandlerFunction;
+  // eslint-disable-next-line import/no-unresolved
+  return require('@serverless/aws-lambda-sdk');
+})()._initialize();
 
-  module.exports.handler = instrument(originalHandler);
-} catch (error) {
-  process._rawDebug(
-    'Fatal Serverless SDK Error: ' +
-      'Please report at https://github.com/serverless/console/issues: ' +
-      'Handler setup failed'
-  );
-  throw error;
+// 2. Initialize original handler
+const nodeVersionMajor = Number(process.version.split('.')[0].slice(1));
+const isAsyncLoader = nodeVersionMajor >= 16;
+const importEsm = (() => {
+  if (isAsyncLoader) {
+    return async (p) => {
+      return await import(p);
+    };
+  }
+  try {
+    // eslint-disable-next-line import/no-unresolved
+    return require(path.resolve(process.env.LAMBDA_RUNTIME_DIR, 'deasync')).deasyncify(
+      async (p) => {
+        return await import(p);
+      }
+    );
+  } catch (error) {
+    // No ESM support (Node.js v12)
+    return null;
+  }
+})();
+
+const [handlerModuleType, handlerModuleFilename] = [
+  handlerModuleInstruction.slice(0, 3),
+  handlerModuleInstruction.slice(4),
+];
+const handlerModule =
+  handlerModuleType === 'esm' ? importEsm(handlerModuleFilename) : require(handlerModuleFilename);
+
+// 3. Resolve and instrument handler function
+const handlerBasename = path.basename(process.env._HANDLER);
+const resolveHandlerNotFoundError = (message) => {
+  return Object.assign(new Error(`${handlerBasename} ${message}`), {
+    name: 'Runtime.HandlerNotFound',
+  });
+};
+if (handlerModule == null) throw resolveHandlerNotFoundError('is undefined or not exported');
+
+const resolveHandlerObject = (resolvedHandlerModule) => {
+  let handlerContext = resolvedHandlerModule;
+  if (handlerContext == null) throw resolveHandlerNotFoundError('is undefined or not exported');
+
+  const handlerModuleBasename = handlerBasename.slice(0, handlerBasename.indexOf('.'));
+
+  const handlerPropertyPathTokens = handlerBasename
+    .slice(handlerModuleBasename.length + 1)
+    .split('.');
+  const handlerFunctionName = handlerPropertyPathTokens.pop();
+  while (handlerPropertyPathTokens.length) {
+    handlerContext = handlerContext[handlerPropertyPathTokens.shift()];
+    if (handlerContext == null) throw resolveHandlerNotFoundError('is undefined or not exported');
+  }
+  const handlerFunction = handlerContext[handlerFunctionName];
+  if (handlerFunction == null) throw resolveHandlerNotFoundError('is undefined or not exported');
+  if (typeof handlerFunction !== 'function') throw resolveHandlerNotFoundError('is not a function');
+
+  try {
+    const instrument = require('../instrument');
+    return { handler: instrument(handlerFunction) };
+  } catch (error) {
+    process._rawDebug(
+      'Fatal Serverless SDK Error: ' +
+        'Please report at https://github.com/serverless/console/issues: ' +
+        'Async handler setup failed: ',
+      error && (error.stack || error)
+    );
+    return { handler: handlerFunction };
+  }
+};
+
+if (isAsyncLoader && typeof handlerModule.then === 'function') {
+  module.exports = handlerModule.then(resolveHandlerObject);
+  return;
 }
+
+module.exports = resolveHandlerObject(handlerModule);

--- a/node/packages/aws-lambda-sdk/scripts/lib/build.js
+++ b/node/packages/aws-lambda-sdk/scripts/lib/build.js
@@ -34,9 +34,7 @@ module.exports = async (distFilename) => {
         await runEsbuild(
           path.resolve(path.resolve(internalDir, 'index.js')),
           '--bundle',
-          '--platform=node',
-          '--external:@serverless/aws-lambda-sdk',
-          '--external:../'
+          '--platform=node'
         )
       );
       zip.addFile(
@@ -46,7 +44,7 @@ module.exports = async (distFilename) => {
           '--bundle',
           '--platform=node',
           '--external:@serverless/aws-lambda-sdk',
-          '--external:../../'
+          '--external:../'
         )
       );
       zip.addFile(


### PR DESCRIPTION
When testing the `console.*` instrumentation, I realized that console patching doesn't pick up as expected. It appears it's because we initialize the SDK and the original handler _before_ the AWS Lambda initialization logic is run. This logic is responsible for patching of some Node.js core modules, including `console` (so messages are prefixed with timestamp and request-id) - so AWS Lambda logic overrides our patching and makes it ineffective.

The reason why we initialize handler _before_  the AWS Lambda initialization is to be able to prevent any instrumentation of the handler in case of its misconfiguration (e.g., not a function exported as a handler), so in such case, we leave the function untouched for AWS Lambda, and the surfaced error is the same whether lambdas are instrumented or not)

However, it introduces more concerning issues. Due to not being instrumented by AWS Lambda `console.*` methods work differently at the initialization phase when the function is instrumented (they're not patched by the AWS and hence not prefixed with the timestamp). Also, some other Node.js modules remain not instrumented at this point which introduces risks of other bugs if the user's code relies on those modules at the initialization phase.

Therefore, the right decision is to ensure that the original function is initialized in the same processing point as when it is not instrumented, which is what this PR fixes.
Thanks to that, all AWS Lambda patching is effective on initialization, and automatically also, our `console.` patching works without the issues.

Concerning invalid handler errors, to mitigate that problem, I've replicated the errors that AWS Lambda throws in such cases, so still user experience should remain the same with this approach.

_I've confirmed the change with all unit and integration tests passing_
