### PR TITLE
SDK: Fix documentation issues

### DIFF
--- a/node/packages/aws-lambda-sdk/docs/instrumentation/aws-sdk.md
+++ b/node/packages/aws-lambda-sdk/docs/instrumentation/aws-sdk.md
@@ -6,7 +6,7 @@ All AWS SDK requests are traced.
 
 Tracing is turned on automatically for AWS SDK clients that are normally loaded via Node.js `require`.
 
-However if AWS SDK is bundled or imported via ESM import, then instrumentation needs to be turned on manually with following steps:
+However if AWS SDK is bundled then instrumentation needs to be turned on manually with following steps:
 
 ```javascript
 import AWS from 'aws-sdk';

--- a/node/packages/sdk/docs/instrumentation/express-app.md
+++ b/node/packages/sdk/docs/instrumentation/express-app.md
@@ -4,8 +4,7 @@ _Disable with `SLS_DISABLE_EXPRESS_MONITORING` environment variable_
 
 If [`express`](https://expressjs.com/) framework (together with tools like [`serverless-http`](https://github.com/dougmoscrop/serverless-http)) is used to route incoming requests. Trace spans for it's middlewares are created
 
-Tracing is turned on automatically, assuming that `express` is loaded normally via Node.js `require`.
-If it comes bundled or imported via ESM import, then instrumentation needs to be turned on manually with following steps:
+Tracing is turned on automatically, assuming that `express` is loaded normally via Node.js `require`. If it comes bundled then instrumentation needs to be turned on manually with following steps:
 
 ```javascript
 import express from 'express';

--- a/node/packages/sdk/docs/sdk.md
+++ b/node/packages/sdk/docs/sdk.md
@@ -20,7 +20,7 @@ Dictionary of common spans created in context of given environment
 
 ### `.instrumentation`
 
-Most of the instrumentation is setup automatically, still there are scenarios when it's difficult to ensure that (e.g. when target modules are imported as ESM, or come from bundles). In such case instrumentation need to be set manually. In context of `@serverless/sdk` following instrumentation extensions are provided:
+Most of the instrumentation is setup automatically, still there are scenarios when it's difficult to ensure that (e.g. when target modules are bundled). In such case instrumentation need to be set manually. In context of `@serverless/sdk` following instrumentation extensions are provided:
 
 - `.instrumentation.expressApp.install(express)` - Instrument Express. See [instrumentatiom/express-app](instrumentation/express-app.md)
 

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -87,7 +87,7 @@ serverlessSdk._initialize = (options = {}) => {
   }
 
   if (!settings.disableExpressMonitoring) {
-    // Auto generate AWS SDK request spans
+    // Auto generate express middleware spans
     require('./lib/instrumentation/express').install();
   }
 


### PR DESCRIPTION
Apparently, auto instrumentation works also if `express` and AWS SDK are imported via ESM import. It won't work only if target imported modules would be ESM, while in this case they remain CJS