### PR TITLE
Fix publish SDK CI workflows

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -14,7 +14,6 @@ jobs:
     name: "[Linux] Python 3.7: Unit Tests"
     runs-on: ubuntu-latest
     outputs:
-      pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
       pathChangedSdk: ${{ steps.pathChanges.outputs.sdk}}
       pathChangedSdkSchema: ${{ steps.pathChanges.outputs.sdkSchema}}
       pathChangedProto: ${{ steps.pathChanges.outputs.proto }}
@@ -36,8 +35,6 @@ jobs:
         id: pathChanges
         with:
           filters: |
-            awsLambdaSdk:
-              - 'python/packages/aws-lambda-sdk/**'
             sdk:
               - 'python/packages/sdk/**'
             sdkSchema:
@@ -102,20 +99,6 @@ jobs:
           python3 -m pip install poethepoet pytest
           python3 -m poethepoet test
 
-      - name: Install AWS Lambda SDK project and dependencies
-        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
-        run: |
-          cd python/packages/aws-lambda-sdk
-
-          python3 -m pip install --editable .
-
-      - name: Unit tests /aws-lambda-sdk
-        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
-        run: |
-          cd python/packages/aws-lambda-sdk
-          python3 -m pip install pytest
-          python3 -m pytest
-
   integratePythonSdk:
     name: Integrate Python SDK
     runs-on: ubuntu-latest
@@ -139,32 +122,6 @@ jobs:
           if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
           then
             git tag python/serverless_sdk@$NEW_VERSION
-            git push --tags
-          fi
-
-  integrateAwsLambdaSdk:
-    name: Integrate Python AWS Lambda SDK
-    runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedAwsLambdaSdk == 'true'
-    timeout-minutes: 5 # Default is 360
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          # Ensure to have complete history of commits pushed with given push operation
-          # It's loose and imperfect assumption that no more than 30 commits will be pushed at once
-          fetch-depth: 30
-          # Tag needs to be pushed with real user token, otherwise pushed tag won't trigger the actions workflow
-          # Hence we're passing 'serverless-ci' user authentication token
-          token: ${{ secrets.USER_GITHUB_TOKEN }}
-
-      - name: Tag if new version
-        run: |
-          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/aws-lambda-sdk/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
-          if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
-          then
-            git tag python/serverless_aws_lambda_sdk@$NEW_VERSION
             git push --tags
           fi
 

--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -14,7 +14,9 @@ jobs:
     name: "[Linux] Python 3.7: Unit Tests"
     runs-on: ubuntu-latest
     outputs:
+      pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
       pathChangedSdk: ${{ steps.pathChanges.outputs.sdk}}
+      pathChangedSdkSchema: ${{ steps.pathChanges.outputs.sdkSchema}}
       pathChangedProto: ${{ steps.pathChanges.outputs.proto }}
     steps:
       - name: Checkout repository
@@ -34,6 +36,8 @@ jobs:
         id: pathChanges
         with:
           filters: |
+            awsLambdaSdk:
+              - 'python/packages/aws-lambda-sdk/**'
             sdk:
               - 'python/packages/sdk/**'
             sdkSchema:
@@ -70,10 +74,13 @@ jobs:
       - name: Buf Setup
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         uses: bufbuild/buf-setup-action@v1
+      - name: Buf Lint
+        if: steps.pathChanges.outputs.proto == 'true'
+        uses: bufbuild/buf-lint-action@v1
         with:
-          github_token: ${{ github.token }}
-
+          input: "proto"
       - name: Build Protobufs
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd ./proto
           python3 -m pip install "betterproto[compiler]"
@@ -95,6 +102,19 @@ jobs:
           python3 -m pip install poethepoet pytest
           python3 -m poethepoet test
 
+      - name: Install AWS Lambda SDK project and dependencies
+        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
+        run: |
+          cd python/packages/aws-lambda-sdk
+
+          python3 -m pip install --editable .
+
+      - name: Unit tests /aws-lambda-sdk
+        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
+        run: |
+          cd python/packages/aws-lambda-sdk
+          python3 -m pip install pytest
+          python3 -m pytest
 
   integratePythonSdk:
     name: Integrate Python SDK
@@ -115,10 +135,36 @@ jobs:
 
       - name: Tag if new version
         run: |
-          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk/pyproject.toml | grep 'version = ' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
           then
             git tag python/serverless_sdk@$NEW_VERSION
+            git push --tags
+          fi
+
+  integrateAwsLambdaSdk:
+    name: Integrate Python AWS Lambda SDK
+    runs-on: ubuntu-latest
+    needs: [ linuxPython37 ]
+    if: needs.linuxPython37.outputs.pathChangedAwsLambdaSdk == 'true'
+    timeout-minutes: 5 # Default is 360
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Ensure to have complete history of commits pushed with given push operation
+          # It's loose and imperfect assumption that no more than 30 commits will be pushed at once
+          fetch-depth: 30
+          # Tag needs to be pushed with real user token, otherwise pushed tag won't trigger the actions workflow
+          # Hence we're passing 'serverless-ci' user authentication token
+          token: ${{ secrets.USER_GITHUB_TOKEN }}
+
+      - name: Tag if new version
+        run: |
+          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/aws-lambda-sdk/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
+          then
+            git tag python/serverless_aws_lambda_sdk@$NEW_VERSION
             git push --tags
           fi
 
