### PR TITLE
fix: Fixed traceId on generated responses

### DIFF
--- a/node/test/go/dev-mode/test/fixtures/lambdas/timeout-with-internal.js
+++ b/node/test/go/dev-mode/test/fixtures/lambdas/timeout-with-internal.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.handler = (event, context, callback) => {
+  // The callback should never get called
+  setTimeout(() => {
+    callback(null, 'ok');
+  }, 10 * 1000);
+};


### PR DESCRIPTION
## Description
If the function timed out (or really errored in some other unhandled way) the final generated response event would not have the correct traceId attached 🤦‍♂️ 