### PR TITLE
AWS Lambda SDK: Print traces in case of unhandled exceptions at invocation phase

### DIFF
--- a/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
@@ -23,6 +23,7 @@ const path = require('path');
   // eslint-disable-next-line import/no-unresolved
   return require('@serverless/aws-lambda-sdk');
 })()._initialize();
+const instrument = require('../instrument');
 
 // 2. Initialize original handler
 const nodeVersionMajor = Number(process.version.split('.')[0].slice(1));
@@ -81,7 +82,6 @@ const resolveHandlerObject = (resolvedHandlerModule) => {
   if (typeof handlerFunction !== 'function') throw resolveHandlerNotFoundError('is not a function');
 
   try {
-    const instrument = require('../instrument');
     return { handler: instrument(handlerFunction) };
   } catch (error) {
     process._rawDebug(

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-async-initialization/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-async-initialization/index.js
@@ -2,4 +2,4 @@
 
 await new Promise((resolve) => setTimeout(resolve));
 
-throw new Error('Unhandled');
+throw new Error('Stop');

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-initialization.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-initialization.js
@@ -1,3 +1,3 @@
 'use strict';
 
-throw new Error('Initialization');
+throw new Error('Stop');

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught-immediate.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught-immediate.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.handler = () => {
+  throw new Error('Stop');
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.handler = () =>
+  setTimeout(() => {
+    throw new Error('Stop');
+  });

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-unhandled.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-unhandled.js
@@ -1,6 +1,3 @@
 'use strict';
 
-module.exports.handler = () =>
-  setTimeout(() => {
-    throw new Error('Unhandled');
-  });
+module.exports.handler = () => setTimeout(() => Promise.reject(new Error('Stop')));


### PR DESCRIPTION
I've found a way on how to hack the AWS setup, so we can observe uncaught exceptions and unhandled rejections as a _man in the middle_, and through that, we can print traces to CW logs when they happen.

One side effect is that AWS normally in such situation immediately stops the Lambda, and our injection logic will postpone it by a few ticks, and in the case of dev mode, it'll take longer as we will wait for requests to drain. This characteristic may introduce situations where Lambda crashes differently whether SDK is attached or not (as during a delay introduced by our SDK the second crash may happen in lambda logic and that will crash Lambda immediately). Still, I consider it a rare edge case.