@@ -141,7 +187,7 @@ jobs:
 
       - name: Tag if new version
         run: |
-          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk-schema/pyproject.toml | grep 'version = ' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk-schema/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
           then
             git tag python/serverless_sdk_schema@$NEW_VERSION

--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -84,7 +84,7 @@ jobs:
           buf generate --template=buf.gen.python.yaml 
 
       - name: Install SDK Schema
-        if: steps.pathChanges.outputs.sdkSchema == 'true'
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
 
@@ -92,7 +92,7 @@ jobs:
           python3 -m poethepoet install
 
       - name: Run SDK Schema unit tests
-        if: steps.pathChanges.outputs.sdkSchema == 'true'
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
 

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -10,6 +10,9 @@ jobs:
     name: Publish new version
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python-sdk-schema-publish.yaml
+++ b/.github/workflows/python-sdk-schema-publish.yaml
@@ -1,28 +1,19 @@
-name: "Python: Publish python/serverless_aws_schema_sdk"
+name: "Python: Publish python/serverless_sdk_schema"
 
 on:
   push:
     tags:
-      - "python/serverless_aws_schema_sdk@[0-9]+.[0-9]+.[0-9]+"
+      - "python/serverless_sdk_schema@[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publishNewSdkVersion:
     name: Publish new version
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Install Python and Pip
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
-
-          # ensure project dependencies are cached
-          # When using only `pyproject.toml` for dependencies, see:
-          #  https://github.com/actions/setup-python/issues/529#issuecomment-1367029699
-          cache: 'pip'
-          cache-dependency-path: |
-            **/pyproject.toml
-
-      - name: Install Python 3.7
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
@@ -37,7 +28,6 @@ jobs:
       - name: Install main project dependencies
         run: |
           cd python/packages/sdk-schema
-
           python3 -m pip install .
 
       - name: Buf Setup
@@ -55,7 +45,7 @@ jobs:
           buf build
           buf generate --template=buf.gen.python.yaml 
 
-          cd ./python/packages/sdk-schema
+          cd ../python/packages/sdk-schema
           python3 -m pip install --upgrade build twine wheel poethepoet
           python3 -m build --wheel --sdist .
           twine upload dist/*.tar.gz dist/*.whl

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -8,8 +8,8 @@ on:
       - proto/**
 
 jobs:
-  linuxPython37:
-    name: "[Linux] Python 3.7: Lint, Formatting & Unit Tests"
+  linuxPython39:
+    name: "[Linux] Python 3.9: Lint, Formatting & Unit Tests"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,15 +33,17 @@ jobs:
               - 'python/packages/sdk/**'
             sdkSchema:
               - 'python/packages/sdk-schema/**'
+            awsLambdaSdk:
+              - 'python/packages/aws-lambda-sdk/**'
             proto:
               - 'proto/**'
             packages:
               - 'python/packages/**'
 
-      - name: Install Python 3.7
+      - name: Install Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:
@@ -129,3 +131,16 @@ jobs:
 
           python3 -m pip install poethepoet pytest
           python3 -m poethepoet test
+
+      - name: Install AWS Lambda SDK project and dependencies
+        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
+        run: |
+          cd python/packages/aws-lambda-sdk
+          python3 -m pip install .
+
+      - name: Run AWS Lambda SDK unit tests
+        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
+        run: |
+          cd python/packages/aws-lambda-sdk
+          python3 -m pip install pytest strenum
+          python3 -m pytest

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -33,8 +33,6 @@ jobs:
               - 'python/packages/sdk/**'
             sdkSchema:
               - 'python/packages/sdk-schema/**'
-            awsLambdaSdk:
-              - 'python/packages/aws-lambda-sdk/**'
             proto:
               - 'proto/**'
             packages:
@@ -131,16 +129,3 @@ jobs:
 
           python3 -m pip install poethepoet pytest
           python3 -m poethepoet test
-
-      - name: Install AWS Lambda SDK project and dependencies
-        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
-        run: |
-          cd python/packages/aws-lambda-sdk
-          python3 -m pip install .
-
-      - name: Run AWS Lambda SDK unit tests
-        if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
-        run: |
-          cd python/packages/aws-lambda-sdk
-          python3 -m pip install pytest strenum
-          python3 -m pytest

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pytest
 
       - name: Install SDK Schema
-        if: steps.pathChanges.outputs.sdkSchema == 'true'
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
 
@@ -123,7 +123,7 @@ jobs:
           buf generate --template=buf.gen.python.yaml 
 
       - name: Run SDK Schema unit tests
-        if: steps.pathChanges.outputs.sdkSchema == 'true'
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
 


### PR DESCRIPTION
### Description
Related issue https://linear.app/serverless/issue/SC-260/aws-lambda-sdk-setup-package-with-a-handler-wrapper
This PR addresses the suggestion https://github.com/serverless/console/pull/464#discussion_r1113056600

* Make sure CI detects changes in sdk-schema when releasing these packages.
* Make sure only the last version of package is processed (this was causing errors if there were more than two versions since last publish, which ideally should not happen but happened to me while testing, so being defensive just in case)
* Checkout the repo when publishing sdk
* Fix naming: serverless_sdk_schema
* Remove redundant python installation step
* Use python 3.9 for the validate workflow (I'll update other flows in subsequent PRs to use 3.9 instead of the soon to be "end of support" 3.7)

### Testing done
Tested by imitating these flows on my GitHub account using different package names.