### PR TITLE
AWS Lamdba SDK: ESM support related test coverage improvements

### DIFF
--- a/node/lib/run-esbuild.js
+++ b/node/lib/run-esbuild.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const path = require('path');
+const spawn = require('child-process-ext/spawn');
+
+const esbuildFilename = path.resolve(__dirname, '../node_modules/.bin/esbuild');
+
+module.exports = async (...args) => {
+  try {
+    return (await spawn(esbuildFilename, args)).stdoutBuffer;
+  } catch (error) {
+    throw new Error(`ESbuild errored: ${String(error.stdBuffer)}`);
+  }
+};

--- a/node/packages/aws-lambda-sdk/scripts/lib/build.js
+++ b/node/packages/aws-lambda-sdk/scripts/lib/build.js
@@ -4,22 +4,13 @@ const path = require('path');
 const unlink = require('fs2/unlink');
 const AdmZip = require('adm-zip');
 const mkdir = require('fs2/mkdir');
-const spawn = require('child-process-ext/spawn');
+const runEsbuild = require('../../../../lib/run-esbuild');
 
 const rootDir = path.resolve(__dirname, '../../../../');
 const packageDir = path.resolve(rootDir, 'packages/aws-lambda-sdk');
-const esbuildFilename = path.resolve(rootDir, 'node_modules/.bin/esbuild');
 const internalDir = path.resolve(packageDir, 'internal-extension');
 
 const extensionDirname = 'sls-sdk-node';
