### PR TITLE
(SC-374) SDK Schema: Document and publish v0.1.0

### DIFF
--- a/python/packages/sdk-schema/CHANGELOG.md
+++ b/python/packages/sdk-schema/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.1.0 (2023-02-22)
+
+- Initial Release of Schema ([c359118](https://github.com/serverless/console/commit/c3591187e854af1bad6fcac28d612e73c4daecc0))

--- a/python/packages/sdk-schema/README.md
+++ b/python/packages/sdk-schema/README.md
@@ -1,0 +1,3 @@
+# Serverless SDK Schema
+
+This is the auto generated Python package from the Serverless Protobufs. Serverless uses Protobufs as the required format for all instrumentation libraries that communicate with the Serverless Platform.

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 
 [project]
 name = "serverless-sdk-schema"
-version = "0.0.0"
+version = "0.1.0"
 description = "The protobuf generated Serverless SDK Schema"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
### Description
**Note**: Might be a good idea to merge this after https://github.com/serverless/console/pull/469 to see the CI pipeline in action.

* Related issue https://linear.app/serverless/issue/SC-374/sdk-schema-document-and-publish-v010
* Add manually created changelog for the initial 0.1.0 version
* Bump serverless-sdk-schema version to 0.1.0
* Add docs for python serverless-sdk package.

### Testing done
N/A
