### PR TITLE
Schema: Distinguish user and sdk caught errors

### DIFF
--- a/node/packages/sdk-schema/test/unit/event.test.js
+++ b/node/packages/sdk-schema/test/unit/event.test.js
@@ -27,7 +27,7 @@ const expectedEventErrorData = {
       name: 'testError',
       message: 'abc123',
       stacktrace: 'test',
-      type: ErrorType.ERROR_TYPE_CAUGHT,
+      type: ErrorType.ERROR_TYPE_CAUGHT_USER,
     },
     sdk: {
       name: '@serverless/aws-lambda-sdk',

--- a/proto/serverless/instrumentation/tags/v1/error.proto
+++ b/proto/serverless/instrumentation/tags/v1/error.proto
@@ -18,12 +18,23 @@ message ErrorTags {
 
         // An unexpected error that caused the application to fail
         ERROR_TYPE_UNCAUGHT = 1;
-       
-        // An error that was reported via the Serverless SDK.
-        // Error that doesn't explicitly fail the application.
-        // Multiple errors of this type can be reported during a single application run
-        ERROR_TYPE_CAUGHT = 2;
 
+        // An error that was reported by user explictly via the Serverless SDK or console.error call
+        // Error doesn't explicitly fail the application.
+        // Multiple errors of this type can be reported during a single application run
+        ERROR_TYPE_CAUGHT_USER = 2;
+
+        // An error that was reported by the Serverless SDK internally that reports user error
+        // (misuage of the SDK)
+        // Error doesn't explicitly fail the application.
+        // Multiple errors of this type can be reported during a single application run
+        ERROR_TYPE_CAUGHT_SDK_USER = 3;
+
+        // An error that was reported by the Serverless SDK internally that reports
+        // internal SDK error
+        // Error doesn't explicitly fail the application.
+        // Multiple errors of this type can be reported during a single application run
+        ERROR_TYPE_CAUGHT_SDK_INTERNAL = 4;
     }
 
     ErrorType type = 4;


### PR DESCRIPTION
Dictionary needed for error reporting on the SDK side

- `ERROR_TYPE_CAUGHT_USER` - error reported by user via `serverlessSdk.captureError(..)` or `console.error(..)` call
- `ERROR_TYPE_CAUGHT_SDK_USER` - error reported by the SDK that reports SDK misuage by user (e.g. attempt to set an invalid tag)
- `ERROR_TYPE_CAUGHT_SDK_INTERNAL` - error reported by the SDK that reports SDK internal failure which was silenced to not crash user's lambda