### PR TITLE
AWS Lambda SDK: Ensure to not instrument S3 requests signing

### DIFF
--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -22,6 +22,13 @@ module.exports.install = (Sdk) => {
   const shouldMonitorRequestResponse =
     serverlessSdk._isDevMode && !serverlessSdk._settings.disableRequestResponseMonitoring;
   const originalRunTo = Sdk.Request.prototype.runTo;
+  const originalPresign = Sdk.Request.prototype.presign;
+  Sdk.Request.prototype.presign = function presign(expires, callback) {
+    // Presign only pre-configures request url but does not issue real AWS SDK request.
+    // Ensure to not instrument such requests
+    this.runTo = originalRunTo;
+    return originalPresign.call(this, expires, callback);
+  };
   Sdk.Request.prototype.runTo = function runTo(state, done) {
     // identifier
     const serviceName =

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -68,6 +68,10 @@ module.exports.install = (client) => {
           if (!traceSpan.endTime) traceSpan.close();
           throw error;
         } else {
+          if (!response.output.$metadata.requestId) {
+            traceSpan.destroy(); // Not a real AWS request (e.g. S3 presigned URL)
+            return response;
+          }
           traceSpan.tags.set('aws.sdk.request_id', response.output.$metadata.requestId);
           if (shouldMonitorRequestResponse) traceSpan.output = safeStringify(response.output);
           if (tagMapper && tagMapper.responseData) {

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
@@ -1,10 +1,11 @@
 'use strict';
 
 // eslint-disable-next-line import/no-unresolved
-const { SQS, SNS, DynamoDB, STS } = require('aws-sdk');
+const { S3, SQS, SNS, DynamoDB, STS } = require('aws-sdk');
 
 const wait = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const s3 = new S3();
 const sqs = new SQS();
 const sns = new SNS();
 const dynamoDb = new DynamoDB();
@@ -19,6 +20,10 @@ module.exports.handler = async () => {
 
     // STS (any service tracing
     await sts.getCallerIdentity().promise();
+
+    // s3.getSignedUrlPromise won't issue a real HTTP request
+    // It's injected to confirm no trace span will be created for it
+    await s3.getSignedUrlPromise('putObject', { Bucket: 'test', Key: 'test', Expires: 500 });
 
     // SQS
     const queueName = `${process.env.AWS_LAMBDA_FUNCTION_NAME}-${invocationCount}.fifo`;

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -1,10 +1,12 @@
 {
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.245.0",
+    "@aws-sdk/client-s3": "^3.245.0",
     "@aws-sdk/client-sns": "^3.245.0",
     "@aws-sdk/client-sqs": "^3.245.0",
     "@aws-sdk/client-sts": "^3.245.0",
     "@aws-sdk/lib-dynamodb": "^3.245.0",
+    "@aws-sdk/s3-request-presigner": "^3.245.0",
     "aws-sdk": "^2.1294.0",
     "express": "^4.18.2",
     "serverless-http": "^3.1.1"


### PR DESCRIPTION
Addresses issue reported internally by @ac360 Where relying on `s3.getSignedUrlPromise()` was creating unresolved AWS SDK trace span which produced warning as:

```
Serverless SDK Warning: Following trace spans didn't end before end of lambda invocation
```

It's caused by the fact that AWS SDK for request signing (resolution of preconfigured request URLs) relies on internal `Request` interface. In this case, no real HTTP requests are issued yet our instrumentation is attempting to track these as real requests which leads to errors.