### PR TITLE
AWS Lambda SDK: Test: Fix tests that confirm on dynamodb document client

### DIFF
--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -259,17 +259,17 @@ describe('integration', function () {
       expect(sdkTags.dynamodb.tableName).to.equal(tableName);
       expect(sdkTags.dynamodb.keyCondition).to.equal('#id = :id');
       // Query with document client
+      const dynamoDbServiceName = testConfig.configuration.FunctionName.includes('aws-sdk-v2')
+        ? 'dynamodb'
+        : 'dynamodbdocument';
       expect(dynamodbDocumentClientSpan.parentSpanId.toString()).to.equal(
         invocationSpan.id.toString()
       );
-      const expectedSpanName = /aws-sdk-v2/.test(testConfig.configuration.FunctionName)
-        ? 'aws.sdk.dynamodb.query'
-        : 'aws.sdk.dynamodbdocument.query';
-      expect(dynamodbDocumentClientSpan.name).to.equal(expectedSpanName);
+      expect(dynamodbDocumentClientSpan.name).to.equal(`aws.sdk.${dynamoDbServiceName}.query`);
       sdkTags = dynamodbDocumentClientSpan.tags.aws.sdk;
       expect(sdkTags.region).to.equal(process.env.AWS_REGION);
       expect(sdkTags.signatureVersion).to.equal('v4');
-      expect(sdkTags.service).to.equal('dynamodbdocument');
+      expect(sdkTags.service).to.equal(dynamoDbServiceName);
       expect(sdkTags.operation).to.equal('query');
       expect(sdkTags).to.have.property('requestId');
       expect(sdkTags).to.not.have.property('error');

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -29,7 +29,7 @@ for (const name of ['TEST_INTERNAL_LAYER_FILENAME']) {
 }
 
 describe('integration', function () {
-  this.timeout(120000);
+  this.timeout(180000);
   const coreConfig = {};
 
   const getCreateHttpApi = (payloadFormatVersion) => async (testConfig) => {


### PR DESCRIPTION
Fix for issue introduced with https://github.com/serverless/console/pull/354 (exposed with integration test fail: https://github.com/serverless/console/actions/runs/3874394369/jobs/6605548546)

In AWS SDK v2 service name is `dynamodb` while in AWS SDK v3 it's `dynamodbdocument`. Configured test took that into account with the span name but not with the `service` tag.

Additionally, increased timeout for integration tests, as it needs more room if e.g. tests are started after failure, and functions need to be re-created (so removed and created and not just created)