### PR TITLE
AWS Lambda SDK: Revert problematic TS addition

### DIFF
--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -1,6 +1,5 @@
 import TraceSpan from './lib/trace-span';
 import ExpressAppInstrument from './instrumentation/express-app';
-import sdk from './../index';
 
 export interface TraceSpans {}
 
@@ -8,7 +7,7 @@ export interface Instrumentation {
   expressApp: ExpressAppInstrument;
 }
 
-export interface Sdk {
+interface Sdk {
   name: string;
   version: string;
   orgId: string;
@@ -41,6 +40,8 @@ export interface Sdk {
   ): undefined;
 }
 
+export default Sdk;
+
 export interface SdkOptions {
   orgId?: string;
   disableHttpMonitoring?: boolean;
@@ -49,5 +50,3 @@ export interface SdkOptions {
   disableNodeConsoleMonitoring?: boolean;
   traceMaxCapturedBodySizeKb?: number;
 }
-
-export default sdk;

--- a/node/packages/sdk/index.ts
+++ b/node/packages/sdk/index.ts
@@ -1,4 +1,0 @@
-import { Sdk } from '@serverless/sdk';
-const sdk = require('./index.js');
-
-export default sdk as Sdk;


### PR DESCRIPTION
Revert https://github.com/serverless/console/pull/360

1. Our extension stopped building properly
2. We should not introduce TS files. I believe as in the case of other packages that take a similar approach, just typing should be good enough to have ensured proper IntelliSense. If there's an issue with that I'll look into improvement to typings on their own