### PR TITLE
AWS Lambda SDK: Do not send `console.*` originated events to dev mode

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -54,6 +54,7 @@ serverlessSdk._eventEmitter.on('trace-span-close', (traceSpan) => {
 });
 
 serverlessSdk._eventEmitter.on('captured-event', (capturedEvent) => {
+  if (capturedEvent._origin === 'nodeConsole') return;
   pendingCapturedEvents.push(capturedEvent);
   scheduleEventually();
 });

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.11.6",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk": "^0.2.0",
+    "@serverless/sdk": "^0.2.1",
     "@serverless/sdk-schema": "^0.14.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
@@ -18,6 +18,13 @@ module.exports.handler = async (event) => {
     tags: { 'user.tag': 'example', 'invocationid': invocationId },
   });
 
+  console.error('My error: ', new Error('Consoled error'));
+
+  sdk.captureWarning('Captured warning', {
+    tags: { 'user.tag': 'example', 'invocationid': invocationId },
+  });
+
+  console.warn('Consoled warning', 12, true);
   return {
     name: sdk.name,
     version: sdk.version,

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1339,21 +1339,61 @@ describe('integration', function () {
               expect(payload.version).to.equal(pkgJson.version);
               expect(payload.rootSpanName).to.equal('aws.lambda');
 
-              const userEvent = events[0];
-              expect(events).to.deep.equal([
+              const normalizeEvent = (event) => {
+                event = { ...event };
+                expect(Buffer.isBuffer(event.id)).to.be.true;
+                expect(typeof event.timestampUnixNano).to.equal('number');
+                if (event.tags.error) delete event.tags.error.stacktrace;
+                delete event.id;
+                delete event.timestampUnixNano;
+                return event;
+              };
+              expect(events.map(normalizeEvent)).to.deep.equal([
                 {
-                  id: userEvent.id,
                   traceId: awsLambdaInvocationSpan.traceId,
                   spanId: awsLambdaInvocationSpan.id,
-                  timestampUnixNano: userEvent.timestampUnixNano,
-                  eventName: userEvent.eventName,
+                  eventName: 'telemetry.error.generated.v1',
                   customTags: JSON.stringify({ 'user.tag': 'example', 'invocationid': index + 1 }),
                   tags: {
                     error: {
                       name: 'Error',
                       message: 'Captured error',
-                      stacktrace: userEvent.tags.error.stacktrace,
                       type: 2,
+                    },
+                  },
+                },
+                {
+                  traceId: awsLambdaInvocationSpan.traceId,
+                  spanId: awsLambdaInvocationSpan.id,
+                  eventName: 'telemetry.error.generated.v1',
+                  customTags: JSON.stringify({}),
+                  tags: {
+                    error: {
+                      name: 'Error',
+                      message: 'Consoled error',
+                      type: 2,
+                    },
+                  },
+                },
+                {
+                  traceId: awsLambdaInvocationSpan.traceId,
+                  spanId: awsLambdaInvocationSpan.id,
+                  eventName: 'telemetry.warning.generated.v1',
+                  customTags: JSON.stringify({ 'user.tag': 'example', 'invocationid': index + 1 }),
+                  tags: {
+                    warning: {
+                      message: 'Captured warning',
+                    },
+                  },
+                },
+                {
+                  traceId: awsLambdaInvocationSpan.traceId,
+                  spanId: awsLambdaInvocationSpan.id,
+                  eventName: 'telemetry.warning.generated.v1',
+                  customTags: JSON.stringify({}),
+                  tags: {
+                    warning: {
+                      message: 'Consoled warning 12 true',
                     },
                   },
                 },


### PR DESCRIPTION
Additionally, ensure unit and integration tests for `capture*` methods and `console.*` instrumentation