### PR TITLE
fix: Use correct regex for tag name validation

### DIFF
--- a/python/packages/sdk/serverless_sdk/span/tags.py
+++ b/python/packages/sdk/serverless_sdk/span/tags.py
@@ -16,12 +16,8 @@ from ..exceptions import (
     InvalidTraceSpanTagValue,
 )
 
-
-RE: Final[str] = (
-    r"^[a-z][a-z0-9]*"
-    r"(?:_[a-z][a-z0-9]*)*"
-    r"(?:\.[a-z][a-z0-9]*(?:_[a-z][a-z0-9]*)*)*$"
-)
+# from https://github.com/serverless/console/blob/fe64a4f53529285e89a64f7d50ec9528a3c4ce57/node/packages/sdk/lib/tags.js#L12
+RE: Final[str] = r"^[a-zA-Z0-9_.-]+$"
 RE_C: Final[Pattern] = compile(RE)
 
 

--- a/python/packages/sdk/serverless_sdk/tests/test_tags.py
+++ b/python/packages/sdk/serverless_sdk/tests/test_tags.py
@@ -20,15 +20,14 @@ VALID_NAMES: Final[Tuple[str, ...]] = (
     "validname",
     "a_b_c.d_e_f",
     "a_b_c1.d_e_f2",
+    "Valid.Name",
+    "Valid_name",
 )
 
 INVALID_NAMES: Final[Tuple[str, ...]] = (
     "invalid name",
     "invalid.name,_999",
-    "_invalid.name",
-    "Invalid.name",
-    "inValid.name",
-    "invalid.Name",
+    "?invalid.name",
 )
 
 


### PR DESCRIPTION
This PR contains these changes:
 - Fix tag name validation by using the correct regex
 - Fix tests to reflect validation changes