### PR TITLE
AWS Lambda SDK: Prevent internal crashes

### DIFF
--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -15,12 +15,16 @@ serverlessSdk.instrumentation.awsSdkV2 = require('./instrumentation/aws-sdk-v2')
 serverlessSdk.instrumentation.awsSdkV3Client = require('./instrumentation/aws-sdk-v3-client');
 
 serverlessSdk._initializeExtension = (options) => {
-  const settings = serverlessSdk._settings;
-  serverlessSdk._settings.disableAwsSdkMonitoring = Boolean(
-    process.env.SLS_DISABLE_AWS_SDK_MONITORING || options.disableAwsSdkMonitoring
-  );
-  if (!settings.disableAwsSdkMonitoring) {
-    require('./lib/instrumentation/aws-sdk').install();
+  try {
+    const settings = serverlessSdk._settings;
+    serverlessSdk._settings.disableAwsSdkMonitoring = Boolean(
+      process.env.SLS_DISABLE_AWS_SDK_MONITORING || options.disableAwsSdkMonitoring
+    );
+    if (!settings.disableAwsSdkMonitoring) {
+      require('./lib/instrumentation/aws-sdk').install();
+    }
+  } catch (error) {
+    serverlessSdk._reportSdkError(error);
   }
 };
 serverlessSdk._isDevMode = Boolean(process.env.SLS_DEV_MODE_ORG_ID);

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -174,12 +174,7 @@ const closeTrace = async (outcome, outcomeResult) => {
       `${Math.round(Number(process.hrtime.bigint() - endTime) / 1000000)}ms`
     );
   } catch (error) {
-    process._rawDebug(
-      'Fatal Serverless SDK Error: ' +
-        'Please report at https://github.com/serverless/console/issues: ' +
-        'Response handling failed: ',
-      error && (error.stack || error)
-    );
+    serverlessSdk._reportSdkError(error);
     if (!isRootSpanReset) clearRootSpan();
   }
 };
@@ -259,12 +254,7 @@ module.exports = (originalHandler, options = {}) => {
         `${Math.round(Number(process.hrtime.bigint() - requestStartTime) / 1000000)}ms`
       );
     } catch (error) {
-      process._rawDebug(
-        'Fatal Serverless SDK Error: ' +
-          'Please report at https://github.com/serverless/console/issues: ' +
-          'Request handling failed: ',
-        error && (error.stack || error)
-      );
+      serverlessSdk._reportSdkError(error);
       if (originalDone) contextDone = originalDone;
       return originalHandler(event, context, awsCallback);
     }

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v2.js
@@ -94,4 +94,4 @@ module.exports.uninstall = (client) => {
   if (uninstall) uninstall();
 };
 
-const serverlessSdk = global.serverlessSdk || require('../');
+const serverlessSdk = require('../');

--- a/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
+++ b/node/packages/aws-lambda-sdk/instrumentation/aws-sdk-v3-client.js
@@ -108,4 +108,4 @@ module.exports.uninstall = (client) => {
   if (uninstall) uninstall();
 };
 
-const serverlessSdk = global.serverlessSdk || require('../');
+const serverlessSdk = require('../');

--- a/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
@@ -23,7 +23,11 @@ const serverlessSdk = (() => {
   // eslint-disable-next-line import/no-unresolved
   return require('@serverless/aws-lambda-sdk');
 })();
-serverlessSdk._initialize();
+try {
+  serverlessSdk._initialize();
+} catch (error) {
+  serverlessSdk._reportSdkError(error);
+}
 const instrument = require('../instrument');
 
 // 2. Initialize original handler

--- a/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
@@ -13,7 +13,7 @@ delete EvalError.$serverlessHandlerModuleInstruction;
 const path = require('path');
 
 // 1. Initialize SDK instrumentation
