### PR TITLE
SDK: Prevent internal crashes

### DIFF
--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -38,10 +38,18 @@ Object.defineProperties(
   })
 );
 serverlessSdk.captureError = (error, options = {}) => {
-  createErrorCapturedEvent(error, options);
+  try {
+    createErrorCapturedEvent(error, options);
+  } catch (reportError) {
+    reportSdkError(reportError);
+  }
 };
 serverlessSdk.captureWarning = (message, options = {}) => {
-  createWarningCapturedEvent(message, options);
+  try {
+    createWarningCapturedEvent(message, options);
+  } catch (reportError) {
+    reportSdkError(reportError);
+  }
 };
 serverlessSdk.setTag = (name, value) => {
   try {

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -45,9 +45,9 @@ serverlessSdk.captureWarning = (message, options = {}) => {
 };
 serverlessSdk.setTag = (name, value) => {
   try {
-    serverlessSdk._customTags.set(name, value);
+    serverlessSdk._customTags._set(name, value);
   } catch (error) {
-    console.error(error);
+    reportSdkError(error, { type: 'USER' });
   }
 };
 

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -17,6 +17,7 @@ const Tags = require('./lib/tags');
 const TraceSpan = require('./lib/trace-span');
 const createErrorCapturedEvent = require('./lib/create-error-captured-event');
 const createWarningCapturedEvent = require('./lib/create-warning-captured-event');
+const reportSdkError = require('./lib/report-sdk-error');
 const pkgJson = require('./package');
 
 const serverlessSdk = module.exports;
@@ -102,6 +103,7 @@ serverlessSdk._initialize = (options = {}) => {
 };
 
 serverlessSdk._createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
+serverlessSdk._reportSdkError = reportSdkError;
 serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
 serverlessSdk._debugLog = (...args) => {
   if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);

--- a/node/packages/sdk/lib/captured-event.js
+++ b/node/packages/sdk/lib/captured-event.js
@@ -15,6 +15,7 @@ const emitter = require('./emitter');
 const Tags = require('./tags');
 const TraceSpan = require('./trace-span');
 const ServerlessSdkError = require('./error');
+const reportSdkError = require('./report-sdk-error');
 
 class CapturedEvent {
   constructor(name, options = {}) {
@@ -41,14 +42,14 @@ class CapturedEvent {
       name: 'options.customTags',
     });
     try {
-      if (customTags) this.customTags.setMany(customTags);
+      if (customTags) this.customTags._setMany(customTags);
       this.customFingerprint = ensureString(options.customFingerprint, {
         isOptional: true,
         name: 'options.fingerprint',
         Error: ServerlessSdkError,
       });
     } catch (error) {
-      console.error(error);
+      reportSdkError(error, { type: 'USER' });
     }
     if (options._origin) this._origin = options._origin;
     this.traceSpan = TraceSpan.resolveCurrentSpan();

--- a/node/packages/sdk/lib/create-error-captured-event.js
+++ b/node/packages/sdk/lib/create-error-captured-event.js
@@ -5,12 +5,7 @@ const isObject = require('type/object/is');
 const isError = require('type/error/is');
 const CapturedEvent = require('./captured-event');
 const resolveStackTraceString = require('./resolve-stack-trace-string');
-
-const resolveNonErrorName = (value) => {
-  if (isObject(value)) return 'object';
-  if (value === null) return 'null';
-  return typeof value;
-};
+const resolveNonErrorName = require('./resolve-non-error-name');
 
 module.exports = (error, options = {}) => {
   const timestamp = options._timestamp || process.hrtime.bigint();

--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const reportSdkError = require('../../report-sdk-error');
+
 const instrumentedLayers = new WeakMap();
 const expressSpansMap = new WeakMap();
 const invalidNameCharsPatern = /[^0-9a-zA-Z]/g;
@@ -14,57 +16,71 @@ module.exports.install = (layerPrototype) => {
   const originalHandleError = layerPrototype.handle_error;
 
   layerPrototype.handle_request = function handle(req, res, next) {
-    if (!expressSpansMap.has(req)) {
-      const expressSpan = serverlessSdk._createTraceSpan('express');
-      const openedSpans = new Set();
-      const expressRouteData = { expressSpan, openedSpans };
-      expressSpansMap.set(req, expressRouteData);
-      res.on('finish', () => {
-        const endTime = process.hrtime.bigint();
-        if (expressRouteData.route && expressRouteData.route.path && rootSpan) {
-          // Override eventual API Gateway's `resourcePath`
-          rootSpan.tags.delete('aws.lambda.http_router.path');
-          rootSpan.tags.set('aws.lambda.http_router.path', expressRouteData.route.path);
-        }
-        for (const subSpan of openedSpans) {
-          if (!subSpan.endTime) subSpan.close({ endTime });
-        }
-        openedSpans.clear();
-        if (!expressSpan.endTime) expressSpan.close({ endTime });
-      });
-    }
-    const expressRouteData = expressSpansMap.get(req);
-    const { routeSpan, openedSpans } = expressRouteData;
-    const isRouterMiddleware = !routeSpan && this.name === 'bound dispatch';
-    const middlewareSpanName = (() => {
-      if (routeSpan) {
-        return `express.middleware.route.${[
-          generateMiddlewareName(this.method),
-          generateMiddlewareName(this.name) || 'unknown',
-        ]
-          .filter(Boolean)
-          .join('.')}`;
+    let middlewareSpan;
+    let expressRouteData;
+    try {
+      if (!expressSpansMap.has(req)) {
+        const expressSpan = serverlessSdk._createTraceSpan('express');
+        const openedSpans = new Set();
+        expressRouteData = { expressSpan, openedSpans };
+        expressSpansMap.set(req, expressRouteData);
+        res.on('finish', () => {
+          const endTime = process.hrtime.bigint();
+          if (expressRouteData.route && expressRouteData.route.path && rootSpan) {
+            // Override eventual API Gateway's `resourcePath`
+            rootSpan.tags.delete('aws.lambda.http_router.path');
+            rootSpan.tags.set('aws.lambda.http_router.path', expressRouteData.route.path);
+          }
+          for (const subSpan of openedSpans) {
+            if (!subSpan.endTime) subSpan.close({ endTime });
+          }
+          openedSpans.clear();
+          if (!expressSpan.endTime) expressSpan.close({ endTime });
+        });
       }
-      return isRouterMiddleware
-        ? 'express.middleware.router'
-        : `express.middleware.${generateMiddlewareName(this.name) || 'unknown'}`;
-    })();
-    const middlewareSpan = serverlessSdk._createTraceSpan(middlewareSpanName);
-    openedSpans.add(middlewareSpan);
-    if (this.path && (!expressRouteData.path || expressRouteData.path.length < this.path.length)) {
-      expressRouteData.path = this.path;
-    }
-    if (this.method) expressRouteData.method = this.method;
-    if (isRouterMiddleware) {
-      expressRouteData.routeSpan = middlewareSpan;
-      expressRouteData.route = this.route;
+      expressRouteData = expressSpansMap.get(req);
+      const { routeSpan, openedSpans } = expressRouteData;
+      const isRouterMiddleware = !routeSpan && this.name === 'bound dispatch';
+      const middlewareSpanName = (() => {
+        if (routeSpan) {
+          return `express.middleware.route.${[
+            generateMiddlewareName(this.method),
+            generateMiddlewareName(this.name) || 'unknown',
+          ]
+            .filter(Boolean)
+            .join('.')}`;
+        }
+        return isRouterMiddleware
+          ? 'express.middleware.router'
+          : `express.middleware.${generateMiddlewareName(this.name) || 'unknown'}`;
+      })();
+      middlewareSpan = serverlessSdk._createTraceSpan(middlewareSpanName);
+      openedSpans.add(middlewareSpan);
+      if (
+        this.path &&
+        (!expressRouteData.path || expressRouteData.path.length < this.path.length)
+      ) {
+        expressRouteData.path = this.path;
+      }
+      if (this.method) expressRouteData.method = this.method;
+      if (isRouterMiddleware) {
+        expressRouteData.routeSpan = middlewareSpan;
+        expressRouteData.route = this.route;
+      }
+    } catch (error) {
+      reportSdkError(error);
+      return originalHandleRequest.call(this, req, res, next);
     }
     try {
       return originalHandleRequest.call(this, req, res, (...args) => {
-        if (!middlewareSpan.endTime) {
-          openedSpans.delete(middlewareSpan);
-          middlewareSpan.close();
-          if (this.name === 'bound dispatch') delete expressRouteData.routeSpan;
+        try {
+          if (!middlewareSpan.endTime) {
+            expressRouteData.openedSpans.delete(middlewareSpan);
+            middlewareSpan.close();
+            if (this.name === 'bound dispatch') delete expressRouteData.routeSpan;
+          }
+        } catch (error) {
+          reportSdkError(error);
         }
         return next(...args);
       });
@@ -74,14 +90,21 @@ module.exports.install = (layerPrototype) => {
   };
   // eslint-disable-next-line camelcase
   layerPrototype.handle_error = function handle_error(error, req, res, next) {
-    const { openedSpans } = expressSpansMap.get(req);
-    const middlewareSpan = serverlessSdk._createTraceSpan(
-      `express.middleware.error.${generateMiddlewareName(this.name) || 'unknown'}`
-    );
-    openedSpans.add(middlewareSpan);
+    const expressRouteData = expressSpansMap.get(req);
+    let middlewareSpan;
+    try {
+      const { openedSpans } = expressRouteData;
+      middlewareSpan = serverlessSdk._createTraceSpan(
+        `express.middleware.error.${generateMiddlewareName(this.name) || 'unknown'}`
+      );
+      openedSpans.add(middlewareSpan);
+    } catch (sdkError) {
+      reportSdkError(sdkError);
+      return originalHandleError.call(this, error, req, res, next);
+    }
     return originalHandleError.call(this, error, req, res, (...args) => {
       if (!middlewareSpan.endTime) {
-        openedSpans.delete(middlewareSpan);
+        expressRouteData.openedSpans.delete(middlewareSpan);
         middlewareSpan.close();
       }
       return next(...args);

--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const instrumentedLayers = new WeakMap();
-
 const expressSpansMap = new WeakMap();
-
 const invalidNameCharsPatern = /[^0-9a-zA-Z]/g;
 const digitStartRe = /^\d+/;
 

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -227,6 +227,7 @@ module.exports.install = () => {
 };
 
 module.exports.ignoreFollowingRequest = () => {
+  if (!isInstalled) return;
   serverlessSdk._debugLog('ignore HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
   shouldIgnoreFollowingRequest = true;
   process.nextTick(() => {

--- a/node/packages/sdk/lib/report-sdk-error.js
+++ b/node/packages/sdk/lib/report-sdk-error.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const util = require('util');
+const isError = require('type/error/is');
+const resolveNonErrorName = require('./resolve-non-error-name');
+
+module.exports = (error, options = {}) => {
+  if (process.env.SLS_CRASH_ON_SDK_ERROR) throw error;
+  let name;
+  let message;
+  if (isError(error)) {
+    name = error.name;
+    message = error.message;
+  } else {
+    name = resolveNonErrorName(error);
+    message = typeof error === 'string' ? error : util.inspect(error);
+  }
+  const type = options.type || 'INTERNAL';
+  console.error({
+    source: 'serverlessSdk',
+    type,
+    description:
+      type === 'INTERNAL'
+        ? 'Internal Serverless SDK Error. ' +
+          'Please report at https://github.com/serverless/console/issue'
+        : undefined,
+    name,
+    message,
+    code: error && error.code,
+    stackTrace: error && error.stack,
+  });
+};

--- a/node/packages/sdk/lib/resolve-non-error-name.js
+++ b/node/packages/sdk/lib/resolve-non-error-name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const isObject = require('type/object/is');
+
+module.exports = (value) => {
+  if (isObject(value)) return 'object';
+  if (value === null) return 'null';
+  return typeof value;
+};

--- a/node/packages/sdk/test/unit/lib/tags.test.js
+++ b/node/packages/sdk/test/unit/lib/tags.test.js
@@ -37,12 +37,11 @@ describe('lib/tags.test.js', () => {
     ]);
   });
 
-  it('should reject setting with different value tag that alraedy exists', () => {
+  it('should reject, but handle silently, setting with different value tag that alraedy exists', () => {
     const tags = new Tags();
     tags.set('tag', true);
-    expect(() => tags.set('tag', 'again'))
-      .to.throw(Error)
-      .with.property('code', 'DUPLICATE_TRACE_SPAN_TAG_NAME');
+    tags.set('tag', 'again');
+    expect(tags.get('tag')).to.equal(true);
   });
 
   it('should ignore resetting tag with same value', () => {


### PR DESCRIPTION
When SDK processing fails, if possible log error information instead of crashing user Lambda.

- Log error, instead of throwing error on invalid tag values as set for internal tags
- Wrap certain instrumentation parts of HTTP and express with crash prevention
- Wrap registration of captured events with crash prevention

After this is merged and released, it'll be followed up with similar update to AWS Lambda SDK for which changes I have ready locally