### PR TITLE
SDK: Improve structured error logs handling

### DIFF
--- a/node/packages/sdk/lib/create-error-captured-event.js
+++ b/node/packages/sdk/lib/create-error-captured-event.js
@@ -23,10 +23,10 @@ module.exports = (error, options = {}) => {
     tags.name = error.name;
     tags.message = error.message;
   } else {
-    tags.name = resolveNonErrorName(error);
+    tags.name = options._name || resolveNonErrorName(error);
     tags.message = typeof error === 'string' ? error : util.inspect(error);
   }
-  tags.stacktrace = resolveStackTraceString(error);
+  tags.stacktrace = options._stack || resolveStackTraceString(error);
   capturedEvent.tags.setMany(tags, { prefix: 'error' });
 
   return capturedEvent;

--- a/node/packages/sdk/lib/instrumentation/node-console.js
+++ b/node/packages/sdk/lib/instrumentation/node-console.js
@@ -33,10 +33,19 @@ module.exports.install = () => {
   nodeConsole.error = function (...args) {
     original.error.apply(this, args);
     try {
-      createErrorCapturedEvent(
-        args.length === 1 && isError(args[0]) ? args[0] : resolveMessage(args),
-        { _origin: 'nodeConsole' }
-      );
+      const input = args[0];
+      if (args.length === 1 && isPlainObject(input) && input.source === 'serverlessSdk') {
+        createErrorCapturedEvent(input.message, {
+          _name: input.name,
+          _stack: input.stack,
+          _origin: 'nodeConsole',
+        });
+      } else {
+        createErrorCapturedEvent(
+          args.length === 1 && isError(input) ? input : resolveMessage(args),
+          { _origin: 'nodeConsole' }
+        );
+      }
     } catch (error) {
       reportSdkError(error);
     }

--- a/node/packages/sdk/lib/report-sdk-error.js
+++ b/node/packages/sdk/lib/report-sdk-error.js
@@ -27,6 +27,6 @@ module.exports = (error, options = {}) => {
   errorData.name = name;
   errorData.message = message;
   if (error.code) errorData.code = error.code;
-  if (error.stack) errorData.stakTrace = resolveStackTraceString(error);
+  if (error.stack) errorData.stack = resolveStackTraceString(error);
   console.error(errorData);
 };

--- a/node/packages/sdk/lib/report-sdk-error.js
+++ b/node/packages/sdk/lib/report-sdk-error.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const isError = require('type/error/is');
 const resolveNonErrorName = require('./resolve-non-error-name');
+const resolveStackTraceString = require('./resolve-stack-trace-string');
 
 module.exports = (error, options = {}) => {
   if (process.env.SLS_CRASH_ON_SDK_ERROR) throw error;
@@ -26,6 +27,6 @@ module.exports = (error, options = {}) => {
   errorData.name = name;
   errorData.message = message;
   if (error.code) errorData.code = error.code;
-  if (error.stack) errorData.stakTrace = error.stack;
+  if (error.stack) errorData.stakTrace = resolveStackTraceString(error);
   console.error(errorData);
 };

--- a/node/packages/sdk/lib/report-sdk-error.js
+++ b/node/packages/sdk/lib/report-sdk-error.js
@@ -16,17 +16,16 @@ module.exports = (error, options = {}) => {
     message = typeof error === 'string' ? error : util.inspect(error);
   }
   const type = options.type || 'INTERNAL';
-  console.error({
-    source: 'serverlessSdk',
-    type,
-    description:
-      type === 'INTERNAL'
-        ? 'Internal Serverless SDK Error. ' +
-          'Please report at https://github.com/serverless/console/issue'
-        : undefined,
-    name,
-    message,
-    code: error && error.code,
-    stackTrace: error && error.stack,
-  });
+
+  const errorData = { source: 'serverlessSdk', type };
+  if (type === 'INTERNAL') {
+    errorData.description =
+      'Internal Serverless SDK Error. ' +
+      'Please report at https://github.com/serverless/console/issue';
+  }
+  errorData.name = name;
+  errorData.message = message;
+  if (error.code) errorData.code = error.code;
+  if (error.stack) errorData.stakTrace = error.stack;
+  console.error(errorData);
 };

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
@@ -64,4 +64,26 @@ describe('lib/instrumentation/node-console.js', () => {
     expect(capturedEvent.tags.get('warning.type')).to.equal(2);
     expect(capturedEvent._origin).to.equal('nodeConsole');
   });
+
+  it('should recognize Serverless SDK error', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+    // eslint-disable-next-line no-console
+    console.error({
+      source: 'serverlessSdk',
+      type: 'INTERNAL',
+      description: 'Internal Serverless SDK Error',
+      name: 'Error',
+      message: 'Something failed',
+      code: 'ERROR_CODE',
+      stack: 'at /foo.js:12:1\nat /bar.js:13:1',
+    });
+
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('Something failed');
+    expect(capturedEvent.tags.get('error.type')).to.equal(2);
+    expect(capturedEvent.tags.get('error.name')).to.equal('Error');
+    expect(capturedEvent.tags.get('error.stacktrace')).to.equal('at /foo.js:12:1\nat /bar.js:13:1');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
 });


### PR DESCRIPTION
- Ensure to not report `undefined` properties in structured log, as they're presented in output (not like in JSON case where they're stripped)
- Ensure that captured event created from SDK generated structured error log has log data meaningfully resolved (and does not pack object into `error.message` tag.