### PR TITLE
SDK: Interface for notice reporting and large body stripping

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -55,13 +55,6 @@ const resolveResponseString = (response) => {
       if (response.isBase64Encoded) {
         delete response.body;
         response.isBodyExcluded = true;
-      } else {
-        try {
-          JSON.parse(response.body);
-        } catch {
-          delete response.body;
-          response.isBodyExcluded = true;
-        }
       }
     }
   }

--- a/node/packages/sdk/.ts-types/index.d.ts
+++ b/node/packages/sdk/.ts-types/index.d.ts
@@ -35,7 +35,6 @@ export interface SdkOptions {
   disableRequestResponseMonitoring?: boolean;
   disableExpressMonitoring?: boolean;
   disableNodeConsoleMonitoring?: boolean;
-  traceMaxCapturedBodySizeKb?: number;
 }
 declare const sdk: Sdk;
 export default sdk;

--- a/node/packages/sdk/README.md
+++ b/node/packages/sdk/README.md
@@ -70,10 +70,6 @@ Disable automated express monitoring. See [express app instrumentation](docs/ins
 
 Disable writing captured events registered via `.captureError` and `.captureWarning` to stdout
 
-##### `SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB` (or `options.traceMaxCapturedBodySizeKb`)
-
-In dev mode, HTTP request and response bodies are stored as tags. To avoid performance issues, bodies that extend 10 000KB in size are not exposed. This default can be overridden with this settin
-
 ### Instrumentation
 
 This package comes with instrumentation for following areas.

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -19,6 +19,7 @@ const createErrorCapturedEvent = require('./lib/create-error-captured-event');
 const createWarningCapturedEvent = require('./lib/create-warning-captured-event');
 const reportError = require('./lib/report-error');
 const reportWarning = require('./lib/report-warning');
+const reportNotice = require('./lib/report-notice');
 const pkgJson = require('./package');
 
 const serverlessSdk = module.exports;
@@ -117,6 +118,7 @@ serverlessSdk._initialize = (options = {}) => {
 serverlessSdk._createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
 serverlessSdk._reportError = reportError;
 serverlessSdk._reportWarning = reportWarning;
+serverlessSdk._reportNotice = reportNotice;
 serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
 serverlessSdk._debugLog = (...args) => {
   if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -9,7 +9,6 @@ if (uniGlobal.serverlessSdk) {
 
 uniGlobal.serverlessSdk = module.exports;
 
-const coerceToNaturalNumber = require('type/natural-number/coerce');
 const ensureString = require('type/string/ensure');
 const d = require('d');
 const lazy = require('d/lazy');
@@ -87,10 +86,6 @@ serverlessSdk._initialize = (options = {}) => {
   serverlessSdk._settings.disableNodeConsoleMonitoring = Boolean(
     process.env.SLS_DISABLE_NODE_CONSOLE_MONITORING || options.disableNodeConsoleMonitoring
   );
-  serverlessSdk._settings.traceMaxCapturedBodySizeKb =
-    coerceToNaturalNumber(process.env.SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB) ||
-    coerceToNaturalNumber(options.traceMaxCapturedBodySizeKb) ||
-    10000;
   serverlessSdk._settings.disableCapturedEventsStdout = Boolean(
     process.env.SLS_DISABLE_CAPTURED_EVENTS_STDOUT || options.disableCapturedEventsStdout
   );
@@ -123,6 +118,7 @@ serverlessSdk._isDebugMode = Boolean(process.env.SLS_SDK_DEBUG);
 serverlessSdk._debugLog = (...args) => {
   if (serverlessSdk._isDebugMode) process._rawDebug('⚡ SDK:', ...args);
 };
+serverlessSdk._maximumBodyByteLength = 1024 * 127; // 127 KB
 
 serverlessSdk._eventEmitter = require('./lib/emitter');
 

--- a/node/packages/sdk/lib/captured-event.js
+++ b/node/packages/sdk/lib/captured-event.js
@@ -52,7 +52,7 @@ class CapturedEvent {
       reportError(error, { type: 'USER' });
     }
     if (options._origin) this._origin = options._origin;
-    this.traceSpan = TraceSpan.resolveCurrentSpan();
+    this.traceSpan = options._traceSpan || TraceSpan.resolveCurrentSpan();
     emitter.emit('captured-event', this);
   }
   toJSON() {

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -54,7 +54,12 @@ const install = (protocol, httpModule) => {
         if (isCapturing) {
           if (typeof chunk === 'string') {
             body += chunk;
-            if (Buffer.byteLength(body) > bodySizeLimit) abortCapture();
+            if (Buffer.byteLength(body) > bodySizeLimit) {
+              serverlessSdk._reportNotice('Large body excluded', 'INPUT_BODY_TOO_LARGE', {
+                _traceSpan: traceSpan,
+              });
+              abortCapture();
+            }
           } else {
             abortCapture();
           }
@@ -69,7 +74,12 @@ const install = (protocol, httpModule) => {
         if (isCapturing) {
           if (typeof chunk === 'string') {
             body += chunk;
-            if (Buffer.byteLength(body) > bodySizeLimit) abortCapture();
+            if (Buffer.byteLength(body) > bodySizeLimit) {
+              serverlessSdk._reportNotice('Large body excluded', 'INPUT_BODY_TOO_LARGE', {
+                _traceSpan: traceSpan,
+              });
+              abortCapture();
+            }
           } else if (chunk) {
             abortCapture();
           }
@@ -99,7 +109,12 @@ const install = (protocol, httpModule) => {
               bodyBuffer,
               typeof chunk === 'string' ? Buffer.from(chunk) : chunk,
             ]);
-            if (bodyBuffer.length > bodySizeLimit) bodyBuffer = null;
+            if (bodyBuffer.length > bodySizeLimit) {
+              serverlessSdk._reportNotice('Large body excluded', 'OUTPUT_BODY_TOO_LARGE', {
+                _traceSpan: traceSpan,
+              });
+              bodyBuffer = null;
+            }
           } catch (error) {
             reportError(error);
           }

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -34,7 +34,7 @@ const resolveQueryParamNamesFromSearchString = (searchString) => {
 };
 
 const install = (protocol, httpModule) => {
-  const bodySizeLimit = serverlessSdk._settings.traceMaxCapturedBodySizeKb * 1000;
+  const bodySizeLimit = serverlessSdk._maximumBodyByteLength;
   const shouldMonitorRequestResponse =
     serverlessSdk._isDevMode && !serverlessSdk._settings.disableRequestResponseMonitoring;
 

--- a/node/packages/sdk/lib/report-notice.js
+++ b/node/packages/sdk/lib/report-notice.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const CapturedEvent = require('./captured-event');
+
+module.exports = (message, code, options = {}) => {
+  const timestamp = process.hrtime.bigint();
+
+  return new CapturedEvent('telemetry.notice.generated.v1', {
+    timestamp,
+    customFingerprint: code,
+    tags: {
+      'notice.message': message,
+      'notice.type': 1,
+    },
+    _traceSpan: options._traceSpan,
+  });
+};

--- a/node/packages/sdk/test/unit/lib/report-notice.test.js
+++ b/node/packages/sdk/test/unit/lib/report-notice.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const requireUncached = require('ncjsm/require-uncached');
+
+describe('lib/report-notice.test.js', () => {
+  let serverlessSdk;
+  let reportNotice;
+  before(() => {
+    requireUncached(() => {
+      serverlessSdk = require('../../..');
+      reportNotice = require('../../../lib/report-notice');
+    });
+  });
+  after(() => {
+    delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
+  });
+
+  it('should report captured event for internal notice', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+    // eslint-disable-next-line no-console
+    reportNotice('Something occured', 'NOTICE_CODE');
+
+    expect(capturedEvent.name).to.equal('telemetry.notice.generated.v1');
+    expect(capturedEvent.tags.get('notice.message')).to.equal('Something occured');
+    expect(capturedEvent.tags.get('notice.type')).to.equal(1);
+    expect(capturedEvent.customFingerprint).to.equal('NOTICE_CODE');
+  });
+});


### PR DESCRIPTION
- Internal `_reportNotice` interface
- Remove `traceCaptureBodySizeKb` in favor of internal hard coded `_maximumBodyByteLength` (this setting should not be open for customization as it may introduce payloads too large to process
- Do not strip non JSON bodies (limit stripping just to binary and too large payloads)
- Report notice on large HTTP request and response bodies