### PR TITLE
chore: Release v0.2.5 of the sdk

### DIFF
--- a/node/packages/sdk/CHANGELOG.md
+++ b/node/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.5](https://github.com/serverless/console/compare/@serverless/sdk@0.2.4...@serverless/sdk@0.2.5) (2023-01-11)
+
+### Bug Fixes
+
+- Fixed typings file ([#369](https://github.com/serverless/console/issues/369)) ([2deeb4b](https://github.com/serverless/console/commit/2deeb4b49b196eadde6ca85fc87f7fb9c00f453c))
+
 ### [0.2.4](https://github.com/serverless/console/compare/@serverless/sdk@0.2.3...@serverless/sdk@0.2.4) (2023-01-11)
 
 ### Features

--- a/node/packages/sdk/package.json
+++ b/node/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/sdk",
   "repository": "serverless/console",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "Serverless, Inc.",
   "dependencies": {
     "d": "^1.0.1",


### PR DESCRIPTION
## Description
Releasing this version of the sdk so that we can include it in the `aws-lambda-sdk` release 😎 