### PR TITLE
fix: Adjusted typescript implementation for sdk

### DIFF
--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -19,7 +19,7 @@ export interface Sdk {
     options?: {
       startTime?: bigint;
       immediateDescendants?: string[];
-      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
+      tags?: Record<string, boolean | number | string | Date | Array<unknown> | null>;
       input?: string;
       output?: string;
       onCloseByRoot?: Function;
@@ -28,13 +28,13 @@ export interface Sdk {
   captureError(
     error: Error,
     options?: {
-      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
+      tags?: Record<string, boolean | number | string | Date | Array<unknown> | null>;
     }
   ): undefined;
   captureWarning(
     message: string,
     options?: {
-      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
+      tags?: Record<string, boolean | number | string | Date | Array<unknown> | null>;
     }
   ): undefined;
 }

--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -1,5 +1,6 @@
 import TraceSpan from './lib/trace-span';
 import ExpressAppInstrument from './instrumentation/express-app';
+import sdk from './../index';
 
 export interface TraceSpans {}
 
@@ -7,7 +8,7 @@ export interface Instrumentation {
   expressApp: ExpressAppInstrument;
 }
 
-interface Sdk {
+export interface Sdk {
   name: string;
   version: string;
   orgId: string;
@@ -18,7 +19,7 @@ interface Sdk {
     options?: {
       startTime?: bigint;
       immediateDescendants?: string[];
-      tags?: Record<string, boolean | number | string | Date | Array | Null>;
+      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
       input?: string;
       output?: string;
       onCloseByRoot?: Function;
@@ -27,18 +28,16 @@ interface Sdk {
   captureError(
     error: Error,
     options?: {
-      tags?: Record<string, boolean | number | string | Date | Array | Null>;
+      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
     }
   ): undefined;
   captureWarning(
     message: string,
     options?: {
-      tags?: Record<string, boolean | number | string | Date | Array | Null>;
+      tags?: Record<string, boolean | number | string | Date | Array<any> | null>;
     }
   ): undefined;
 }
-
-export default Sdk;
 
 export interface SdkOptions {
   orgId?: string;
@@ -48,3 +47,5 @@ export interface SdkOptions {
   disableNodeConsoleMonitoring?: boolean;
   traceMaxCapturedBodySizeKb?: number;
 }
+
+export default sdk;

--- a/node/packages/sdk/.ts-types/lib/tags.d.ts
+++ b/node/packages/sdk/.ts-types/lib/tags.d.ts
@@ -1,7 +1,7 @@
 declare class Tags extends Map {
-  set(key: string, value: boolean | number | string | Date | Array<any>): Tags;
+  set(key: string, value: boolean | number | string | Date | Array<unknown>): this;
   setMany(
-    tags: Record<string, boolean | number | string | Date | Array<any> | null>,
+    tags: Record<string, boolean | number | string | Date | Array<unknown> | null>,
     options?: { prefix?: string }
   ): Tags;
 }

--- a/node/packages/sdk/.ts-types/lib/tags.d.ts
+++ b/node/packages/sdk/.ts-types/lib/tags.d.ts
@@ -1,7 +1,7 @@
 declare class Tags extends Map {
-  set(key: string, value: boolean | number | string | Date | Array): Tags;
+  set(key: string, value: boolean | number | string | Date | Array<any>): Tags;
   setMany(
-    tags: Record<string, boolean | number | string | Date | Array | Null>,
+    tags: Record<string, boolean | number | string | Date | Array<any> | null>,
     options?: { prefix?: string }
   ): Tags;
 }

--- a/node/packages/sdk/index.ts
+++ b/node/packages/sdk/index.ts
@@ -1,0 +1,4 @@
+import { Sdk } from '@serverless/sdk';
+const sdk = require('./index.js');
+
+export default sdk as Sdk;


### PR DESCRIPTION
## Description
Changed the `index.d.ts` file to import the main implementation file via the `index.ts` file as well as export the `Sdk` type. This should give typescript projects typical intellisense and the ability to import the sdk like typical typescript packages.