### PR TITLE
Fix python integrate flow

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -20,15 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 30
-
-      - name: Retrieve last main commit (for `git diff` purposes)
-        run: |
-          git checkout -b pr
-          git fetch --prune --depth=30 origin +refs/heads/main:refs/remotes/origin/main
-          git checkout main
-          git checkout pr
 
       - name: Resolve path filters
         uses: dorny/paths-filter@v2


### PR DESCRIPTION
### Description
Related issue https://github.com/serverless/console/pull/467#issuecomment-1439810314

The integrate flow runs in the context of the main branch, it does not need a step to checkout another branch which was causing no diffs and the flow ending prematurely.

### Testing done
I've pushed the changes on my forked repo and verified the path changes are picked up

![Screenshot 2023-02-22 at 14 14 58](https://user-images.githubusercontent.com/7043904/220604563-6b43ed74-ef4a-4e86-bcd7-731fcc4169a7.png)
