### PR TITLE
AWS Lambda SDK: Fix AWS SDK error reporting

### DIFF
--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -63,7 +63,9 @@ module.exports.install = (Sdk) => {
       wasCompleted = true;
       if (response.requestId) traceSpan.tags.set('aws.sdk.request_id', response.requestId);
       if (response.error) {
-        traceSpan.tags.set('aws.sdk.error', response.error.message);
+        // Fallback to error.name, as there are cases when AWS SDK returns error with no message:
+        // https://github.com/aws/aws-sdk-js/issues/4330
+        traceSpan.tags.set('aws.sdk.error', response.error.message || response.error.name);
       } else {
         if (shouldMonitorRequestResponse) traceSpan.output = safeStringify(response.data);
         if (tagMapper && tagMapper.responseData) tagMapper.responseData(traceSpan, response.data);

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -65,6 +65,7 @@ module.exports.install = (client) => {
           if (error.$metadata && error.$metadata.requestId) {
             traceSpan.tags.set('aws.sdk.request_id', error.$metadata.requestId);
           }
+          traceSpan.tags.set('aws.sdk.error', error.message || error.name);
           if (!traceSpan.endTime) traceSpan.close();
           throw error;
         } else {

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // eslint-disable-next-line import/no-unresolved
-const { S3, SQS, SNS, DynamoDB, STS, Lambda } = require('aws-sdk');
+const { S3, SQS, SNS, DynamoDB, STS, SSM, Lambda } = require('aws-sdk');
 
 const wait = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -9,6 +9,7 @@ const s3 = new S3();
 const sqs = new SQS();
 const sns = new SNS();
 const lambda = new Lambda();
+const ssm = new SSM();
 const dynamoDb = new DynamoDB();
 const dynamodbDocumentClient = new DynamoDB.DocumentClient();
 const sts = new STS();
@@ -29,6 +30,12 @@ module.exports.handler = async () => {
     // Test request error reporting
     try {
       await lambda.getFunction({ FunctionName: 'not-existing' }).promise();
+    } catch (error) {
+      // do nothing
+    }
+    try {
+      // Special error case: https://github.com/aws/aws-sdk-js/issues/4330
+      await ssm.getParameter({ Name: '/not/existing' }).promise();
     } catch (error) {
       // do nothing
     }

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
@@ -18,7 +18,7 @@ module.exports.handler = async () => {
   try {
     ++invocationCount;
 
-    // STS (any service tracing
+    // STS (confirm on tracing of any AWS service)
     await sts.getCallerIdentity().promise();
 
     // s3.getSignedUrlPromise won't issue a real HTTP request

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2.js
@@ -1,13 +1,14 @@
 'use strict';
 
 // eslint-disable-next-line import/no-unresolved
-const { S3, SQS, SNS, DynamoDB, STS } = require('aws-sdk');
+const { S3, SQS, SNS, DynamoDB, STS, Lambda } = require('aws-sdk');
 
 const wait = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const s3 = new S3();
 const sqs = new SQS();
 const sns = new SNS();
+const lambda = new Lambda();
 const dynamoDb = new DynamoDB();
 const dynamodbDocumentClient = new DynamoDB.DocumentClient();
 const sts = new STS();
@@ -24,6 +25,13 @@ module.exports.handler = async () => {
     // s3.getSignedUrlPromise won't issue a real HTTP request
     // It's injected to confirm no trace span will be created for it
     await s3.getSignedUrlPromise('putObject', { Bucket: 'test', Key: 'test', Expires: 500 });
+
+    // Test request error reporting
+    try {
+      await lambda.getFunction({ FunctionName: 'not-existing' }).promise();
+    } catch (error) {
+      // do nothing
+    }
 
     // SQS
     const queueName = `${process.env.AWS_LAMBDA_FUNCTION_NAME}-${invocationCount}.fifo`;

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
@@ -29,7 +29,7 @@ module.exports.handler = async () => {
   try {
     ++invocationCount;
 
-    // STS (any service tracing
+    // STS (confirm on tracing of any AWS service)
     await sts.getCallerIdentity();
 
     // getSignedUrl won't issue a real HTTP request

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
@@ -5,6 +5,7 @@ const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 const { SQS } = require('@aws-sdk/client-sqs');
 const { SNS } = require('@aws-sdk/client-sns');
 const { STS } = require('@aws-sdk/client-sts');
+const { Lambda } = require('@aws-sdk/client-lambda');
 const { DynamoDB, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, QueryCommand } = require('@aws-sdk/lib-dynamodb');
 
@@ -20,6 +21,7 @@ const wait = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const s3Client = new S3Client();
 const sqs = new SQS();
 const sns = new SNS();
+const lambda = new Lambda();
 const dynamoDb = new DynamoDB();
 const sts = new STS();
 
@@ -37,6 +39,13 @@ module.exports.handler = async () => {
     await getSignedUrl(s3Client, new GetObjectCommand({ Bucket: 'test', Key: 'test' }), {
       expiresIn: 3600,
     });
+
+    // Test request error reporting
+    try {
+      await lambda.getFunction({ FunctionName: 'not-existing' });
+    } catch (error) {
+      // do nothing
+    }
 
     // SQS
     const queueName = `${process.env.AWS_LAMBDA_FUNCTION_NAME}-${invocationCount}.fifo`;

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3.js
@@ -6,6 +6,7 @@ const { SQS } = require('@aws-sdk/client-sqs');
 const { SNS } = require('@aws-sdk/client-sns');
 const { STS } = require('@aws-sdk/client-sts');
 const { Lambda } = require('@aws-sdk/client-lambda');
+const { SSM } = require('@aws-sdk/client-ssm');
 const { DynamoDB, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, QueryCommand } = require('@aws-sdk/lib-dynamodb');
 
@@ -22,6 +23,7 @@ const s3Client = new S3Client();
 const sqs = new SQS();
 const sns = new SNS();
 const lambda = new Lambda();
+const ssm = new SSM();
 const dynamoDb = new DynamoDB();
 const sts = new STS();
 
@@ -43,6 +45,11 @@ module.exports.handler = async () => {
     // Test request error reporting
     try {
       await lambda.getFunction({ FunctionName: 'not-existing' });
+    } catch (error) {
+      // do nothing
+    }
+    try {
+      await ssm.getParameter({ Name: '/not/existing' });
     } catch (error) {
       // do nothing
     }

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -5,6 +5,7 @@
     "@aws-sdk/client-s3": "^3.258.0",
     "@aws-sdk/client-sns": "^3.258.0",
     "@aws-sdk/client-sqs": "^3.258.0",
+    "@aws-sdk/client-ssm": "^3.259.0",
     "@aws-sdk/client-sts": "^3.258.0",
     "@aws-sdk/lib-dynamodb": "^3.258.0",
     "@aws-sdk/s3-request-presigner": "^3.258.0",

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.258.0",
+    "@aws-sdk/client-lambda": "^3.259.0",
     "@aws-sdk/client-s3": "^3.258.0",
     "@aws-sdk/client-sns": "^3.258.0",
     "@aws-sdk/client-sqs": "^3.258.0",

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -108,6 +108,7 @@ describe('integration', function () {
       const [
         invocationSpan,
         stsSpan,
+        lambdaErrorSpan,
         sqsCreateSpan,
         sqsSendSpan,
         sqsDeleteSpan,
@@ -129,6 +130,17 @@ describe('integration', function () {
       expect(sdkTags.operation).to.equal('getcalleridentity');
       expect(sdkTags).to.have.property('requestId');
       expect(sdkTags).to.not.have.property('error');
+
+      // Lambda error span
+      expect(lambdaErrorSpan.parentSpanId.toString()).to.equal(invocationSpan.id.toString());
+      expect(lambdaErrorSpan.name).to.equal('aws.sdk.lambda.getfunction');
+      sdkTags = lambdaErrorSpan.tags.aws.sdk;
+      expect(sdkTags.region).to.equal(process.env.AWS_REGION);
+      expect(sdkTags.signatureVersion).to.equal('v4');
+      expect(sdkTags.service).to.equal('lambda');
+      expect(sdkTags.operation).to.equal('getfunction');
+      expect(sdkTags).to.have.property('requestId');
+      expect(sdkTags).to.have.property('error');
 
       // SNS
       const queueName = `${testConfig.configuration.FunctionName}-${index + 1}.fifo`;

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -109,6 +109,7 @@ describe('integration', function () {
         invocationSpan,
         stsSpan,
         lambdaErrorSpan,
+        ssmErrorSpan,
         sqsCreateSpan,
         sqsSendSpan,
         sqsDeleteSpan,
@@ -139,6 +140,17 @@ describe('integration', function () {
       expect(sdkTags.signatureVersion).to.equal('v4');
       expect(sdkTags.service).to.equal('lambda');
       expect(sdkTags.operation).to.equal('getfunction');
+      expect(sdkTags).to.have.property('requestId');
+      expect(sdkTags).to.have.property('error');
+
+      // SSM error span
+      expect(ssmErrorSpan.parentSpanId.toString()).to.equal(invocationSpan.id.toString());
+      expect(ssmErrorSpan.name).to.equal('aws.sdk.ssm.getparameter');
+      sdkTags = ssmErrorSpan.tags.aws.sdk;
+      expect(sdkTags.region).to.equal(process.env.AWS_REGION);
+      expect(sdkTags.signatureVersion).to.equal('v4');
+      expect(sdkTags.service).to.equal('ssm');
+      expect(sdkTags.operation).to.equal('getparameter');
       expect(sdkTags).to.have.property('requestId');
       expect(sdkTags).to.have.property('error');
 

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -1104,7 +1104,7 @@ describe('integration', function () {
               },
             },
           ],
-          ['external', {}],
+          ['external', { configuration: { Runtime: 'nodejs18.x' } }],
         ]),
       },
     ],
@@ -1117,6 +1117,7 @@ describe('integration', function () {
             'internal',
             {
               configuration: {
+                Runtime: 'nodejs18.x',
                 Code: {
                   ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, 'aws-sdk-v3.js')),
                 },


### PR DESCRIPTION
1. Fix error reporting on AWS SDK v3 side. It appears `aws.sdk.error` tag was not set in case of error
2. Fix handling of special error case, as observed on AWS SDK v2, where `error.message` equals `null` (reported to AWS SDK at https://github.com/aws/aws-sdk-js/issues/4330)