### PR TITLE
docs: Adding docs on the @serverless/sdk package

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 menuText: FAQ
 description: Frequently Asked Questions about Serverless Console
-menuOrder: 5
+menuOrder: 6
 -->
 
 # FAQ

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary
 menuText: Glossary
 description: 
-menuOrder: 4
+menuOrder: 5
 -->
 
 # Glossary

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -50,35 +50,6 @@ Serverless Console in order for the data to be ingested.
 
 [Enable Tracing, Logging, and Dev Mode](/console/docs/integrations/enable-monitoring-features)
 
-**Using a bundler**
-
-If you use a bundler, like esbuild, the AWS Lambda Layer for Serverless Console
-will not be able to auto-instrument traces and spans on your handler. To enable
-auto-instrumentation of spans and traces, you will need to manually add the
-AWS-specific auto-instrumentation library and initiate auto-instrumentation.
-
-First, install the `@serverless/aws-lambda-sdk` package locally. This replaces
-the need for the `@serverless/sdk` package, so you do not need both.
-
-```javascript
-npm install @serverless/aws-lambda-sdk --save
-# or
-yarn add @serverless/aws-lambda-sdk
-```
-
-```javascript
-const serverlessSdk = require("@serverless/aws-lambda-sdk");
-
-// Instrument AWS SDK v2
-serverlessSdk.instrumentation.awsSdkV2.install(AWS)
-
-// Instrument AWS SDK v3 client
-serverlessSdk.instrumentation.awsSdkV3Client.install(client)
-
-// instruments Express.js
-serverlessSdk.instrumentation.expressApp.install(express)
-```
-
 ## Usage
 
 The package does not require any configuration as the credentials are

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -22,6 +22,13 @@ Serverless Console, much like a Captured Error.
 Captured Error or Captured Warning, and sent to Serverless Console. Tags can be
 viewed on the Trace Explorer Details and Dev Mode.
 
+## Compatibility
+
+While Serverless Console is developed by the makers of the Serverless Framework,
+the entire Serverless Console product and this SDK are 100% agnostic of the
+deployment tool you use. Serverless Console and this SDK work just as well with
+Terraform, CDK, SAM, Pulumi, etc, as as they do with Serverless Framework.
+
 ## Installation
 
 **Install the package**

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -36,10 +36,41 @@ If you will run this on AWS Lambda without Serverless Console Tracing enabled,
 or running it on a different runtime, like locally, then you'll need to add the
 `@serverless/sdk` package.
 
-```javascript
+```
 npm install @serverless/sdk --save
 # or
 yarn add @serverless/sdk
