### PR TITLE
SDK: Store global tags on SDK directly, not on root span

### DIFF
--- a/node/packages/sdk/docs/sdk.md
+++ b/node/packages/sdk/docs/sdk.md
@@ -44,7 +44,7 @@ Record warning
 
 ### `.setTag(name, value)`
 
-Set custom (user defined) tag on root span
+Set custom (user defined) trace tag
 
 - `name` _(string)_ - Tag name, can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters
 - `value` (any) - Tag value. Can be _string_, _boolean_, _number_, _Date_ or _Array_ containing any values of prior listed types

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -32,7 +32,7 @@ serverlessSdk.instrumentation = {};
 Object.defineProperties(
   serverlessSdk.instrumentation,
   lazy({
-    expressApp: d('cew', () => require('./instrumentation/express-app')),
+    expressApp: d('cew', () => require('./instrumentation/express-app'), { flat: true }),
   })
 );
 serverlessSdk.captureError = (error, options = {}) => {

--- a/node/packages/sdk/test/unit/index.test.js
+++ b/node/packages/sdk/test/unit/index.test.js
@@ -44,7 +44,7 @@ describe('index.test.js', () => {
 
   it('should expose .setTag', () => {
     serverlessSdk.setTag('tag', 'value');
-    expect(rootSpan.customTags.get('tag')).to.equal('value');
+    expect(serverlessSdk._customTags.get('tag')).to.equal('value');
   });
 
   it('should not crash on invalid .setTag input', () => {

--- a/node/packages/sdk/test/unit/index.test.js
+++ b/node/packages/sdk/test/unit/index.test.js
@@ -11,6 +11,8 @@ describe('index.test.js', () => {
     requireUncached(() => {
       const TraceSpan = require('../../lib/trace-span');
       serverlessSdk = require('../../');
+      // Ensure to trigger unerlying lazy require
+      serverlessSdk.instrumentation.expressApp;
       rootSpan = new TraceSpan('test');
     });
   });
@@ -22,7 +24,7 @@ describe('index.test.js', () => {
   it('should expose `.traceSpans`', () =>
     expect(serverlessSdk.traceSpans).to.be.instanceOf(Object));
   it('should expose .instrumentation.expressApp', () =>
-    expect(typeof serverlessSdk.instrumentation.expressApp).to.equal('function'));
+    expect(typeof serverlessSdk.instrumentation.expressApp.install).to.equal('function'));
   it('should expose .captureError', () => {
     let capturedEvent;
     serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));


### PR DESCRIPTION
They're considered as trace-wide tags, not specific to any span.

Additionally fixed discovered issue in how `expressApp` instrumentation interface was exposed