### PR TITLE
SDK: Differentiate events sourced from console.* calls

### DIFF
--- a/node/packages/sdk/lib/instrumentation/node-console.js
+++ b/node/packages/sdk/lib/instrumentation/node-console.js
@@ -2,6 +2,8 @@
 
 const isError = require('type/error/is');
 const util = require('util');
+const createErrorCapturedEvent = require('../create-error-captured-event');
+const createWarningCapturedEvent = require('../create-warning-captured-event');
 
 const nodeConsole = console;
 
@@ -30,12 +32,12 @@ module.exports.install = () => {
     original.error.apply(this, args);
     const error = args.find(isError);
     if (!error) return;
-    serverlessSdk.captureError(error);
+    createErrorCapturedEvent(error)._origin = 'nodeConsole';
   };
 
   nodeConsole.warn = function (...args) {
     original.warn.apply(this, args);
-    serverlessSdk.captureWarning(resolveWarnMesssage(args));
+    createWarningCapturedEvent(resolveWarnMesssage(args))._origin = 'nodeConsole';
   };
 
   uninstall = () => {
@@ -49,5 +51,3 @@ module.exports.uninstall = () => {
   isInstalled = false;
   uninstall();
 };
-
-const serverlessSdk = require('../..');

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { expect } = require('chai');
+const instrumentNodeConsole = require('../../../../lib/instrumentation/node-console');
+
+describe('lib/instrumentation/node-console.js', () => {
+  let serverlessSdk;
+  before(() => {
+    serverlessSdk = require('../../../../');
+    instrumentNodeConsole.install();
+  });
+  after(() => {
+    instrumentNodeConsole.uninstall();
+  });
+
+  it('should instrument `console.error`', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+    // eslint-disable-next-line no-console
+    console.error(new Error('My error'));
+
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `console.warn`', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+    // eslint-disable-next-line no-console
+    console.warn('My message', 12, true);
+
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('My message 12 true');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+});


### PR DESCRIPTION
_Depends on #346, which needs to be merged first_

For dev mode, we need to differentiate events sourced from `console.*` calls.

Initially, I planned to add an `origin` tag, but as this tag won't be supported by schema, it'll require extra cleanup work on the AWS Lambda SDK side. Therefore I resorted to a more primitive approach for now.