+```
+
+**Using a bundler**
+
+If you use a bundler, like esbuild, the AWS Lambda Layer for Serverless Console
+will not be able to auto-instrument traces and spans on your handler. To enable
+auto-instrumentation of spans and traces, you will need to manually add the
+AWS-specific auto-instrumentation library and initiate auto-instrumentation.
+
+Install the `@serverless/aws-lambda-sdk` package locally. This replaces
+the need for the `@serverless/sdk` package, so you do not need both.
+
+```
+npm install @serverless/aws-lambda-sdk --save
+# or
+yarn add @serverless/aws-lambda-sdk
+```
+
+Use the following methods to instrument the AWS client libraries and Express.js.
+
+```javascript
+const serverlessSdk = require("@serverless/aws-lambda-sdk");
+
+// Instrument AWS SDK v2
+serverlessSdk.instrumentation.awsSdkV2.install(AWS)
+
+// Instrument AWS SDK v3 client
+serverlessSdk.instrumentation.awsSdkV3Client.install(client)
+
+// instruments Express.js
+serverlessSdk.instrumentation.expressApp.install(expressApp)
 ```
 
 **Enable Tracing, Logging, and Dev Mode**

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -237,7 +237,7 @@ CloudWatch Log Insights to parse and search.
 ```javascript
 {
   "source": "serverlessSdk",
-  "type": "ERROR_TYPE_CAUGHT",
+  "type": "ERROR_TYPE_CAUGHT_USER",
   "message": "User not found",
   "stackTrace": "...",
   "tags": { 

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -212,3 +212,32 @@ Errors.
 
 Tag keys on `captureWarning` are validated the same way as tag keys on
 `setTag()`.
+
+### Structured Logs with captureError and captureWarning
+
+The `captureWarning` and `captureError` methods will send the content to
+Serverless Console in a binary format. To enable humand readability these
+methods will also output a structured-log JSON string, like the one shown
+below.
+
+This string is easier to read, and can also be used with other tools like
+CloudWatch Log Insights to parse and search.
+
+```javascript
+{
+  "source": "serverlessSdk",
+  "type": "ERROR_TYPE_CAUGHT",
+  "message": "User not found",
+  "stackTrace": "...",
+  "tags": { 
+    "userId": "eb661c69405c"
+   }
+}
+```
+
+To disable the output of the structured logs with `captureError` and
+`captureWarning`, set this environment variable in the runtime.
+
+```bash
+SLS_DISABLE_CAPTURED_EVENTS_STDOUT=true
+```

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -51,9 +51,12 @@ yarn add @serverless/sdk
 **Using a bundler**
 
 If you use a bundler, like esbuild, the AWS Lambda Layer for Serverless Console
-will not be able to auto-instrument traces and spans on your handler. To enable
-auto-instrumentation of spans and traces, you will need to manually add the
-AWS-specific auto-instrumentation library and initiate auto-instrumentation.
+will instrument native Node.js APIs like `http` and `console`, and APIs
+available on the runtime like the AWS SDK; however, if the handler bundles APIs,
+like `express` or the AWS SDK, then Serverless Console will not be able to
+auto-instrument. To enable auto-instrumentation for these APIs, you will need to
+manually add the AWS-specific auto-instrumentation library and initiate
+auto-instrumentation.
 
 Install the `@serverless/aws-lambda-sdk` package locally. This replaces
 the need for the `@serverless/sdk` package, so you do not need both.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -14,9 +14,8 @@ library must be added and instrumented in your AWS Lambda function handler.
 
 ## Key terms
 
-- A **Captured Error** is one instance of an `Error` object in Node.js that is
-sent to Serverless Console. It can be viewed in Dev Mode or the Trace Explorer
-Details.
+- A **Captured Error** is one instance of an error that is sent to Serverless
+Console. It can be viewed in Dev Mode or the Trace Explorer Details.
 - A **Captured Warning** is one instance of a string in Node.js that is sent to
 Serverless Console, much like a Captured Error.
 - A **Tag** is a key/value-pair that can be set on the Trace or an individual
@@ -25,7 +24,7 @@ viewed on the Trace Explorer Details and Dev Mode.
 
 ## Installation
 
-**Install the package with:**
+**Install the package**
 
 When Tracing is enabled in Servelress Console, an  AWS Lambda Layer is added to
 your AWS Lambda function with the `@serverless/sdk` package. If you are running
@@ -109,7 +108,6 @@ try {
 }
 ```
 
-
 **Using console.error**
 
 ```javascript
@@ -124,9 +122,11 @@ The Serverless SDK automatically instruments the `console.error` method to
 capture errors. This makes instrumentation much easier as you may already be
 using `console.error` to dispaly the errors.
 
-This method only supports capturing Errors, that is, the object must inherit
-from the Node.js `Error` object. Passing values of any other type will be
-ignored.
+This method can be used to capture `Error` objects, as well as any combination
+of strings. If only an `Error` object is provided, then the stack trace in
+Console will show the stack trace of the error object. If a string, or a
+combination of a string and `Error`, are provided, then then stack trace of the
+`console.error` will be captured.
 
 ### Capturing Warnings
 
@@ -151,6 +151,9 @@ This method only supports capturing strings.
 We recommend avoiding using unique instance values for the strings. For example,
 if you need to include a userId, email, request ID, or any ID that may be unique
 to the individual invocation, we recommend using Tagging instead.
+
+This method will capture the stack trace of the `console.warn` call so it
+is easy to identify in Console.
 
 ### Tagging
 

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -27,6 +27,15 @@ viewed on the Trace Explorer Details and Dev Mode.
 
 **Install the package with:**
 
+When Tracing is enabled in Servelress Console, an  AWS Lambda Layer is added to
+your AWS Lambda function with the `@serverless/sdk` package. If you are running
+the handler with Tracing enabled on AWS Lambda only, then you can skip this
+step.
+
+If you will run this on AWS Lambda without Serverless Console Tracing enabled,
+or running it on a different runtime, like locally, then you'll need to add the
+`@serverless/sdk` package.
+
 ```javascript
 npm install @serverless/sdk --save
 # or

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -50,6 +50,35 @@ Serverless Console in order for the data to be ingested.
 
 [Enable Tracing, Logging, and Dev Mode](/console/docs/integrations/enable-monitoring-features)
 
+**Using a bundler**
+
+If you use a bundler, like esbuild, the AWS Lambda Layer for Serverless Console
+will not be able to auto-instrument traces and spans on your handler. To enable
+auto-instrumentation of spans and traces, you will need to manually add the
+AWS-specific auto-instrumentation library and initiate auto-instrumentation.
+
+First, install the `@serverless/aws-lambda-sdk` package locally. This replaces
+the need for the `@serverless/sdk` package, so you do not need both.
+
+```javascript
+npm install @serverless/aws-lambda-sdk --save
+# or
+yarn add @serverless/aws-lambda-sdk
+```
+
+```javascript
+const serverlessSdk = require("@serverless/aws-lambda-sdk");
+
+// Instrument AWS SDK v2
+serverlessSdk.instrumentation.awsSdkV2.install(AWS)
+
+// Instrument AWS SDK v3 client
+serverlessSdk.instrumentation.awsSdkV3Client.install(client)
+
+// instruments Express.js
+serverlessSdk.instrumentation.expressApp.install(express)
+```
+
 ## Usage
 
 The package does not require any configuration as the credentials are

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -40,7 +40,8 @@ step.
 
 If you will run this on AWS Lambda without Serverless Console Tracing enabled,
 or running it on a different runtime, like locally, then you'll need to add the
-`@serverless/sdk` package.
+`@serverless/sdk` package. Even though the SDK is already available in the AWS
+Lambda layer, bundling it in your handler will not conflict with the layer.
 
 ```
 npm install @serverless/sdk --save

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -1,0 +1,161 @@
+<!--
+title: Node.js SDK
+menuText: Node.js SDK
+description: 
+menuOrder: 4
+-->
+
+# Node.js SDK
+
+Serverless Console, when Tracing is enabled on an AWS Lambda function, will hook
+into the AWS Lambda runtime environment and automatically report Traces and
+Spans. To capture handled errors, warnings, and to set custom tags, the SDK
+library must be added and instrumented in your AWS Lambda function handler.
+
+## Key terms
+
+- A **Captured Error** is one instance of an `Error` object in Node.js that is
+sent to Serverless Console. It can be viewed in Dev Mode or the Trace Explorer
+Details.
+- A **Captured Warning** is one instance of a string in Node.js that is sent to
+Serverless Console, much like a Captured Error.
+- A **Tag** is a key/value-pair that can be set on the Trace or an individual
+Captured Error or Captured Warning, and sent to Serverless Console. Tags can be
+viewed on the Trace Explorer Details and Dev Mode.
+
+## Installation
+
+**Install the package with:**
+
+```javascript
+npm install @serverless/sdk --save
+# or
+yarn add @serverless/sdk
+```
+
+**Enable Tracing, Logging, and Dev Mode**
+
+The SDK will merely generate the necessary Tags, Captured Errors, and Captured
+Warnings; however, Tracing, Logging, and Dev Mode must be enabled on your org on
+Serverless Console in order for the data to be ingested.
+
+[Enable Tracing, Logging, and Dev Mode](/console/docs/integrations/enable-monitoring-features)
+
+## Usage
+
+The package does not require any configuration as the credentials are
+automatically set on the AWS Lambda function environment variables when Tracing
+is enabled in Serverless Console.
+
+To use the Serverless SDK you must require the `@serverless/sdk` method in your
+AWS Lambda function handler.
+
+```javascript
+const serverlessSdk = require("@serverless/sdk");
+```
+
+### Capturing Errors
+
+The most common use case for the Serverless SDK is to capture handled errors.
+There are two mechanisms for capturing handled errors.
+
+**Using captureError**
+
+```javascript
+try {
+  // an error is thrown
+} catch (ex) {
+  serverlessSdk.captureError(ex)
+}
+```
+
+
+**Using console.error**
+
+```javascript
+try {
+  // an error is thrown
+} catch (ex) {
+  console.error(ex)
+}
+```
+
+The Serverless SDK automatically instruments the `console.error` method to
+capture errors. This makes instrumentation much easier as you may already be
+using `console.error` to dispaly the errors.
+
+This method only supports capturing Errors, that is, the object must inherit
+from the Node.js `Error` object. Passing values of any other type will be
+ignored.
+
+### Capturing Warnings
+
+**Using captureWarning**
+
+```javascript
+serverlessSdk.captureWarning("Something bad will happen soon")
+```
+
+**Using console.warn**
+
+```javascript
+console.warn("My Warning")
+```
+
+The Serverless SDK automatically instruments the `console.warn` method to
+capture warnings. This makes instrumentation easier as you may already be using
+`console.warn` to display warnings.
+
+This method only supports capturing strings.
+
+We recommend avoiding using unique instance values for the strings. For example,
+if you need to include a userId, email, request ID, or any ID that may be unique
+to the individual invocation, we recommend using Tagging instead.
+
+### Tagging
+
+**Setting Tags on the Trace**
+
+```javascript
+serverlessSdk.setTag("userId", "bd86489cf036")
+```
+
+Using the `setTag()` method will create Tags associated with the entire Trace.
+You'll be able to see the Tags on the Trace Details page in the Trace Explorer.
+
+All Tags set with `setTag()` are also inherited by all the Captured Errors and
+Captured Warnings. 
+
+**Settings Tags with console.error and console.warn**
+
+```javascript
+serverlessSdk.setTag("userId", "bd86489cf036")
+console.warn("warning message")
+console.error(new Error("some error"))
+```
+
+Using `setTag()` sets the Tag values on both the Trace and all Captured Errors
+and Captured Warnings. Captured Errors and Captured Warnings can be created
+using the `console.error` and `console.warn` methods. Therefore, Tags set with
+`setTag()` will therefore apply to all Captured Errors and Captured Warnings
+created using `console.error` and `console.warn`.
+
+**Setting Tags on Captured Errors**
+
+```javascript
+serverlessSdk.captureError(ex, {tags:{userId:"1b8b4c6b4b14"}})
+```
+
+Tags can also be set on the individual error. If you previously set a Tag using
+`setTag()` then the Tags set on `captureError` will override the Tags on the
+Captured Error, while keeping the Tag on the trace unmodified.
+
+
+**Setting Tags on Captured Warnings**
+
+```javascript
+serverlessSdk.captureWarning("warning message", {tags:{userId:"eb661c69405c"}})
+```
+
+Tags can also be added on the individual Captured Warnings, just like Captured
+Errors.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -121,10 +121,15 @@ serverlessSdk.setTag("userId", "bd86489cf036")
 ```
 
 Using the `setTag()` method will create Tags associated with the entire Trace.
-You'll be able to see the Tags on the Trace Details page in the Trace Explorer.
+You'll be able to see the Tags on the Trace Details page in the Trace Explorer
+and the Invocation Started/Stopped even on Dev Mode.
 
 All Tags set with `setTag()` are also inherited by all the Captured Errors and
 Captured Warnings. 
+
+Tag keys may only contain alphanumeric, `.`, `-`, and `_` characters. Tag values
+may contain any string value. Invalid tag keys will not throw errors, instead,
+an SDK error will be made available in Dev Mode and Trace Details.
 
 **Settings Tags with console.error and console.warn**
 
@@ -150,6 +155,8 @@ Tags can also be set on the individual error. If you previously set a Tag using
 `setTag()` then the Tags set on `captureError` will override the Tags on the
 Captured Error, while keeping the Tag on the trace unmodified.
 
+Tag keys on `captureError` are validated the same way as tag keys on `setTag()`.
+
 
 **Setting Tags on Captured Warnings**
 
@@ -159,3 +166,6 @@ serverlessSdk.captureWarning("warning message", {tags:{userId:"eb661c69405c"}})
 
 Tags can also be added on the individual Captured Warnings, just like Captured
 Errors.
+
+Tag keys on `captureWarning` are validated the same way as tag keys on
+`setTag()`.


### PR DESCRIPTION
Adding documentation on `@serverless/sdk` package.

This adds documentation on the package, capturing errors/warnings, and tagging.

I intentionally left out fingerprinting for now as there is no UI yet that groups by the fingerprint. 