### PR TITLE
(SC-372) SDK: Document and publish v0.1.0

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.1.0 (2023-02-22)
+
+### Features
+
+- Initial version ([3687baa](https://github.com/serverless/console/commit/3687baac1f5c2f48518eebb0a400801d8f4ec54a))

--- a/python/packages/sdk/README.md
+++ b/python/packages/sdk/README.md
@@ -1,0 +1,54 @@
+# serverless-sdk
+
+## [Serverless Console](https://www.serverless.com/console) SDK for Python
+
+### Use case
+
+Environment agnostic [Serverless Console](https://www.serverless.com/console) instrumentation functions for Python applications.
+
+This library is safe to use without side-effects in any Python application. It becomes effective once (one of the listed below) environment specific SDK is loaded on top.
+
+#### Environment extensions
+
+- **AWS Lambda** - [serverless-aws-lambda-sdk](https://github.com/serverless/console/tree/main/python/packages/aws-lambda-sdk#readme)
+
+### Installation
+
+```shell
+pip install serverless-sdk
+```
+
+### Usage
+
+```python
+from serverless_sdk import serverlessSdk
+print(serverlessSdk.name)
+```
+
+### Setup
+
+#### 1. Register with [Serverless Console](https://console.serverless.com/)
+
+#### 2. Initialize and setup SDK specific to your enviroment
+
+See [Environment extensions](#environment-extensions)
+
+##### 2.1 Configuration options
+
+_Common options supported by all environments:_
+
+###### `SLS_ORG_ID` (or `options.orgId`)
+
+Required setting. Id of your organization in Serverless Console.
+
+### Instrumentation
+
+This package comes with instrumentation for following areas.
+
+_Note: instrumentation is enabled via environment specific SDK instance, relying just on `serverless-sdk` doesn't enable any instrumentation)_
+
+- N/A
+
+### API
+
+- [serverlessSdk](docs/sdk.md)

--- a/python/packages/sdk/docs/sdk.md
+++ b/python/packages/sdk/docs/sdk.md
@@ -1,0 +1,15 @@
+# Serverless SDK
+
+## Properties and methods of the `serverlessSdk`
+
+### `.name`
+
+Name of the used SDK package. By default `serverless-sdk`, but if environment extension is used, it's overriden (to e.g. `serverless-aws-lambda-sdk`)
+
+### `.version`
+
+Package version
+
+### `.org_id`
+
+Authenticated Serverless Console organization id

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless_sdk"
-version = "0.0.0"
+version = "0.1.0"
 description = "Serverless SDK for Python"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
### Description
Related issue https://linear.app/serverless/issue/SC-372/sdk-document-and-publish-v010
* Add manually created changelog for the initial 0.1.0 version
* Bump serverless-sdk version to 0.1.0
* Add docs for python serverless-sdk package.

Note that the base sdk is missing some features, for instance `.instrumentation` is just a placeholder. As such I haven't completed those parts of the API in documentation.

### Testing done
N/A