### PR TITLE
fix: Enable user-installable packages in integration

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -41,6 +41,18 @@ jobs:
             proto:
               - 'proto/**'
 
+      - name: Install Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+
+          # ensure project dependencies are cached
+          # When using only `pyproject.toml` for dependencies, see:
+          #  https://github.com/actions/setup-python/issues/529#issuecomment-1367029699
+          cache: 'pip'
+          cache-dependency-path: |
+            **/pyproject.toml
+
       - name: Install SDK project and dependencies
         if: steps.pathChanges.outputs.sdk == 'true'
         run: |


### PR DESCRIPTION
Use `setup-python` as a base to ensure that packages can be installed as a user versus system.