### PR TITLE
AWS Lambda SDK: Ensure to not propagate root span without requestId tag do dev mode

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -157,7 +157,8 @@ const closeTrace = async (outcome, outcomeResult) => {
     }
     if (traceSpans.awsLambdaInvocation) traceSpans.awsLambdaInvocation.close({ endTime });
     awsLambdaSpan.close({ endTime });
-    // Trace report requires requestId, which we don't have if handler crashed at initialization
+    // Root span comes with "aws.lambda.*" tags, which require unconditionally requestId
+    // which we don't have if handler crashed at initialization
     if (invocationContextAccessor.value) reportTrace();
     flushSpans();
     clearRootSpan();

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -38,6 +38,11 @@ const sendData = () => {
   };
   pendingSpans.length = 0;
   pendingCapturedEvents.length = 0;
+  if (!invocationContextAccessor.value) {
+    // Root span comes with "aws.lambda.*" tags, which require unconditionally requestId
+    // which we don't have if handler crashed at initialization.
+    payload.spans = payload.spans.filter((span) => span.name !== 'aws.lambda');
+  }
   serverlessSdk._deferredTelemetryRequests.push(
     sendTelemetry('trace', traceProto.TracePayload.encode(payload).finish())
   );


### PR DESCRIPTION
As we unconditionally require `aws.lambda.requestId` tag by schema on root span, we cannot report root span if lambda crashes at initialization.

This was taken into account in report writing, but it's not taken into account with dev mode, this patch fixes that