### PR TITLE
SDK: Do not crash `setTag` when run in uninstrumented environment

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
@@ -24,6 +24,8 @@ module.exports.handler = async (event) => {
     tags: { 'user.tag': 'example', 'invocationid': invocationId },
   });
 
+  sdk.setTag('user.tag', 'example');
+
   console.warn('Consoled warning', 12, true);
   return {
     name: sdk.name,

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1396,6 +1396,7 @@ describe('integration', function () {
               expect(payload.name).to.equal(pkgJson.name);
               expect(payload.version).to.equal(pkgJson.version);
               expect(payload.rootSpanName).to.equal('aws.lambda');
+              expect(JSON.parse(spans[0].customTags)).to.deep.equal({ 'user.tag': 'example' });
 
               const normalizeEvent = (event) => {
                 event = { ...event };

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -815,6 +815,7 @@ describe('internal-extension/index.test.js', () => {
     expect(result.name).to.equal(pkgJson.name);
     expect(result.version).to.equal(pkgJson.version);
     expect(result.rootSpanName).to.equal('aws.lambda');
+    expect(JSON.parse(spans[0].customTags)).to.deep.equal({ 'user.tag': 'example' });
 
     const normalizeEvent = (event) => {
       event = { ...event };

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -43,7 +43,15 @@ serverlessSdk.captureWarning = (message, options = {}) => {
 };
 serverlessSdk.setTag = (name, value) => {
   if (!serverlessSdk.traceSpans.root) {
-    throw new Error('Cannot set tag with no root trace span being initialized');
+    console.warn({
+      source: 'serverlessSdk',
+      message:
+        'Cannot set tag with no root trace span being initialized. ' +
+        'Lack of root span signals that Serverless SDK was most likely not initialized ' +
+        '(given environment is not being instrumented)',
+      code: 'NO_ROOT_TRACE_SPAN',
+    });
+    return;
   }
   serverlessSdk.traceSpans.root.customTags.set(name, value);
 };


### PR DESCRIPTION
@skierkowski reported a case where Lambda crashed with:

```
Error: Cannot set tag with no root trace span being initialized
```

The stack trace shows that it's thrown by the SDK installed in the Lambda folder by the user (not one provided through the extension). The fact that this error is thrown signals that there's no SDK initialized by the extension, so we deal with not instrumented Lambda. This is a real-world scenario that will happen for users when Lambda's configuration is updated, and for some time SDK extension is removed.

This patch ensures we do not crash in such case. Just log a warning.

Additionally added proper integration test coverage for `serverlessSdk.setTag`