### PR TITLE
feat: Add Validation Root Comment

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -10,6 +10,7 @@ import "serverless/instrumentation/tags/v1/notice.proto";
 
 option go_package = ".;protoc";
 
+// @validation_root
 message Tags {
   reserved 108;
   reserved "sls_tags";


### PR DESCRIPTION
This comment string is used internally to create validation rules for our schema. 