-
-const runEsbuild = async (...args) => {
-  try {
-    return (await spawn(esbuildFilename, args)).stdoutBuffer;
-  } catch (error) {
-    throw new Error(`ESbuild errored: ${String(error.stdBuffer)}`);
-  }
-};
 
 module.exports = async (distFilename) => {
   const zip = new AdmZip();

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-bundled.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-bundled.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+const serverlessSdk = require('@serverless/aws-lambda-sdk');
+const AWS = require('aws-sdk');
+
+serverlessSdk.instrumentation.awsSdkV2.install(AWS);
+
+const sts = new AWS.STS();
+
+module.exports.handler = async () => {
+  // STS (confirm on tracing of any AWS service)
+  await sts.getCallerIdentity().promise();
+
+  return 'ok';
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3-bundled.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v3-bundled.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+const serverlessSdk = require('@serverless/aws-lambda-sdk');
+const { STS } = require('@aws-sdk/client-sts');
+
+const sts = new STS();
+serverlessSdk.instrumentation.awsSdkV3Client.install(sts);
+
+module.exports.handler = async () => {
+  // STS (confirm on tracing of any AWS service)
+  await sts.getCallerIdentity();
+
+  return 'ok';
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/.eslintrc.cjs
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  parserOptions: { sourceType: 'module' },
+  rules: { 'import/prefer-default-export': 'off' },
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/index.js
@@ -1,0 +1,10 @@
+import AWS from 'aws-sdk';
+
+const sts = new AWS.STS();
+
+export const handler = async () => {
+  // STS (confirm on tracing of any AWS service)
+  await sts.getCallerIdentity().promise();
+
+  return 'ok';
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v2/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/.eslintrc.cjs
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  parserOptions: { sourceType: 'module' },
+  rules: { 'import/prefer-default-export': 'off' },
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/index.js
@@ -1,0 +1,10 @@
+import { STS } from '@aws-sdk/client-sts';
+
+const sts = new STS();
+
+export const handler = async () => {
+  // STS (confirm on tracing of any AWS service)
+  await sts.getCallerIdentity();
+
+  return 'ok';
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-aws-sdk-v3/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/.eslintrc.cjs
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  parserOptions: { sourceType: 'module' },
+  rules: { 'import/prefer-default-export': 'off' },
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/index.js
@@ -1,0 +1,13 @@
+import serverless from 'serverless-http';
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/test', (req, res) => {
+  res.send('"ok"');
+});
+
+app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+export const handler = serverless(app);

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-express/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/.eslintrc.cjs
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  parserOptions: { sourceType: 'module' },
+  rules: { 'import/prefer-default-export': 'off' },
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/index.js
@@ -1,0 +1,40 @@
+import http from 'http';
+import https from 'https';
+
+const TEST_SERVER_PORT = 3177;
+
+const getServer = () =>
+  http
+    .createServer((request, response) => {
+      request.on('data', () => {});
+      request.on('end', () => {
+        response.writeHead(200, {});
+        response.end('"ok"');
+      });
+    })
+    .listen(TEST_SERVER_PORT);
+
+export const handler = (event, context, callback) => {
+  let url = event.url;
+  let server;
+  if (!url) {
+    server = getServer();
+    url = `http://localhost:${TEST_SERVER_PORT}/?foo=bar`;
+  }
+  const request = url.startsWith('https') ? https.request : http.request;
+  request(url, { headers: { someHeader: 'bar' } }, (response) => {
+    let body = '';
+    response.on('data', (data) => {
+      body += data;
+    });
+    response.on('end', () => {
+      if (server) server.close();
+      callback(null, JSON.parse(body));
+    });
+  })
+    .end()
+    .on('error', (error) => {
+      if (server) server.close();
+      callback(error);
+    });
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-http/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/.eslintrc.cjs
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  parserOptions: { sourceType: 'module' },
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/index.js
@@ -1,0 +1,31 @@
+// eslint-disable-next-line import/no-unresolved
+import sdk from '@serverless/aws-lambda-sdk';
+
+let counter = 0;
+
+// eslint-disable-next-line import/prefer-default-export
+export const handler = async () => {
+  const invocationId = ++counter;
+  if (!sdk) throw new Error('SDK not exported');
+
+  sdk._createTraceSpan('user.span').close();
+
+  sdk.captureError(new Error('Captured error'), {
+    tags: { 'user.tag': 'example', 'invocationid': invocationId },
+  });
+
+  console.error('My error:', new Error('Consoled error'));
+
+  sdk.captureWarning('Captured warning', {
+    tags: { 'user.tag': 'example', 'invocationid': invocationId },
+  });
+
+  sdk.setTag('user.tag', `example:${invocationId}`);
+
+  console.warn('Consoled warning', 12, true);
+  return {
+    name: sdk.name,
+    version: sdk.version,
+    rootSpanName: sdk.traceSpans.root.name,
+  };
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/esm-sdk/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/express-bundled.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/express-bundled.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+const serverlessSdk = require('@serverless/aws-lambda-sdk');
+const serverless = require('serverless-http');
+const express = require('express');
+
+const app = express();
+serverlessSdk.instrumentation.expressApp.install(app);
+app.use(express.json());
+
+app.post('/test', (req, res) => {
+  res.send('"ok"');
+});
+
+app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+module.exports.handler = serverless(app);

--- a/node/packages/sdk/docs/instrumentation/express-app.md
+++ b/node/packages/sdk/docs/instrumentation/express-app.md
@@ -12,7 +12,7 @@ import express from 'express';
 
 const app = express();
 
-serverlessSdk.instrumentation.expressApp.install(express);
+serverlessSdk.instrumentation.expressApp.install(app);
 ```
 
 Handling of express route is covered in context of main `express` span. Additionally middleware jobs are recorded as following spans:

--- a/node/test/lib/get-process-function.js
+++ b/node/test/lib/get-process-function.js
@@ -52,7 +52,7 @@ module.exports = async (basename, coreConfig, options) => {
     const resultConfiguration = {
       ...baseLambdaConfiguration,
       ...configuration,
-      ...(deferredConfiguration && deferredConfiguration(testConfig, coreConfig)),
+      ...(deferredConfiguration && (await deferredConfiguration(testConfig, coreConfig))),
     };
     if (process.env.SERVERLESS_PLATFORM_STAGE === 'dev') {
       resultConfiguration.Environment.Variables.SERVERLESS_PLATFORM_STAGE = 'dev';

--- a/node/test/utils/resolve-dir-zip-buffer.js
+++ b/node/test/utils/resolve-dir-zip-buffer.js
@@ -7,13 +7,16 @@ const memoizee = require('memoizee');
 const log = require('log').get('test');
 
 module.exports = memoizee(
-  async (functionRoot) => {
+  async (functionRoot, options = {}) => {
     log.info('Start creating zip buffer %s', functionRoot);
     const lambdaFiles = await readdir(functionRoot, { depth: Infinity, type: { file: true } });
     const zip = new AdmZip();
 
     for (const file of lambdaFiles) {
-      zip.addLocalFile(path.resolve(functionRoot, file), path.dirname(file));
+      zip.addLocalFile(
+        path.resolve(functionRoot, file),
+        path.join(options.dirname || '', path.dirname(file))
+      );
     }
 
     try {


### PR DESCRIPTION
Added test coverage for following cases:
- Ensure that automatic instrumentation works for ESM import of `express`, `aws-sdk` `@aws-sdk/*` and `http`
- Ensure that manual instrumentation of `express` and AWS SDK v2 and v3 works in context of bundles
- Ensure that import of `@serverless/aws-lambda-sdk` works in context of native ESM module - It's supported starting from `nodejs18.x` runtime, as it's where AWS ensured that `NODE_PATH` is supported for ESM imports