### PR TITLE
Schema: Distinguish between user or internal SDK generated warning

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/warning.proto
+++ b/proto/serverless/instrumentation/tags/v1/warning.proto
@@ -17,8 +17,11 @@ message WarningTags {
       // Warning explicitly reported by user
       WARNING_TYPE_USER = 1;
 
-      // Warning reported internally by the SDK
-      WARNING_TYPE_SDK = 2;
+      // Warning reported internally by the SDK that signal potential misusage on user side
+      WARNING_TYPE_SDK_USER = 2;
+
+      // Warning reported internally by the SDK that signal non fatal SDK issue
+      WARNING_TYPE_SDK_INTERNAL = 3;
   }
 
   optional WarningType type = 2;


### PR DESCRIPTION
When inspecting currently configured internal warnings, I've realized that we have both user code-related warnings (e.g. warn on double SDK resolution) and SDK internal warnings (e.g. that dev mode server is not responsive)