### PR TITLE
AWS Lambda SDK: Propagate all captured events to `dev mode`

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -54,7 +54,6 @@ serverlessSdk._eventEmitter.on('trace-span-close', (traceSpan) => {
 });
 
 serverlessSdk._eventEmitter.on('captured-event', (capturedEvent) => {
-  if (capturedEvent._origin === 'nodeConsole') return;
   pendingCapturedEvents.push(capturedEvent);
   scheduleEventually();
 });

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -1006,6 +1006,8 @@ describe('internal-extension/index.test.js', () => {
         ],
         traceEvents: [
           { eventName: 'telemetry.error.generated.v1' },
+          { eventName: 'telemetry.error.generated.v1' },
+          { eventName: 'telemetry.warning.generated.v1' },
           { eventName: 'telemetry.warning.generated.v1' },
         ],
       });


### PR DESCRIPTION
As all captured events are expected to be shown in a special way, we agreed to propagate all of them, and instead filter related `console.error` and `console.warn` CW logs on dev mode side.