### PR TITLE
feat: Add fingerprints array to span schema

### DIFF
--- a/node/packages/sdk-schema/test/unit/span.test.js
+++ b/node/packages/sdk-schema/test/unit/span.test.js
@@ -33,6 +33,7 @@ const testTracePayload = {
       name: 'test',
       startTimeUnixNano: longValue,
       endTimeUnixNano: longValue,
+      fingerprints: [],
       tags: {
         aws: {
           lambda: {

--- a/node/packages/sdk/lib/trace-span.js
+++ b/node/packages/sdk/lib/trace-span.js
@@ -160,6 +160,7 @@ class TraceSpan {
       output: this.output || undefined,
       tags: this.tags,
       customTags: objHasOwnProperty.call(this, 'customTags') ? this.customTags : undefined,
+      fingerprints: [],
     };
   }
   toProtobufObject() {
@@ -176,6 +177,7 @@ class TraceSpan {
       customTags: objHasOwnProperty.call(this, 'customTags')
         ? JSON.stringify(this.customTags)
         : undefined,
+      fingerprints: [],
     };
   }
   get spans() {

--- a/node/packages/sdk/test/unit/lib/trace-span.test.js
+++ b/node/packages/sdk/test/unit/lib/trace-span.test.js
@@ -143,6 +143,7 @@ describe('lib/trace-span.test.js', () => {
       endTime: jsonValue.endTime,
       tags: { foo: 12 },
       customTags: { elo: 'marko' },
+      fingerprints: [],
     });
   });
 
@@ -170,6 +171,7 @@ describe('lib/trace-span.test.js', () => {
       endTimeUnixNano: protoJson.endTimeUnixNano,
       input: 'some input',
       output: 'some output',
+      fingerprints: [],
       tags: {
         toptag: '1',
         top: { nested: '2', deep: { nested: '3' } },

--- a/proto/serverless/instrumentation/v1/trace.proto
+++ b/proto/serverless/instrumentation/v1/trace.proto
@@ -74,4 +74,9 @@ message Span {
     // The optional custom tags to be set by the user
     // This is expected to be a JSON object in string format.
     optional string custom_tags = 13;
+
+    // Optional list of event fingerprints related to the span.
+    // This will most likely always be populated by ingest when looking at the events
+    // attached to the TracePayload
+    repeated string fingerprints = 14;
 }


### PR DESCRIPTION
We need to be able to filter spans/traces by the errors/warnings that they generate. This PR Adds a repeated field on the `Span` schema that we can populate on ingest when we have the spans and events together. 