### PR TITLE
AWS Lambda SDK: Ensure to clear custom tags collection between invocations

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -132,6 +132,7 @@ const closeTrace = async (outcome, outcomeResult) => {
     awsLambdaSpan.tags.reset();
     awsLambdaSpan.subSpans.clear();
     capturedEvents.length = 0;
+    if (objHasOwnProperty.call(serverlessSdk, '_customTags')) serverlessSdk._customTags.clear();
     isRootSpanReset = true;
   };
 

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/sdk.js
@@ -24,7 +24,7 @@ module.exports.handler = async (event) => {
     tags: { 'user.tag': 'example', 'invocationid': invocationId },
   });
 
-  sdk.setTag('user.tag', 'example');
+  sdk.setTag('user.tag', `example:${invocationId}`);
 
   console.warn('Consoled warning', 12, true);
   return {

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1398,7 +1398,7 @@ describe('integration', function () {
               expect(payload.name).to.equal(pkgJson.name);
               expect(payload.version).to.equal(pkgJson.version);
               expect(payload.rootSpanName).to.equal('aws.lambda');
-              expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': 'example' });
+              expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': `example:${index + 1}` });
 
               const normalizeEvent = (event) => {
                 event = { ...event };

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -818,7 +818,7 @@ describe('internal-extension/index.test.js', () => {
     expect(result.name).to.equal(pkgJson.name);
     expect(result.version).to.equal(pkgJson.version);
     expect(result.rootSpanName).to.equal('aws.lambda');
-    expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': 'example' });
+    expect(JSON.parse(customTags)).to.deep.equal({ 'user.tag': `example:${1}` });
 
     const normalizeEvent = (event) => {
       event = { ...event };


### PR DESCRIPTION
Fixes issue, where setting same tag with different value in other invocation is rejected