### PR TITLE
AWS Lambda SDK: Expose custom tags directly on trace instead of root span

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -16,6 +16,8 @@ const pkgJson = require('../package');
 
 const serverlessSdk = require('./lib/sdk');
 
+const objHasOwnProperty = Object.prototype.hasOwnProperty;
+
 const capturedEvents = [];
 serverlessSdk._eventEmitter.on('captured-event', (capturedEvent) =>
   capturedEvents.push(capturedEvent)
@@ -101,6 +103,9 @@ const reportTrace = () => {
       return spanPayload;
     }),
     events: capturedEvents.map((capturedEvent) => capturedEvent.toProtobufObject()),
+    customTags: objHasOwnProperty.call(serverlessSdk, '_customTags')
+      ? JSON.stringify(serverlessSdk._customTags)
+      : undefined,
   });
   const payloadBuffer = (serverlessSdk._lastTraceBuffer =
     traceProto.TracePayload.encode(payload).finish());

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -2,6 +2,8 @@
 
 const serverlessSdk = require('./sdk');
 
+const objHasOwnProperty = Object.prototype.hasOwnProperty;
+
 serverlessSdk._deferredTelemetryRequests = [];
 
 if (!serverlessSdk._isDevMode) {
@@ -30,6 +32,9 @@ const sendData = () => {
     },
     spans: pendingSpans.map((span) => span.toProtobufObject()),
     events: pendingCapturedEvents.map((capturedEvent) => capturedEvent.toProtobufObject()),
+    customTags: objHasOwnProperty.call(serverlessSdk, '_customTags')
+      ? JSON.stringify(serverlessSdk._customTags)
+      : undefined,
   };
   pendingSpans.length = 0;
   pendingCapturedEvents.length = 0;

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.13.1",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk": "^0.3.1",
+    "@serverless/sdk": "^0.4.0",
     "@serverless/sdk-schema": "^0.14.3",
     "d": "^1.0.1",
     "ext": "^1.7.0",

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1374,7 +1374,7 @@ describe('integration', function () {
           isCustomResponse: true,
           test: ({ invocationsData }) => {
             for (const [index, { trace, responsePayload }] of invocationsData.entries()) {
-              const { spans, events } = trace;
+              const { spans, events, customTags } = trace;
               let awsLambdaInvocationSpan;
               if (index === 0) {
                 awsLambdaInvocationSpan = spans[2];
@@ -1396,7 +1396,7 @@ describe('integration', function () {
               expect(payload.name).to.equal(pkgJson.name);
               expect(payload.version).to.equal(pkgJson.version);
               expect(payload.rootSpanName).to.equal('aws.lambda');
-              expect(JSON.parse(spans[0].customTags)).to.deep.equal({ 'user.tag': 'example' });
+              expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': 'example' });
 
               const normalizeEvent = (event) => {
                 event = { ...event };

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -804,7 +804,7 @@ describe('internal-extension/index.test.js', () => {
       payload: { isTriggeredByUnitTest: true },
     });
 
-    const { spans, events } = trace;
+    const { spans, events, customTags } = trace;
 
     expect(spans.map(({ name }) => name)).to.deep.equal([
       'aws.lambda',
@@ -815,7 +815,7 @@ describe('internal-extension/index.test.js', () => {
     expect(result.name).to.equal(pkgJson.name);
     expect(result.version).to.equal(pkgJson.version);
     expect(result.rootSpanName).to.equal('aws.lambda');
-    expect(JSON.parse(spans[0].customTags)).to.deep.equal({ 'user.tag': 'example' });
+    expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': 'example' });
 
     const normalizeEvent = (event) => {
       event = { ...event };


### PR DESCRIPTION
Global custom tags are exposed on TracePayload instead of root span. It's configured both for CW trace report writing and dev mode