### PR TITLE
AWS Lambda SDK: Fix invocation closure race condition

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught-resolution-race.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/error-uncaught-resolution-race.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.handler = () => {
+  let resolve;
+  const promise = new Promise((_resolve) => {
+    resolve = _resolve;
+  });
+  process.nextTick(() => {
+    resolve();
+    throw new Error('Stop');
+  });
+  return promise;
+};

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -565,6 +565,18 @@ describe('integration', function () {
       },
     ],
     [
+      'error-uncaught-resolution-race',
+      {
+        variants: new Map([
+          ['v12', { configuration: { Runtime: 'nodejs12.x' } }],
+          ['v14', { configuration: { Runtime: 'nodejs14.x' } }],
+          ['v16', { configuration: { Runtime: 'nodejs16.x' } }],
+          ['v18', { configuration: { Runtime: 'nodejs18.x' } }],
+        ]),
+        config: { expectedOutcome: 'error:unhandled' },
+      },
+    ],
+    [
       'error-unhandled',
       {
         variants: new Map([


### PR DESCRIPTION
When reproducing error addressed with https://github.com/serverless/console/pull/429 I've observed an error situation where invocation closure is processed twice for same invocation.
It appears we didn't have prevention for scenario when uncaught exception happens and right after invocation resolves. This PR fixes that