### PR TITLE
fix: Log console messages as events

### DIFF
--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -49,6 +49,9 @@ func (e *Extension) ExternalExtension() {
 	printPrefix := fmt.Sprintf("[%s]", extensionName)
 	extensionClient := extension.NewClient(os.Getenv("AWS_LAMBDA_RUNTIME_API"))
 
+	// Print environment variables
+	lib.Info(os.Environ())
+
 	// Get account id from sts
 	getAccountId(e.Client)
 

--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -50,7 +50,6 @@ func (e *Extension) ExternalExtension() {
 	extensionClient := extension.NewClient(os.Getenv("AWS_LAMBDA_RUNTIME_API"))
 
 	// Print environment variables
-	lib.Info(os.Environ())
 
 	// Get account id from sts
 	getAccountId(e.Client)

--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -49,8 +49,6 @@ func (e *Extension) ExternalExtension() {
 	printPrefix := fmt.Sprintf("[%s]", extensionName)
 	extensionClient := extension.NewClient(os.Getenv("AWS_LAMBDA_RUNTIME_API"))
 
-	// Print environment variables
-
 	// Get account id from sts
 	getAccountId(e.Client)
 

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.5.0",
     "@serverless/eslint-config": "^5.0.1",
-    "@serverless/sdk-schema": "^0.11.0",
+    "@serverless/sdk-schema": "^0.14.3",
     "@serverless/test": "^11.1.0",
     "@serverless/utils": "^6.8.2",
     "@tsconfig/node16": "^1.0.3",

--- a/node/test/go/dev-mode/test/fixtures/lambdas/with-internal.js
+++ b/node/test/go/dev-mode/test/fixtures/lambdas/with-internal.js
@@ -2,5 +2,7 @@
 
 module.exports.handler = (event, context, callback) => {
   console.log('with-internal 1');
+  console.warn('with-internal warning 1');
+  console.error(new Error('with-internal warning 1'));
   callback(null, 'ok');
 };

--- a/node/test/go/dev-mode/test/fixtures/lambdas/with-internal.js
+++ b/node/test/go/dev-mode/test/fixtures/lambdas/with-internal.js
@@ -3,6 +3,6 @@
 module.exports.handler = (event, context, callback) => {
   console.log('with-internal 1');
   console.warn('with-internal warning 1');
-  console.error(new Error('with-internal warning 1'));
+  console.error(new Error('with-internal error 1'));
   callback(null, 'ok');
 };

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -5,7 +5,7 @@ const { expect } = require('chai');
 const path = require('path');
 const log = require('log').get('test');
 const logProto = require('@serverless/sdk-schema/dist/log');
-// const traceProto = require('@serverless/sdk-schema/dist/trace');
+const devModeProto = require('@serverless/sdk-schema/dist/dev_mode');
 const cleanup = require('../lib/cleanup');
 const createCoreResources = require('../lib/create-core-resources');
 const processFunction = require('../lib/process-function');
@@ -83,9 +83,9 @@ describe('Integration', function () {
               // but we should always have at least 1
               expect(traces.length >= 1).to.equal(true);
               // For whatever reason the traces are being written in a bad wire format? 🤔
-              // const traceData = Buffer.from(traces[0], 'base64');
-              // const tracePayload = traceProto.TracePayload.decode(traceData);
-              // expect(tracePayload.events.length).to.equal(2);
+              const devModeData = Buffer.from(traces[0].trim(), 'base64');
+              const devModePayload = devModeProto.DevModePayload.decode(devModeData);
+              expect(devModePayload.payload.trace.events.length).to.equal(2);
             }
           },
         },

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -5,6 +5,7 @@ const { expect } = require('chai');
 const path = require('path');
 const log = require('log').get('test');
 const logProto = require('@serverless/sdk-schema/dist/log');
+// const traceProto = require('@serverless/sdk-schema/dist/trace');
 const cleanup = require('../lib/cleanup');
 const createCoreResources = require('../lib/create-core-resources');
 const processFunction = require('../lib/process-function');
@@ -51,7 +52,7 @@ describe('Integration', function () {
       'with-internal',
       {
         variants: new Map([
-          ['v14', { configuration: { Runtime: 'nodejs14.x', Timeout: 10 }, includeInternal: true }],
+          // ['v14', { configuration: { Runtime: 'nodejs14.x', Timeout: 10 }, includeInternal: true }],
           ['v16', { configuration: { Runtime: 'nodejs16.x', Timeout: 10 }, includeInternal: true }],
         ]),
         config: {
@@ -81,6 +82,10 @@ describe('Integration', function () {
               // Since we are sending spans as they are complete I need to change this to a variable length
               // but we should always have at least 1
               expect(traces.length >= 1).to.equal(true);
+              // For whatever reason the traces are being written in a bad wire format? 🤔
+              // const traceData = Buffer.from(traces[0], 'base64');
+              // const tracePayload = traceProto.TracePayload.decode(traceData);
+              // expect(tracePayload.events.length).to.equal(2);
             }
           },
         },

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -52,7 +52,7 @@ describe('Integration', function () {
       'with-internal',
       {
         variants: new Map([
-          // ['v14', { configuration: { Runtime: 'nodejs14.x', Timeout: 10 }, includeInternal: true }],
+          ['v14', { configuration: { Runtime: 'nodejs14.x', Timeout: 10 }, includeInternal: true }],
           ['v16', { configuration: { Runtime: 'nodejs16.x', Timeout: 10 }, includeInternal: true }],
         ]),
         config: {

--- a/node/test/go/dev-mode/test/integration/index.test.js
+++ b/node/test/go/dev-mode/test/integration/index.test.js
@@ -82,7 +82,6 @@ describe('Integration', function () {
               // Since we are sending spans as they are complete I need to change this to a variable length
               // but we should always have at least 1
               expect(traces.length >= 1).to.equal(true);
-              // For whatever reason the traces are being written in a bad wire format? 🤔
               const devModeData = Buffer.from(traces[0].trim(), 'base64');
               const devModePayload = devModeProto.DevModePayload.decode(devModeData);
               expect(devModePayload.payload.trace.events.length).to.equal(2);

--- a/node/test/go/dev-mode/test/lib/process-function.js
+++ b/node/test/go/dev-mode/test/lib/process-function.js
@@ -25,7 +25,7 @@ const create = async (testConfig, coreConfig) => {
   const { configuration, includeInternal } = testConfig;
   const resultConfiguration = {
     Role: coreConfig.roleArn,
-    Runtime: 'nodejs16.x',
+    Runtime: 'nodejs18.x',
     MemorySize: 1024,
     Code: {
       ZipFile: await resolveDirZipBuffer(fixturesDirname),


### PR DESCRIPTION
## Description
According to SC-360 we wanted to log `console.error` and `console.warn` messages as events in dev mode rather than normal logs. This PR combined with [the PR @medikoo submitted](https://github.com/serverless/console/pull/396) this should forward the events rather than `console.warn` and `console.error` logs.

> Note: when I test this manually things appear to work fine but when I am running the integration tests I am getting a proto parsing error on the trace payloads 🤔 I commented out the part of the integration tests but maybe @medikoo would know what I am doing wrong? 🤔 