### PR TITLE
Fix pyproject.toml formatter

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -121,7 +121,7 @@ jobs:
           NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
           then
-            git tag python/serverless_sdk@$NEW_VERSION
+            git tag python/serverless-sdk@$NEW_VERSION
             git push --tags
           fi
 
@@ -147,6 +147,6 @@ jobs:
           NEW_VERSION=`git diff -U0 ${{ github.event.before }} python/packages/sdk-schema/pyproject.toml | grep 'version = ' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$NEW_VERSION" ] && [ $NEW_VERSION != "0.0.0" ];
           then
-            git tag python/serverless_sdk_schema@$NEW_VERSION
+            git tag python/serverless-sdk-schema@$NEW_VERSION
             git push --tags
           fi

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -1,9 +1,9 @@
-name: "Python: Publish python/serverless_sdk"
+name: "Python: Publish python/serverless-sdk"
 
 on:
   push:
     tags:
-      - "python/serverless_sdk@[0-9]+.[0-9]+.[0-9]+"
+      - "python/serverless-sdk@[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publishNewSdkVersion:

--- a/.github/workflows/python-sdk-schema-publish.yaml
+++ b/.github/workflows/python-sdk-schema-publish.yaml
@@ -1,9 +1,9 @@
-name: "Python: Publish python/serverless_sdk_schema"
+name: "Python: Publish python/serverless-sdk-schema"
 
 on:
   push:
     tags:
-      - "python/serverless_sdk_schema@[0-9]+.[0-9]+.[0-9]+"
+      - "python/serverless-sdk-schema@[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publishNewSdkVersion:

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd python/packages
           
-          python3 -m pip install pyproject-fmt
+          python3 -m pip install pyproject-fmt==0.4.1
           
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd python/packages
           
-          python3 -m pip install pyproject-fmt==0.4.1
+          python3 -m pip install pyproject-fmt
           
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 ]
 
 [project]
-name = "serverless_sdk_schema"
+name = "serverless-sdk-schema"
 version = "0.0.0"
 description = "The protobuf generated Serverless SDK Schema"
 authors = [{ name = "serverlessinc" }]
@@ -29,10 +29,8 @@ tests = [
     "ruff>=0.0.199",
 ]
 
-
 [tool.ruff]
 ignore = ["F401"]
-
 
 [tool.poe.tasks]
 build = "bash ./scripts/build.sh"

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
     "black>=22.12",
-    "pyproject-fmt>=0.4.1",
     "pytest>=7.2",
     "ruff>=0.0.199",
 ]

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 ]
 
 [project]
-name = "serverless_sdk"
+name = "serverless-sdk"
 version = "0.0.0"
 description = "Serverless SDK for Python"
 authors = [{ name = "serverlessinc" }]
@@ -25,7 +25,6 @@ tests = [
     "pytest>=7.2",
     "ruff>=0.0.199",
 ]
-
 
 [tool.ruff]
 ignore = ["F401"]


### PR DESCRIPTION
### Description
Currently linting step in the CI fails as in https://github.com/serverless/console/actions/runs/4240504929/jobs/7369594955#step:8:53

The problem is that new versions of `pyproject-fmt` is normalizing the package names and rewrites "serverless_sdk" as "serverless-sdk" and returns an error code:

```
 [project]
-name = "serverless_sdk"
+name = "serverless-sdk"
```

I've did a quick search to see if there's a better linter for pyproject.toml files but couldn't find one. Removing this linter step is another possible resolution. I've also removed the dependency for `pyproject-fmt` from the package as it's only required for the CI step, which installs the specific version of the package.

This fix is in https://github.com/serverless/console/pull/464 as well, I'll update that PR once we agree on a resolution.

### Testing done
I've tried `pyproject-fmt==0.4.1` and this version accepts underscores as in `serverless_sdk`.