### PR TITLE
feat: Added increasing string as sequenceId

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -157,7 +157,7 @@ func FormatLogs(logs []LogItem, requestId string, accountId string, traceId stri
 		SlsTags:   &slsTags,
 		LogEvents: messages,
 	}
-	for _, log := range logs {
+	for i, log := range logs {
 		if log.LogType == "function" {
 			t, _ := time.Parse(time.RFC3339, log.Time)
 			if !strings.Contains(log.Record.(string), "SERVERLESS_TELEMETRY.") {
@@ -167,6 +167,7 @@ func FormatLogs(logs []LogItem, requestId string, accountId string, traceId stri
 				logStream := os.Getenv("AWS_LAMBDA_LOG_STREAM_NAME")
 				orgId := os.Getenv("SLS_DEV_MODE_ORG_ID")
 				rec := log.Record.(string)
+				sequenceId := fmt.Sprintf("%v", time.Now().UnixNano()+int64(i))
 				messages = append(messages, &schema.LogEvent{
 					Body:      rec,
 					Timestamp: uint64(t.UnixMilli()),
@@ -177,10 +178,11 @@ func FormatLogs(logs []LogItem, requestId string, accountId string, traceId stri
 					TraceId:        &traceId,
 					Tags: &tags.Tags{
 						Aws: &tags.AwsTags{
-							LogGroup:  &logGroup,
-							LogStream: &logStream,
-							AccountId: &accountId,
-							RequestId: &requestId,
+							LogGroup:   &logGroup,
+							LogStream:  &logStream,
+							SequenceId: &sequenceId,
+							AccountId:  &accountId,
+							RequestId:  &requestId,
 						},
 						OrgId: &orgId,
 					},

--- a/go/packages/dev-mode/main_test.go
+++ b/go/packages/dev-mode/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -212,6 +213,13 @@ func TestInvokeStartDoneTwice(t *testing.T) {
 		for index, event := range protoPayload.LogEvents {
 			if event.Body != messages[index] {
 				t.Errorf("Expected log message %s Received %s", event.Body, messages[index])
+			}
+			if index == 1 {
+				event2SeqId, _ := strconv.ParseInt(*event.Tags.Aws.SequenceId, 10, 64)
+				event1SeqId, _ := strconv.ParseInt(*protoPayload.LogEvents[index-1].Tags.Aws.SequenceId, 10, 64)
+				if event2SeqId < event1SeqId {
+					t.Errorf("Expected log message sequenceId to be an increasing value. Event 2 SequenceId %d. Event 1 SequenceId %d", event2SeqId, event1SeqId)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Added a sequenceId that increases in value so that we can use this as a fallback if two logs have the same timestamp 