### PR TITLE
fix: Added v3 document client support

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/service-mapper.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/service-mapper.js
@@ -1,5 +1,50 @@
 'use strict';
 
+const dynamodbConfig = {
+  params: (
+    traceSpan,
+    {
+      TableName: tableName,
+      GlobalTableName: globalTableName,
+      ConsistentRead: consistentRead,
+      Limit: limit,
+      AttributesToGet: attributesToGet,
+      ProjectionExpression: projectionExpression,
+      IndexName: indexName,
+      ScanIndexForward: scanIndexForward,
+      Select: select,
+      KeyConditionExpression: keyConditionExpression,
+      FilterExpression: filterExpression,
+      Segment: segment,
+      TotalSegments: totalSegments,
+      ExclusiveStartKey: exclusiveStartKey,
+    }
+  ) => {
+    const tags = {};
+    if (tableName) tags.table_name = tableName;
+    else if (globalTableName) tags.table_name = globalTableName;
+    if (consistentRead) tags.consistent_read = consistentRead;
+    if (limit) tags.limit = limit;
+    tags.attributes_to_get = attributesToGet || [];
+    if (projectionExpression) tags.projection = projectionExpression;
+    if (indexName) tags.index_name = indexName;
+    if (scanIndexForward) tags.scan_forward = scanIndexForward;
+    if (select) tags.select = select;
+    if (filterExpression) tags.filter = filterExpression;
+    if (keyConditionExpression) tags.key_condition = keyConditionExpression;
+    if (segment) tags.segment = segment;
+    if (totalSegments) tags.total_segments = totalSegments;
+    if (exclusiveStartKey) tags.exclusive_start_key = JSON.stringify(exclusiveStartKey);
+    traceSpan.tags.setMany(tags, { prefix: 'aws.sdk.dynamodb' });
+  },
+  responseData: (traceSpan, { Count: count, ScannedCount: scannedCount }) => {
+    const tags = {};
+    if (count) tags.count = count;
+    if (scannedCount) tags.scanned_count = scannedCount;
+    traceSpan.tags.setMany(tags, { prefix: 'aws.sdk.dynamodb' });
+  },
+};
+
 module.exports = new Map([
   [
     'sns',
@@ -57,51 +102,6 @@ module.exports = new Map([
       },
     },
   ],
-  [
-    'dynamodb',
-    {
-      params: (
-        traceSpan,
-        {
-          TableName: tableName,
-          GlobalTableName: globalTableName,
-          ConsistentRead: consistentRead,
-          Limit: limit,
-          AttributesToGet: attributesToGet,
-          ProjectionExpression: projectionExpression,
-          IndexName: indexName,
-          ScanIndexForward: scanIndexForward,
-          Select: select,
-          KeyConditionExpression: keyConditionExpression,
-          FilterExpression: filterExpression,
-          Segment: segment,
-          TotalSegments: totalSegments,
-          ExclusiveStartKey: exclusiveStartKey,
-        }
-      ) => {
-        const tags = {};
-        if (tableName) tags.table_name = tableName;
-        else if (globalTableName) tags.table_name = globalTableName;
-        if (consistentRead) tags.consistent_read = consistentRead;
-        if (limit) tags.limit = limit;
-        tags.attributes_to_get = attributesToGet || [];
-        if (projectionExpression) tags.projection = projectionExpression;
-        if (indexName) tags.index_name = indexName;
-        if (scanIndexForward) tags.scan_forward = scanIndexForward;
-        if (select) tags.select = select;
-        if (filterExpression) tags.filter = filterExpression;
-        if (keyConditionExpression) tags.key_condition = keyConditionExpression;
-        if (segment) tags.segment = segment;
-        if (totalSegments) tags.total_segments = totalSegments;
-        if (exclusiveStartKey) tags.exclusive_start_key = JSON.stringify(exclusiveStartKey);
-        traceSpan.tags.setMany(tags, { prefix: 'aws.sdk.dynamodb' });
-      },
-      responseData: (traceSpan, { Count: count, ScannedCount: scannedCount }) => {
-        const tags = {};
-        if (count) tags.count = count;
-        if (scannedCount) tags.scanned_count = scannedCount;
-        traceSpan.tags.setMany(tags, { prefix: 'aws.sdk.dynamodb' });
-      },
-    },
-  ],
+  ['dynamodb', dynamodbConfig],
+  ['dynamodbdocument', dynamodbConfig],
 ]);

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
@@ -8,6 +8,7 @@ const wait = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const sqs = new SQS();
 const sns = new SNS();
 const dynamoDb = new DynamoDB();
+const dynamodbDocumentClient = new DynamoDB.DocumentClient();
 const sts = new STS();
 
 let invocationCount = 0;
@@ -62,6 +63,14 @@ module.exports.handler = async () => {
         KeyConditionExpression: '#id = :id',
         ExpressionAttributeNames: { '#id': 'id' },
         ExpressionAttributeValues: { ':id': { S: 'test' } },
+      })
+      .promise();
+    await dynamodbDocumentClient
+      .query({
+        TableName: tableName,
+        KeyConditionExpression: '#id = :id',
+        ExpressionAttributeNames: { '#id': 'id' },
+        ExpressionAttributeValues: { ':id': 'test' },
       })
       .promise();
     await dynamoDb.deleteTable({ TableName: tableName }).promise();

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -1,9 +1,10 @@
 {
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.241.0",
+    "@aws-sdk/client-dynamodb": "^3.245.0",
     "@aws-sdk/client-sns": "^3.241.0",
     "@aws-sdk/client-sqs": "^3.241.0",
     "@aws-sdk/client-sts": "^3.241.0",
+    "@aws-sdk/lib-dynamodb": "^3.245.0",
     "aws-sdk": "^2.1288.0",
     "express": "^4.18.2",
     "serverless-http": "^3.1.0"


### PR DESCRIPTION
## Description
It is kind of funny we didn't notice this until recently but if you use document client in the v3 sdk the `dynamodb` tags were not showing up in the `aws.sdk` tags section because it was called `dynamodbdocument` instead of `dynamodb`.

This addresses that issue by adding a common dynamodb config between document client and the usual dynamo client 👍 