### PR TITLE
SDK: SC-356 Create Lambda process trace spans with related tags

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools>=65.6.3",
+    "wheel>=0.38.4",
+]
+
+[project]
+name = "serverless_aws_lambda_sdk"
+version = "0.0.0"
+description = "Serverless AWS Lambda SDK for Python"
+authors = [{ name = "serverlessinc" }]
+requires-python = ">=3.7"
+dependencies = [
+    "importlib_metadata>=5.2", # included in Python >=3.8
+    "serverless_sdk",
+    "serverless_sdk_schema",
+    "strenum>=0.4.9",
+    "typing-extensions>=4.4", # included in Python 3.8 - 3.11
+]
+[project.optional-dependencies]
+tests = [
+    "black>=22.12",
+    "pyproject-fmt>=0.4.1",
+    "pytest>=7.2",
+    "ruff>=0.0.199",
+]
+
+
+[tool.ruff]
+ignore = ["F401"]
+#fix = true

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/README.md
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/README.md
@@ -1,0 +1,5 @@
+# Serverless AWS Lambda SDK
+
+## Setup
+
+Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/serverless_aws_lambda_sdk/internal_extension/exec_wrapper` in your Lambda environment.

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from serverless_sdk import serverlessSdk
+
+
+__all__ = [
+    "serverlessSdk",
+]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/base.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Tuple, TypeVar
+
+from importlib_metadata import packages_distributions, version
+from strenum import StrEnum
+from typing_extensions import Concatenate, Final, ParamSpec, Self
+
+
+FIRST: Final[int] = 0
+
+_packages: Final[Dict[str, List[str]]] = packages_distributions()
+_pkg_name: str = __name__ or __package__
+_pkg_name, *_ = _pkg_name.split(".")
+_distribution: Final[List[str]] = _packages[_pkg_name]
+
+# module metadata
+__name__: Final[str] = _distribution[FIRST]
+__version__: Final[str] = version(__name__)
+
+NAME: Final[str] = __name__
+
+
+NEW_HANDLER: Final[
+    str
+] = "/opt/serverless_aws_lambda_sdk/internal_extension/wrapper.handler"
+PYTHON_EXTS: Final[Tuple[str, ...]] = (".py", ".pyc", ".pyo", ".pyd")
+
+
+P = ParamSpec("P")
+I_P = ParamSpec("I_P")
+T = TypeVar("T")
+
+HandlerPath = str
+Handler = Callable[P, T]
+InstrumentParams = Concatenate[HandlerPath, I_P]
+Instrument = Callable[InstrumentParams, Handler]
+Loader = Callable[[HandlerPath], Handler]
+
+
+class Env(StrEnum):
+    HANDLER: Self = "_HANDLER"
+    ORIGIN_HANDLER: Self = "_ORIGIN_HANDLER"
+
+    AWS_LAMBDA_FUNCTION_NAME: Self = "AWS_LAMBDA_FUNCTION_NAME"
+    AWS_LAMBDA_INITIALIZATION_TYPE: Self = "AWS_LAMBDA_INITIALIZATION_TYPE"
+    AWS_LAMBDA_FUNCTION_VERSION: Self = "AWS_LAMBDA_FUNCTION_VERSION"
+    AWS_LAMBDA_LOG_STREAM_NAME: Self = "AWS_LAMBDA_LOG_STREAM_NAME"
+
+    LAMBDA_RUNTIME_DIR: Self = "LAMBDA_RUNTIME_DIR"
+    LAMBDA_TASK_ROOT: Self = "LAMBDA_TASK_ROOT"
+
+    SLS_ORG_ID: Self = "SLS_ORG_ID"
+    SLS_SDK_DEBUG: Self = "SLS_SDK_DEBUG"
+
+
+class Tag(StrEnum):
+    org_id = "orgId"
+    service = "service"
+    sdk_name = "sdk.name"
+    sdk_version = "sdk.version"
+
+    arch = "aws.lambda.arch"
+    is_coldstart = "aws.lambda.is_coldstart"
+    name = "aws.lambda.name"
+    request_id = "aws.lambda.request_id"
+    version = "aws.lambda.version"
+    outcome = "aws.lambda.outcome"
+
+    error_message = "aws.lambda.error_exception_message"
+    error_stacktrace = "aws.lambda.error_exception_stacktrace"
+
+
+class Name(StrEnum):
+    aws_lambda = "aws.lambda"
+    aws_lambda_invocation = "aws.lambda.invocation"
+    aws_lambda_initialization = "aws.lambda.initialization"
+
+
+class Outcome(StrEnum):
+    success = "success"
+    error_handled = "error:handled"
+
+
+class Arch(StrEnum):
+    x64 = "x86_64"
+    arm = "arm64"

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/exceptions.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/exceptions.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing_extensions import NoReturn, Self
+
+from strenum import StrEnum
+
+
+class LambdaError(StrEnum):
+    """Lambda Runtime errors"""
+
+    BUILT_IN_MODULE_CONFLICT: Self = "Runtime.BuiltInModuleConflict"
+    HANDLER_NOT_FOUND: Self = "Runtime.HandlerNotFound"
+    IMPORT_MODULE_ERROR: Self = "Runtime.ImportModuleError"
+    LAMBDA_CONTEXT_UNMARSHAL_ERROR: Self = "Runtime.LambdaContextUnmarshalError"
+    MALFORMED_HANDLER_NAME: Self = "Runtime.MalformedHandlerName"
+    MARSHAL_ERROR: Self = "Runtime.MarshalError"
+    UNMARSHAL_ERROR: Self = "Runtime.UnmarshalError"
+    USER_CODE_SYNTAX_ERROR: Self = "Runtime.UserCodeSyntaxError"
+
+
+class LambdaSdkException(Exception):
+    """Base class for all exceptions raised by the SDK."""
+
+    pass
+
+
+class HandlerNotFound(LambdaSdkException):
+    error: LambdaError = LambdaError.HANDLER_NOT_FOUND
+
+
+class MalformedHandlerName(LambdaSdkException):
+    error: LambdaError = LambdaError.MALFORMED_HANDLER_NAME
+
+
+class BuiltInModuleConflict(LambdaSdkException):
+    error: LambdaError = LambdaError.BUILT_IN_MODULE_CONFLICT
+
+
+class ImportModuleError(LambdaSdkException):
+    error: LambdaError = LambdaError.IMPORT_MODULE_ERROR
+
+
+class UserCodeSyntaxError(LambdaSdkException):
+    error: LambdaError = LambdaError.USER_CODE_SYNTAX_ERROR
+
+
+def handler_not_found(basename: str = "SDK", message: str = "") -> NoReturn:
+    raise HandlerNotFound(f"{basename} {message}")

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+import base64
+import traceback
+from functools import wraps
+from time import time_ns
+from typing import Any, Dict, List
+
+from serverless_sdk.span.trace import TraceSpan
+from serverless_sdk_schema import TracePayload
+from typing_extensions import Final
+
+from ..base import Handler, Outcome, Tag
+from ..trace_spans.aws_lambda import (
+    aws_lambda_span,
+    aws_lambda_initialization,
+    aws_lambda_invocation,
+)
+
+
+__all__: Final[List[str]] = [
+    "instrument",
+]
+
+
+TELEMETRY_PREFIX: Final[str] = "SERVERLESS_TELEMETRY.T"
+
+
+def get_stacktrace(exception: Exception) -> str:
+    trace = traceback.format_exception(
+        type(exception), exception, exception.__traceback__
+    )
+    return "".join(trace)
+
+
+def instrument(user_handler: Handler, *args, **kwargs) -> Handler:
+    aws_lambda_initialization.close()
+
+    @wraps(user_handler)
+    def wrapper(event, context: Any = None):
+        if context:
+            aws_lambda_span.tags[Tag.request_id] = context.aws_request_id
+
+        try:
+            result = user_handler(event, context)
+            close_trace(Outcome.success, result)
+            return result
+
+        except Exception as e:
+            logging.error(f"Error executing handler: {e}")
+            close_trace(Outcome.error_handled, e)
+
+    return wrapper
+
+
+def close_trace(outcome: str, outcome_result: Any):
+    aws_lambda_span.tags[Tag.outcome] = outcome
+
+    if outcome == Outcome.error_handled:
+        aws_lambda_span.tags[Tag.error_message] = str(outcome_result)
+        aws_lambda_span.tags[Tag.error_stacktrace] = get_stacktrace(outcome_result)
+
+    end_time = time_ns()
+    aws_lambda_span.close(end_time=end_time)
+    report_trace()
+
+
+def report_trace():
+    payload = get_payload()
+    as_base64 = to_base64_encoded_protobuf(payload)
+    logging.debug(f"{TELEMETRY_PREFIX}.{as_base64}")
+
+
+def convert_tracespan_protobuf_to_dict(span: TraceSpan) -> Dict[str, Any]:
+    obj = span.to_protobuf_object()
+    return obj.dict(by_alias=True)
+
+
+def get_payload() -> Dict[str, Any]:
+    span_buf = convert_tracespan_protobuf_to_dict(aws_lambda_span)
+
+    payload = {
+        "slsTags": {
+            "orgId": aws_lambda_span.tags[Tag.org_id],
+            "service": aws_lambda_span.tags[Tag.service],
+            "sdk": {
+                "name": aws_lambda_span.tags[Tag.sdk_name],
+                "version": aws_lambda_span.tags[Tag.sdk_version],
+            },
+        },
+        "spans": [span_buf],
+        "events": [],
+    }
+    return payload
+
+
+def to_base64_encoded_protobuf(payload: Dict[str, Any]) -> str:
+    trace_payload = TracePayload()
+    trace_payload.from_dict(payload)
+    encoded: bytes = trace_payload.SerializeToString()
+    as_base64: str = base64.b64encode(encoded).decode("utf-8")
+
+    return as_base64

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .base import initialize
+
+
+initialize()

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from functools import lru_cache
+from os import environ
+from pathlib import Path
+from time import time_ns
+from typing import Optional
+
+from typing_extensions import Final
+
+from ..base import Env, Handler, NEW_HANDLER, PYTHON_EXTS
+from ..exceptions import (
+    BuiltInModuleConflict,
+    HandlerNotFound,
+    ImportModuleError,
+    UserCodeSyntaxError,
+)
+
+
+NS_IN_MS: Final[int] = 1_000_000
+
+# Lambda env vars
+HANDLER: Final[Optional[str]] = environ.get(Env.HANDLER)
+LAMBDA_TASK_ROOT: Final[Optional[str]] = environ.get(Env.LAMBDA_TASK_ROOT)
+
+# Serverless env vars
+SLS_ORG_ID: Final[Optional[str]] = environ.get(Env.SLS_ORG_ID)
+SLS_SDK_DEBUG: Final[Optional[str]] = environ.get(Env.SLS_SDK_DEBUG)
+
+START: Final[int] = time_ns()
+DEFAULT_TASK_ROOT: Final[str] = "/var/task"
+
+
+cache = lru_cache(maxsize=1)
+
+
+def initialize(handler: Optional[str] = HANDLER):
+    if SLS_SDK_DEBUG:
+        logging.basicConfig(level=logging.DEBUG, format="⚡ SDK: %(message)s")
+
+    logging.debug("Wrapper initialization")
+
+    if not handler or "." not in handler or ".." in handler:
+        # Bad handler, let error naturally surface
+        return
+
+    if not SLS_ORG_ID:
+        logging.error(
+            "Serverless SDK Warning: "
+            "Cannot instrument function: "
+            'Missing "SLS_ORG_ID" environment variable',
+        )
+        return
+
+    get_module_path(handler)
+    set_handler_vars()
+
+    end = time_ns()
+    ms = round((end - START) / NS_IN_MS)
+
+    logging.debug(f"Overhead duration: Internal initialization: {ms}ms")
+
+
+@cache
+def get_module_path(handler: str = HANDLER) -> Optional[Path]:
+    handler = Path(handler).resolve()
+    handler_dir = handler.parent
+    handler_basename = handler.name
+    handler_module_name, *_ = handler_basename.split(".")
+
+    task_root = Path(LAMBDA_TASK_ROOT).resolve()
+
+    if not task_root.exists():
+        task_root = Path(DEFAULT_TASK_ROOT)
+
+    handler_module_dir = (task_root / handler_dir.name).resolve()
+    handler_module = (handler_module_dir / handler_module_name).resolve()
+
+    for ext in PYTHON_EXTS:
+        module_file = handler_module.with_suffix(ext)
+
+        if module_file.exists():
+            return module_file
+
+    if handler_module.exists():
+        return handler_module
+
+    return None
+
+
+def get_handler_via_module_import(handler: str = HANDLER) -> Handler:
+    """Based on logic from AWS Lambda Python runtime"""
+
+    try:
+        module_name, function_name = handler.rsplit(".", 1)
+
+    except ValueError as e:
+        raise HandlerNotFound(f"Bad handler '{handler}': {e}") from e
+
+    try:
+        name, *_ = module_name.split(".")
+
+        if name in sys.builtin_module_names:
+            raise BuiltInModuleConflict(
+                f"Cannot use built-in module {module_name} as a handler module"
+            )
+
+        path = module_name.replace("/", ".")
+        module = importlib.import_module(path)
+
+    except ImportError as e:
+        raise ImportModuleError(f"Unable to import module '{module_name}': {e}") from e
+
+    except SyntaxError as e:
+        raise UserCodeSyntaxError(f"Syntax error in module '{module_name}': {e}") from e
+
+    try:
+        return getattr(module, function_name)
+
+    except AttributeError as e:
+        raise HandlerNotFound(
+            f"Handler '{function_name}' missing on module '{module_name}'"
+        ) from e
+
+
+def set_handler_vars():
+    environ[Env.ORIGIN_HANDLER] = HANDLER
+    environ[Env.HANDLER] = NEW_HANDLER

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec-wrapper
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec-wrapper
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+
+def main():
+    _, *args = sys.argv
+    command = " ".join(args)
+    os.system(command)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+import sys
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
+from os import environ
+from pathlib import Path
+from types import ModuleType
+from typing import List, Optional
+
+from typing_extensions import Final, TypeAlias, TYPE_CHECKING
+
+from .base import get_handler_via_module_import, get_module_path
+from ..base import Env, Handler
+from ..exceptions import HandlerNotFound, handler_not_found
+from ..instrument import instrument
+
+if TYPE_CHECKING:
+    from serverless_sdk.sdk.base import ServerlessSdk
+
+else:
+    ServerlessSdk: TypeAlias = "ServerlessSdk"
+
+
+__all__: Final[List[str]] = [
+    "get_instrumented_handler",
+    "handler",
+]
+
+
+LAMBDA_RUNTIME_DIR: Final[Optional[str]] = environ.get(Env.LAMBDA_RUNTIME_DIR)
+
+
+# 1. Initialize SDK instrumentation
+def get_sdk(init: bool = False, *args, **kwargs) -> ServerlessSdk:
+    try:
+        from aws_lambda_sdk import serverlessSdk
+
+        sdk = serverlessSdk
+
+    except ImportError:
+        from .. import serverlessSdk
+
+        sdk = serverlessSdk
+
+    if init:
+        sdk._initialize(*args, **kwargs)
+
+    return sdk
+
+
+def import_from_path(path: str) -> Optional[ModuleType]:
+    try:
+        return import_module(path)
+
+    except Exception as e:
+        logging.debug(f"Failed to import {path}: {e}")
+        return None
+
+
+def get_handler_module(handler: str) -> ModuleType:
+    if LAMBDA_RUNTIME_DIR and LAMBDA_RUNTIME_DIR not in sys.path:
+        sys.path.append(LAMBDA_RUNTIME_DIR)
+
+    handler_path = Path(handler)
+    mod_name, func_name = handler_path.name.split(".")
+
+    names = mod_name, handler_path.name, handler_path.parent.name, handler
+
+    for name in names:
+        module = import_from_path(name)
+
+        if module:
+            return module
+
+    try:
+        module_file = get_module_path(handler)
+
+        if not module_file:
+            raise FileNotFoundError(
+                f"Couldn't find Lambda function's module: {handler}={module_file}."
+            )
+
+        spec = spec_from_file_location(handler, module_file)
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        return module
+
+    except Exception as e:
+        logging.debug(f"Failed to import {handler}: {e}")
+        raise handler_not_found(mod_name, "is undefined or not exported") from e
+
+
+def get_handler_from_module(handler_module: ModuleType, handler: str) -> Handler:
+    *_, function_name = handler.split(".")
+
+    try:
+        return getattr(handler_module, function_name)
+
+    except Exception as e:
+        raise handler_not_found(function_name, "is undefined or not exported") from e
+
+
+def instrument_safe(user_handler: Handler) -> Handler:
+    try:
+        return instrument(user_handler)
+
+    except Exception as e:
+        logging.error(
+            "Fatal Serverless SDK Error: "
+            "Please report at https://github.com/serverless/console/issues: "
+            f"Async handler setup failed: {e}"
+        )
+
+        return user_handler
+
+
+def get_instrumented_handler_via_name(handler: str) -> Handler:
+    user_handler = get_handler_via_module_import(handler)
+
+    return instrument_safe(user_handler)
+
+
+def get_instrumented_handler_via_path(handler: str) -> Handler:
+    handler_module = get_handler_module(handler)
+    user_handler = get_handler_from_module(handler_module)
+
+    return instrument_safe(user_handler)
+
+
+def get_original_handler_and_reset_vars() -> str:
+    origin = environ.get(Env.ORIGIN_HANDLER)
+
+    if origin:
+        environ[Env.HANDLER] = origin
+        del environ[Env.ORIGIN_HANDLER]
+
+    handler = environ.get(Env.HANDLER)
+    return handler
+
+
+def get_instrumented_handler(handler: Optional[str] = None) -> Handler:
+    if handler is None:
+        handler = get_original_handler_and_reset_vars()
+
+    if not handler:
+        raise HandlerNotFound(f"{Env.HANDLER} is not set.")
+
+    sdk = get_sdk(init=True)
+    assert sdk
+
+    try:
+        return get_instrumented_handler_via_name(handler)
+
+    except Exception as e:
+        logging.debug(f"Couldn't import module from handler name {handler}: {e}")
+
+    try:
+        return get_instrumented_handler_via_path(handler)
+
+    except Exception as e:
+        logging.error(f"Failed to import handler {handler}: {e}")
+        raise handler_not_found(handler, "is undefined or not exported") from e
+
+
+handler: Final[Handler] = get_instrumented_handler()

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/__init__.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import inspect
+from os import environ
+from functools import wraps
+from typing import Callable, Dict
+
+from ..base import Handler
+
+
+environ["AWS_LAMBDA_FUNCTION_NAME"] = "example.handler"
+environ["SLS_ORG_ID"] = "hello.world"
+environ["AWS_LAMBDA_INITIALIZATION_TYPE"] = "on-demand"
+environ["AWS_LAMBDA_FUNCTION_VERSION"] = "1"
+
+
+Params = Dict[str, inspect.Parameter]
+
+
+class Context:
+    aws_request_id: int = 1234
+
+
+ctx = Context()
+
+
+def reset_globals():
+    from ..trace_spans.aws_lambda import (
+        aws_lambda_span,
+        aws_lambda_initialization,
+        aws_lambda_invocation,
+        get_tags,
+    )
+
+    for span in aws_lambda_span, aws_lambda_initialization, aws_lambda_invocation:
+        tags = get_tags()
+        span.end_time = None
+        span.tags = tags
+
+
+def ensure_globals(func: Callable) -> Callable:
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        reset_globals()
+        val = func(*args, **kwargs)
+        reset_globals()
+
+        return val
+
+    return wrapper
+
+
+def get_params(func: Callable) -> Params:
+    signature = inspect.signature(func)
+
+    return signature.parameters
+
+
+@ensure_globals
+def compare_handlers(original: Handler, instrumented: Handler):
+    assert callable(original) and callable(instrumented)
+
+    orig_params = get_params(original)
+    instrumented_params = get_params(instrumented)
+    assert orig_params == instrumented_params
+
+    orig_result = original(None, ctx)
+    instrumented_result = instrumented(None, ctx)
+    assert orig_result == instrumented_result

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/example.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/example.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing_extensions import Final
+
+
+class ClassHandler:
+    def __call__(self, *args, **kwargs):
+        return "ClassHandler"
+
+
+def handler(*args, **kwargs) -> str:
+    return "Handler"
+
+
+def env_handler(*args, **kwargs) -> str:
+    return "Env_Handler"
+
+
+callable_obj: Final[ClassHandler] = ClassHandler()

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/test_instrument.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from . import compare_handlers, ensure_globals, reset_globals
+from ..base import Handler, Instrument
+
+
+@pytest.fixture
+def instrument() -> Instrument:
+    from ..instrument import instrument
+
+    return instrument
+
+
+def test_instrument_exists_and_importable():
+    try:
+        from ..instrument import instrument
+
+    except ImportError as e:
+        raise AssertionError("`instrument` not found") from e
+
+
+def test_instrument_is_callable(instrument: Instrument):
+    assert callable(instrument)
+
+
+@ensure_globals
+def test_instrument_wraps_callable(instrument: Instrument):
+    def example(event, context):
+        pass
+
+    result = instrument(example)
+    assert callable(result)
+
+
+@ensure_globals
+def test_instrumented_callable_behaves_like_original(instrument: Instrument):
+    def example(event, context) -> str:
+        return "Hello World"
+
+    instrumented = instrument(example)
+
+    compare_handlers(example, instrumented)
+
+
+@ensure_globals
+def test_instrument_works_with_all_callables(instrument: Instrument):
+    class Example:
+        def __call__(self, event, context) -> str:
+            return "Hello World"
+
+    example: Handler = Example()
+    instrumented: Handler = instrument(example)
+
+    compare_handlers(example, instrumented)

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/test_internal_extension.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/tests/test_internal_extension.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from os import environ
+
+from typing_extensions import Final
+
+from . import compare_handlers
+from .example import callable_obj, env_handler, handler as example
+from ..base import Env, Handler
+from ..internal_extension.wrapper import get_instrumented_handler
+
+
+EXAMPLE_MODULE: Final[str] = "serverless_aws_lambda_sdk.tests.example"
+
+HANDLER: Final[str] = f"{EXAMPLE_MODULE}.handler"
+HANDLER_PATH: Final[str] = "serverless_aws_lambda_sdk/tests/example.handler"
+CLS_HANDLER: Final[str] = f"{EXAMPLE_MODULE}.callable_obj"
+ENV_HANDLER: Final[str] = f"{EXAMPLE_MODULE}.env_handler"
+
+
+def test_can_instrument_module():
+    handler = get_instrumented_handler(HANDLER)
+    assert callable(handler)
+
+
+def test_can_instrument_path():
+    handler = get_instrumented_handler(HANDLER_PATH)
+    assert callable(handler)
+
+
+def test_wrapped_callable_behaves_like_original():
+    instrumented: Handler = get_instrumented_handler(HANDLER)
+
+    compare_handlers(example, instrumented)
+
+
+def test_instrument_works_with_all_callables():
+    example: Handler = callable_obj
+    instrumented: Handler = get_instrumented_handler(CLS_HANDLER)
+
+    compare_handlers(example, instrumented)
+
+
+def test_instrument_works_with_env_vars():
+    environ[Env.HANDLER] = ENV_HANDLER
+
+    example: Handler = env_handler
+    instrumented: Handler = get_instrumented_handler(handler=None)
+
+    compare_handlers(example, instrumented)

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import platform
+from os import environ
+from typing import Dict, Optional
+
+from serverless_sdk.span.tags import Tags
+from serverless_sdk.span.trace import TraceSpan
+from typing_extensions import Final
+
+from ..base import Arch, Env, NAME, Name, Tag, __version__
+from ..internal_extension.base import START
+
+
+NOT_SET: Final[str] = ""
+SET_ON_REQUEST: Final[str] = NOT_SET
+
+TAGS: Final[Tags] = Tags()
+_TAGS: Final[Dict[str, str]] = {
+    Tag.org_id: environ.get(Env.SLS_ORG_ID),
+    Tag.service: environ.get(Env.AWS_LAMBDA_FUNCTION_NAME),
+    Tag.sdk_name: NAME,
+    Tag.sdk_version: __version__,
+}
+TAGS.update(_TAGS)
+
+INIT: Final[Optional[str]] = environ.get(Env.AWS_LAMBDA_INITIALIZATION_TYPE)
+
+if INIT == "on-demand":
+    TAGS.update({Tag.is_coldstart: True})
+
+else:
+    TAGS.update({Tag.is_coldstart: False})
+
+
+def get_arch() -> Optional[str]:
+    arch = platform.machine()
+
+    if arch == "AMD64" or arch == "x86_64":
+        return Arch.x64
+
+    elif "arm" in arch.casefold():
+        return Arch.arm
+
+    logging.error(f"Serverless SDK Warning: Unrecognized architecture: {arch}")
+    return None
+
+
+ARCH: Final[str] = get_arch()
+
+if ARCH:
+    TAGS.update({Tag.arch: ARCH})
+
+TAGS[Tag.name] = environ.get(Env.AWS_LAMBDA_FUNCTION_NAME)
+TAGS[Tag.version] = environ.get(Env.AWS_LAMBDA_FUNCTION_VERSION)
+
+
+def get_tags() -> Tags:
+    tags = Tags()
+    tags.update(TAGS)
+
+    return tags
+
+
+aws_lambda_span: Final[TraceSpan] = TraceSpan(
+    name=Name.aws_lambda,
+    start_time=START,
+    tags=get_tags(),
+)
+
+aws_lambda_initialization: Final[TraceSpan] = TraceSpan(
+    name=Name.aws_lambda_initialization,
+    start_time=START,
+    tags=get_tags(),
+)
+
+aws_lambda_invocation: Final[TraceSpan] = TraceSpan(
+    name=Name.aws_lambda_invocation,
+    start_time=START,
+    tags=get_tags(),
+)


### PR DESCRIPTION
This PR includes:
 - `aws.lambda`, `aws.lambda.initialization` and `aws.lambda.invocation` trace spans
 - Tracer, span and span error resolution tags
 - `TracePayload` gets dumped upon invocation end
 - Tests
 
~~I had to update `Tags` from `serverless_sdk` to ensure it works with this PR. I can break it out as a separate PR and clean this one up. I would have done that, but it depends on changes that haven't been merged yet and that might get ugly.~~ 
edit: Broke them up into PRs.