### PR TITLE
AWS Lamda SDK: Upgrade input/output body stripping

### DIFF
--- a/node/packages/aws-lambda-sdk/README.md
+++ b/node/packages/aws-lambda-sdk/README.md
@@ -28,10 +28,6 @@ Disable automated AWS SDK monitoring
 
 Disable automated express monitoring
 
-##### `SLS_TRACE_MAX_CAPTURED_BODY_SIZE_KB` (or `options.traceMaxCapturedBodySizeKb`)
-
-In dev mode, HTTP request and response bodies are stored as tags. To avoid performance issues, bodies that extend 10 000KB in size are not exposed. This default can be overridden with this settin
-
 ### Instrumentation
 
 AWS Lambda SDK automatically creates `aws.lambda`, `aws.lambda.initialization` and `aws.lambda.invocation` trace spans.

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -54,7 +54,9 @@ const resolveResponseString = (response) => {
       response = { ...response };
       if (response.isBase64Encoded) {
         delete response.body;
-        response.isBodyExcluded = true;
+        serverlessSdk._reportNotice('Binary body excluded', 'OUTPUT_BODY_BINARY', {
+          _traceSpan: awsLambdaSpan,
+        });
       }
     }
   }

--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -146,7 +146,11 @@ const closeTrace = async (outcome, outcomeResult) => {
       resolveResponseTags(outcomeResult);
     }
 
-    if (!serverlessSdk._settings.disableRequestResponseMonitoring && !isErrorOutcome) {
+    if (
+      serverlessSdk._isDevMode &&
+      !serverlessSdk._settings.disableRequestResponseMonitoring &&
+      !isErrorOutcome
+    ) {
       serverlessSdk._deferredTelemetryRequests.push(
         reportResponse(outcomeResult, invocationContextAccessor.value, endTime)
       );
@@ -222,7 +226,7 @@ module.exports = (originalHandler, options = {}) => {
         startTime: requestStartTime,
       });
       resolveEventTags(event);
-      if (!serverlessSdk._settings.disableRequestResponseMonitoring) {
+      if (serverlessSdk._isDevMode && !serverlessSdk._settings.disableRequestResponseMonitoring) {
         serverlessSdk._deferredTelemetryRequests.push(reportRequest(event, context));
       }
 

--- a/node/packages/aws-lambda-sdk/package.json
+++ b/node/packages/aws-lambda-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.5",
   "author": "Serverless, Inc.",
   "dependencies": {
-    "@serverless/sdk": "^0.5.0",
+    "@serverless/sdk": "^0.5.1",
     "@serverless/sdk-schema": "^0.15.0",
     "d": "^1.0.1",
     "ext": "^1.7.0",

--- a/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/unit/internal-extension/index.test.js
@@ -114,7 +114,7 @@ const handleInvocation = async (handlerModuleName, options = {}) => {
   const nonRootSpanIds = new Set(outcome.trace.input.spans.slice(1).map(({ id }) => String(id)));
   for (const otherSpan of otherSpans) expect(nonRootSpanIds.has(String(otherSpan.id))).to.be.true;
 
-  if (outcome.isDevMode) {
+  if (outcome.isDevMode && !options.isBodyAltered) {
     expect(normalizeObject(outcome.request.output)).to.deep.equal(
       normalizeObject(outcome.request.input)
     );
@@ -1025,6 +1025,55 @@ describe('internal-extension/index.test.js', () => {
         ],
         traceEvents: [],
       });
+    });
+
+    it('should strip bodies', async () => {
+      const payload = {
+        version: '2.0',
+        routeKey: 'POST /v2',
+        rawPath: '/v2',
+        rawQueryString: 'lone=value&multi=one,stillone&multi=two',
+        headers: {
+          'content-length': '385',
+          'content-type':
+            'multipart/form-data; boundary=--------------------------419073009317249310175915',
+          'multi': 'one,stillone,two',
+        },
+        queryStringParameters: {
+          lone: 'value',
+          multi: 'one,stillone,two',
+        },
+        requestContext: {
+          accountId: '205994128558',
+          apiId: 'xxx',
+          domainName: 'xxx.execute-api.us-east-1.amazonaws.com',
+          domainPrefix: 'xx',
+          http: {
+            method: 'POST',
+            path: '/v2',
+            protocol: 'HTTP/1.1',
+            sourceIp: '80.55.87.22',
+            userAgent: 'PostmanRuntime/7.29.0',
+          },
+          requestId: 'XyGnwhe0oAMEJJw=',
+          routeKey: 'POST /v2',
+          stage: '$default',
+          time: '01/Sep/2022:13:46:51 +0000',
+          timeEpoch: 1662040011065,
+        },
+        body: 'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJMb25lIg0KDQpvbmUNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS00MTkwNzMwMDkzMTcyNDkzMTAxNzU5MTUNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0ibXVsdGkiDQoNCm9uZSxzdGlsbG9uZQ0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJtdWx0aSINCg0KdHdvDQotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tNDE5MDczMDA5MzE3MjQ5MzEwMTc1OTE1LS0NCg==',
+        isBase64Encoded: true,
+      };
+
+      const { request } = await handleInvocation('api-endpoint', {
+        isApiEndpoint: true,
+        isBodyAltered: true,
+        payload,
+      });
+
+      const strippedPayload = { ...payload };
+      delete strippedPayload.body;
+      expect(JSON.parse(request.input.body)).to.deep.equal(strippedPayload);
     });
   });
 });


### PR DESCRIPTION
- Ensure not to resolve request/response payload when it's not meant to send
- Strip binary lambda request
- Strip binary lambda large requests and responses
- Strip AWS SDK large requests and responses
- Notify with notice events body stripping