-(() => {
+const serverlessSdk = (() => {
   try {
     require.resolve('@serverless/aws-lambda-sdk');
   } catch {
@@ -22,7 +22,8 @@ const path = require('path');
 
   // eslint-disable-next-line import/no-unresolved
   return require('@serverless/aws-lambda-sdk');
-})()._initialize();
+})();
+serverlessSdk._initialize();
 const instrument = require('../instrument');
 
 // 2. Initialize original handler
@@ -84,12 +85,7 @@ const resolveHandlerObject = (resolvedHandlerModule) => {
   try {
     return { handler: instrument(handlerFunction) };
   } catch (error) {
-    process._rawDebug(
-      'Fatal Serverless SDK Error: ' +
-        'Please report at https://github.com/serverless/console/issues: ' +
-        'Async handler setup failed: ',
-      error && (error.stack || error)
-    );
+    serverlessSdk._reportSdkError(error);
     return { handler: handlerFunction };
   }
 };

--- a/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/index.js
@@ -16,7 +16,11 @@ module.exports.install = () => {
     const originalSend = Client.prototype.send;
     const uninstallers = new Set();
     Client.prototype.send = function send(command, optionsOrCb, cb) {
-      uninstallers.add(instrumentV3Client(this));
+      try {
+        uninstallers.add(instrumentV3Client(this));
+      } catch (error) {
+        serverlessSdk._reportSdkError(error);
+      }
       return originalSend.call(this, command, optionsOrCb, cb);
     };
     const uninstall = () => {
@@ -34,3 +38,5 @@ module.exports.uninstall = () => {
   cjsHook.unregister('/aws-sdk/lib/core.js');
   cjsHook.unregister('/@aws-sdk/smithy-client/dist-cjs/client.js');
 };
+
+const serverlessSdk = require('../../../');

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.2",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk": "^0.4.1",
+    "@serverless/sdk": "^0.4.3",
     "@serverless/sdk-schema": "^0.14.5",
     "d": "^1.0.1",
     "ext": "^1.7.0",

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -136,6 +136,7 @@ describe('internal-extension/index.test.js', () => {
     process.env.LAMBDA_RUNTIME_DIR = path.resolve(fixturesDirname, 'runtime');
     process.env.SLS_ORG_ID = 'dummy';
     process.env.SLS_UNIT_TEST_RUN = '1';
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
   });
   afterEach(() => {
     delete process.env._HANDLER;

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -55,7 +55,6 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
     const serverlessSdk = require('../../../');
     const { TracePayload } = require('@serverless/sdk-schema/dist/trace');
     const { RequestResponse } = require('@serverless/sdk-schema/dist/request_response');
-    delete global.serverlessSdk;
     return {
       result,
       error,

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -135,6 +135,7 @@ describe('internal-extension/index.test.js', () => {
     process.env.LAMBDA_TASK_ROOT = path.resolve(fixturesDirname, 'lambdas');
     process.env.LAMBDA_RUNTIME_DIR = path.resolve(fixturesDirname, 'runtime');
     process.env.SLS_ORG_ID = 'dummy';
+    process.env.SLS_UNIT_TEST_RUN = '1';
   });
   afterEach(() => {
     delete process.env._HANDLER;

--- a/node/test/lib/get-process-function.js
+++ b/node/test/lib/get-process-function.js
@@ -31,6 +31,7 @@ module.exports = async (basename, coreConfig, options) => {
         Variables: {
           SLS_ORG_ID: process.env.SLS_ORG_ID,
           SLS_SDK_DEBUG: '1',
+          SLS_CRASH_ON_SDK_ERROR: '1',
         },
       },
       Timeout: 15,


### PR DESCRIPTION
Follow up to #431 

- Reconfigure error logs that inform about crashes to rely on internal `_reportSdkError` util
- Wrap certain instrumentation parts of AWS SDK to prevent crashing
- Wrap SDK initialization to prevent crashing
- Ensure that SDK crashes are exposed as crashes in test runs
- Clear left over references to `global.serverlessSdk`
- Ensure to not register uncaught errors listeners in offline unit test run