### PR TITLE
SDK: Dedicated handling for structured warnings issued by the SDK

### DIFF
--- a/node/packages/sdk/lib/create-warning-captured-event.js
+++ b/node/packages/sdk/lib/create-warning-captured-event.js
@@ -13,7 +13,7 @@ module.exports = (message, options = {}) => {
     timestamp,
     customTags: options.tags,
     customFingerprint: options.fingerprint,
-    tags: { 'warning.message': message },
+    tags: { 'warning.message': message, 'warning.type': options.type || 1 },
     _origin: options._origin,
   });
 };

--- a/node/packages/sdk/lib/instrumentation/node-console.js
+++ b/node/packages/sdk/lib/instrumentation/node-console.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isError = require('type/error/is');
+const isPlainObject = require('type/plain-object/is');
 const util = require('util');
 const createErrorCapturedEvent = require('../create-error-captured-event');
 const createWarningCapturedEvent = require('../create-warning-captured-event');
@@ -37,7 +38,11 @@ module.exports.install = () => {
 
   nodeConsole.warn = function (...args) {
     original.warn.apply(this, args);
-    createWarningCapturedEvent(resolveWarnMesssage(args), { _origin: 'nodeConsole' });
+    if (isPlainObject(args[0]) && args[0].source === 'serverlessSdk') {
+      createWarningCapturedEvent(args[0].message, { _origin: 'nodeConsole', type: 2 });
+    } else {
+      createWarningCapturedEvent(resolveWarnMesssage(args), { _origin: 'nodeConsole' });
+    }
   };
 
   uninstall = () => {

--- a/node/packages/sdk/test/unit/lib/create-warning-captured-event.test.js
+++ b/node/packages/sdk/test/unit/lib/create-warning-captured-event.test.js
@@ -12,6 +12,7 @@ describe('lib/create-captured-warning-event.test.js', () => {
     });
     expect(event.tags.toJSON()).to.deep.equal({
       'warning.message': 'Warning message',
+      'warning.type': 1,
     });
     expect(event.customTags.toJSON()).to.deep.equal({
       'my.tag': 'whatever',

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
@@ -34,4 +34,16 @@ describe('lib/instrumentation/node-console.js', () => {
     expect(capturedEvent.tags.get('warning.message')).to.equal('My message 12 true');
     expect(capturedEvent._origin).to.equal('nodeConsole');
   });
+
+  it('should recognize Serverless SDK warning', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+    // eslint-disable-next-line no-console
+    console.warn({ source: 'serverlessSdk', message: 'Something is wrong' });
+
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('Something is wrong');
+    expect(capturedEvent.tags.get('warning.type')).to.equal(2);
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
 });


### PR DESCRIPTION
We want to report warning as generated by SDK to the Console and label them as coming from this SDK.
Additional requirement was to rely on structure logging, so also in CloudWatch those logs are discoverable

This patch implements handing for SDK originated structured warnings as such:

```javascript
console.warn({ source: "serverlessSdk", message: "Something is off"})
```

Those are caught as captured warning events and marked as of SDK type