### PR TITLE
SDK: Make `createTraceSpan` private

### DIFF
--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -1,4 +1,3 @@
-import TraceSpan from './lib/trace-span';
 import ExpressAppInstrument from './instrumentation/express-app';
 
 export interface TraceSpans {}
@@ -13,17 +12,6 @@ export interface Sdk {
   orgId: string;
   traceSpans: TraceSpans;
   instrumentation: Instrumentation;
-  createTraceSpan(
-    name: string,
-    options?: {
-      startTime?: bigint;
-      immediateDescendants?: string[];
-      tags?: Record<string, boolean | number | string | Date | Array<unknown> | null>;
-      input?: string;
-      output?: string;
-      onCloseByRoot?: Function;
-    }
-  ): TraceSpan;
   captureError(
     error: Error,
     options?: {

--- a/node/packages/sdk/.ts-types/lib/trace-span.d.ts
+++ b/node/packages/sdk/.ts-types/lib/trace-span.d.ts
@@ -10,9 +10,6 @@ declare class TraceSpan {
   input?: string;
   output?: string;
 
-  close(): TraceSpan;
-  closeContext(): undefined;
-  destroy(): undefined;
   toJSON(): Object;
 }
 

--- a/node/packages/sdk/README.md
+++ b/node/packages/sdk/README.md
@@ -26,9 +26,7 @@ _CJS:_
 const serverlessSdk = require('@serverless/sdk');
 
 // ...
-const customTraceSpan = serverlessSdk.createTraceSpan('custom.tracespan');
-// ...
-customTraceSpan.close();
+serverlessSdk.captureError(new Error('Unexpected'));
 ```
 
 _ESM:_
@@ -37,9 +35,7 @@ _ESM:_
 import serverlessSdk from '@serverless/sdk';
 
 // ...
-const customTraceSpan = serverlessSdk.createTraceSpan('custom.tracespan');
-// ...
-customTraceSpan.close();
+serverlessSdk.captureError(new Error('Unexpected'));
 ```
 
 ### Setup

--- a/node/packages/sdk/docs/sdk.md
+++ b/node/packages/sdk/docs/sdk.md
@@ -12,18 +12,6 @@ Most of the instrumentation is setup automatically, still there are scenarios wh
 
 - `.expressApp.install(express)` - Instrument Express. See [instrumentatiom/express-app](instrumentation/express-app.md)
 
-### `.createTraceSpan(name[, options])`
-
-Create custom trade span
-
-- `name` - Name of the span
-- `options` - Optional setup:
-  - `startTime` _(bigInt)_ - Externally recorded span _start time_. If not provided, it's resolved automatically on span creation. It cannot be set in a future, and must not be set before `startTime` of the currently ongoing span
-  - `immediateDescendants` _([...string])_ - If intention is to create sub span descenant at once, names of those spans can be passed with this option. Descendant spans will be created automatically and will share same `startTime` as top sub span
-  - `onCloseByRoot` _(function)_ - If provided, it'll be invoked if span will be autoclosed when closing the invocation trace. Useful for reporting errors in such scenarios
-
-Returns instance of [TraceSpan](trace-span.md)
-
 ### `.captureError(error[, options])`
 
 Record captured error

--- a/node/packages/sdk/docs/trace-span.md
+++ b/node/packages/sdk/docs/trace-span.md
@@ -1,7 +1,5 @@
 # TraceSpan
 
-_New trace span can be created via [`serverlessSdk.createTraceSpan`](./sdk.md#serverlesssdkcreatetracespanname-options)._
-
 ## Properties
 
 ### `name` _(string)_
@@ -49,43 +47,6 @@ Eventual span input body
 Eventual span output body
 
 ## Methods
-
-### `close([options])`
-
-Closes span and all sub spans.
-
-Supported options:
-
-- `endTime` - Externally recorded _end time_. If not provided, it's resolved automatically. Cannot be earlier than `startTime` and cannot be set in a future
-
-### `closeContext`
-
-After creating a span, this needs to be called if, after a certain point, we do not want to attribute the following logic to the span context
-
-e.g.:
-
-```javascript
-const fooSpan = serverlessSdk.createTraceSpan('foo');
-runFoo();
-// Ensure "bar" trace span is not a sub span of "foo"
-fooSpan.closeContext();
-const barSpan = serverlessSdk.createTraceSpan('bar');
-runBar();
-```
-
-### `destroy()`
-
-Permanently removes the span from the trace. Useful if we created span, but logic it was supposed to describe failed to initialize,, e.g.:
-
-```javascript
-const fooSpan = serverlessSdk.createTraceSpan('foo');
-try {
-  runFoo().finally(() => fooSpan.close());
-} catch (error) {
-  fooSpan.destroy();
-  throw error;
-}
-```
 
 #### `toJSON()`
 

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -31,7 +31,6 @@ Object.defineProperties(
     expressApp: d('cew', () => require('./instrumentation/express-app')),
   })
 );
-serverlessSdk.createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
 serverlessSdk.captureError = (error, options = {}) => {
   createErrorCapturedEvent(error, options);
 };
@@ -90,6 +89,7 @@ serverlessSdk._initialize = (options = {}) => {
   return serverlessSdk;
 };
 
+serverlessSdk._createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
 serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
 serverlessSdk._debugLog = (...args) => {
   if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);

--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -17,7 +17,7 @@ module.exports.install = (layerPrototype) => {
 
   layerPrototype.handle_request = function handle(req, res, next) {
     if (!expressSpansMap.has(req)) {
-      const expressSpan = serverlessSdk.createTraceSpan('express');
+      const expressSpan = serverlessSdk._createTraceSpan('express');
       const openedSpans = new Set();
       const expressRouteData = { expressSpan, openedSpans };
       expressSpansMap.set(req, expressRouteData);
@@ -51,7 +51,7 @@ module.exports.install = (layerPrototype) => {
         ? 'express.middleware.router'
         : `express.middleware.${generateMiddlewareName(this.name) || 'unknown'}`;
     })();
-    const middlewareSpan = serverlessSdk.createTraceSpan(middlewareSpanName);
+    const middlewareSpan = serverlessSdk._createTraceSpan(middlewareSpanName);
     openedSpans.add(middlewareSpan);
     if (this.path && (!expressRouteData.path || expressRouteData.path.length < this.path.length)) {
       expressRouteData.path = this.path;
@@ -77,7 +77,7 @@ module.exports.install = (layerPrototype) => {
   // eslint-disable-next-line camelcase
   layerPrototype.handle_error = function handle_error(error, req, res, next) {
     const { openedSpans } = expressSpansMap.get(req);
-    const middlewareSpan = serverlessSdk.createTraceSpan(
+    const middlewareSpan = serverlessSdk._createTraceSpan(
       `express.middleware.error.${generateMiddlewareName(this.name) || 'unknown'}`
     );
     openedSpans.add(middlewareSpan);

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -154,7 +154,7 @@ const install = (protocol, httpModule) => {
       if (originalCb) originalCb(response);
     });
 
-    const traceSpan = serverlessSdk.createTraceSpan(`node.${protocol}.request`, {
+    const traceSpan = serverlessSdk._createTraceSpan(`node.${protocol}.request`, {
       startTime,
       onCloseByRoot: () => {
         if (responseReadableState && responseReadableState.flowing === false) {


### PR DESCRIPTION
`sdk.createTraceSpan` is removed. The functionality of creating custom spans is not considered part of public API at the time being (a new method for that will be introduced in one of the following releases)