### PR TITLE
AWS Lambda SDK: Upgrade to `@serverless/sdk` v0.3.1

### DIFF
--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -8,8 +8,7 @@ module.exports = serverlessSdk;
 // Public
 serverlessSdk.name = pkgJson.name;
 serverlessSdk.version = pkgJson.version;
-serverlessSdk.traceSpans.root =
-  serverlessSdk.traceSpans.awsLambda = require('./trace-spans/aws-lambda');
+serverlessSdk.traceSpans.awsLambda = require('./trace-spans/aws-lambda');
 serverlessSdk.traceSpans.awsLambdaInitialization = require('./trace-spans/aws-lambda-initialization');
 
 serverlessSdk.instrumentation.awsSdkV2 = require('./instrumentation/aws-sdk-v2');

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.13.0",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk": "^0.3.0",
+    "@serverless/sdk": "^0.3.1",
     "@serverless/sdk-schema": "^0.14.2",
     "d": "^1.0.1",
     "ext": "^1.7.0",


### PR DESCRIPTION
Starting v0.3.1 `serverlessSdk.traceSpans.root` is auto resolved in SDK context (https://github.com/serverless/console/commit/99eb5e2f20cd60c3e99c75d7e33e70845ef7f9b2)