### PR TITLE
feat: Serialize `TraceSpan` neatly

### DIFF
--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "importlib_metadata>=5.2", # included in Python >=3.8
     "js-regex<1.1.0,>=1.0.1",
     "pydantic>=1.10.4",
+    "pyhumps>=3.8",
     "typing-extensions>=4.4", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]

--- a/python/packages/sdk/serverless_sdk/span/trace.py
+++ b/python/packages/sdk/serverless_sdk/span/trace.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from backports.cached_property import cached_property  # available in Python >=3.8
 from pydantic import BaseModel
 from typing_extensions import Final, Self
+from humps import camelize
 
 from ..base import Nanoseconds, TraceId
 from ..exceptions import (
@@ -49,6 +50,10 @@ class TraceSpanBuf(BaseModel):
     timestamp: Optional[Nanoseconds]
     is_historical: Optional[bool]
     type: Optional[str]
+
+    class Config:
+        alias_generator = camelize
+        allow_population_by_field_name = True
 
 
 class TraceSpan:
@@ -150,7 +155,7 @@ class TraceSpan:
 
     @output.setter
     def output(self, value: str):
-        if not isinstance(value, str):
+        if value is not None and not isinstance(value, str):
             raise InvalidType("`output` must be a string.")
 
         self._output = value


### PR DESCRIPTION
This PR contains these changes:
 - Ensure `TraceSpan`'s `TraceSpanBuf` serialization conforms to `TraceProto`'s shape
 - Add `pyhumps` dependency for case conversion
