### PR TITLE
SDK: Enable customization of event data via private options

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -131,8 +131,9 @@ const closeTrace = async (outcome, outcomeResult) => {
     capturedEvents.length = 0;
     isRootSpanReset = true;
   };
-  const isErrorOutcome = outcome.startsWith('error:');
+
   try {
+    const isErrorOutcome = outcome.startsWith('error:');
     const responseStartTime = process.hrtime.bigint();
 
     awsLambdaSpan.tags.set('aws.lambda.outcome', resolveOutcomeEnumValue(outcome));

--- a/node/packages/sdk/lib/create-error-captured-event.js
+++ b/node/packages/sdk/lib/create-error-captured-event.js
@@ -12,7 +12,7 @@ const resolveNonErrorName = (value) => {
 };
 
 module.exports = (error, options = {}) => {
-  const timestamp = process.hrtime.bigint();
+  const timestamp = options._timestamp || process.hrtime.bigint();
   if (!isObject(options)) options = {};
 
   const capturedEvent = new CapturedEvent('telemetry.error.generated.v1', {
@@ -22,7 +22,7 @@ module.exports = (error, options = {}) => {
     _origin: options._origin,
   });
 
-  const tags = { type: 2 };
+  const tags = { type: options._type === 'unhandled' ? 1 : 2 };
   if (isError(error)) {
     tags.name = error.name;
     tags.message = error.message;

--- a/node/packages/sdk/test/unit/lib/create-error-captured-event.test.js
+++ b/node/packages/sdk/test/unit/lib/create-error-captured-event.test.js
@@ -41,7 +41,7 @@ describe('lib/create-captured-error-event.test.js', () => {
     });
   });
 
-  it('should capture "undfined"', () => {
+  it('should capture "undefined"', () => {
     const event = createCapturedErrorEvent();
     expect(event.tags.toJSON()).to.deep.equal({
       'error.name': 'undefined',

--- a/node/packages/sdk/test/unit/lib/create-error-captured-event.test.js
+++ b/node/packages/sdk/test/unit/lib/create-error-captured-event.test.js
@@ -49,4 +49,14 @@ describe('lib/create-captured-error-event.test.js', () => {
       'error.type': 2,
     });
   });
+
+  it('should support private options"', () => {
+    const timestamp = process.hrtime.bigint();
+    const event = createCapturedErrorEvent(new Error('Stop'), {
+      _type: 'unhandled',
+      _timestamp: timestamp,
+    });
+    expect(event.tags.get('error.type')).to.equal(1);
+    expect(event.timestamp).to.equal(timestamp);
+  });
 });


### PR DESCRIPTION
Needed to support registering uncaught error events which is needed in context of AWS Lambda SDK