### PR TITLE
AWS Lambda SDK: Handle gently non JSON compliant AWS SDK input and output

### DIFF
--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -5,6 +5,7 @@ const ensureConstructor = require('type/constructor/ensure');
 const doNotInstrumentFollowingHttpRequest =
   require('@serverless/sdk/lib/instrumentation/http').ignoreFollowingRequest;
 const serviceMapper = require('../lib/instrumentation/aws-sdk/service-mapper');
+const safeStringify = require('../lib/instrumentation/aws-sdk/safe-stringify');
 
 const instrumentedSdks = new WeakMap();
 
@@ -36,7 +37,7 @@ module.exports.install = (Sdk) => {
         'aws.sdk.service': serviceName,
         'aws.sdk.operation': operationName,
       },
-      input: shouldMonitorRequestResponse ? JSON.stringify(params) : null,
+      input: shouldMonitorRequestResponse ? safeStringify(params) : null,
     });
     if (tagMapper && tagMapper.params) tagMapper.params(traceSpan, params);
     let wasCompleted = false;
@@ -57,7 +58,7 @@ module.exports.install = (Sdk) => {
       if (response.error) {
         traceSpan.tags.set('aws.sdk.error', response.error.message);
       } else {
-        if (shouldMonitorRequestResponse) traceSpan.output = JSON.stringify(response.data);
+        if (shouldMonitorRequestResponse) traceSpan.output = safeStringify(response.data);
         if (tagMapper && tagMapper.responseData) tagMapper.responseData(traceSpan, response.data);
       }
       if (!traceSpan.endTime) traceSpan.close();

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -7,6 +7,7 @@ const doNotInstrumentFollowingHttpRequest =
 const instrumentedClients = new WeakMap();
 
 const serviceMapper = require('../lib/instrumentation/aws-sdk/service-mapper');
+const safeStringify = require('../lib/instrumentation/aws-sdk/safe-stringify');
 
 module.exports.install = (client) => {
   ensureObject(client, { errorMessage: '%v is not an instance of AWS SDK v3 client' });
@@ -36,7 +37,7 @@ module.exports.install = (client) => {
               'aws.sdk.operation': operationName,
               'aws.sdk.signature_version': 'v4',
             },
-            input: shouldMonitorRequestResponse ? JSON.stringify(args.input) : null,
+            input: shouldMonitorRequestResponse ? safeStringify(args.input) : null,
           }
         );
         if (tagMapper && tagMapper.params) tagMapper.params(traceSpan, args.input);
@@ -68,7 +69,7 @@ module.exports.install = (client) => {
           throw error;
         } else {
           traceSpan.tags.set('aws.sdk.request_id', response.output.$metadata.requestId);
-          if (shouldMonitorRequestResponse) traceSpan.output = JSON.stringify(response.output);
+          if (shouldMonitorRequestResponse) traceSpan.output = safeStringify(response.output);
           if (tagMapper && tagMapper.responseData) {
             tagMapper.responseData(traceSpan, response.output);
           }

--- a/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const util = require('util');
+
+const replacer = (key, value) => {
+  return typeof value === 'bigint' ? value.toString() : value;
+};
+
+module.exports = (value) => {
+  try {
+    return JSON.stringify(value, replacer);
+  } catch (error) {
+    console.warn({
+      source: 'serverlessSdk',
+      message:
+        'Detected not serializable value in AWS SDK request:\n' +
+        `\tvalue: ${util.inspect(value)}\n` +
+        `\terror:${error.message}`,
+      code: 'AWS_SDK_DOUBLE_RESOLUTION',
+    });
+    return null;
+  }
+};


### PR DESCRIPTION
/cc @garethmcc 

Addresses issue reported by user attempting to use dev mode

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at /opt/sls-sdk-node/index.js:2919:58
    at /var/runtime/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:6:28"
```

It appears user is passing _bigint_ values with AWS SDK payload.

This fix ensures we normalize such values as strings and do not crash on JSON stringification.

With no integration test at this point, as it's not clear to me which AWS service and method supports bigint as input.