### PR TITLE
Add metadata for pypi publication

### DIFF
--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -13,6 +13,7 @@ requires = [
 name = "serverless-sdk-schema"
 version = "0.1.0"
 description = "The protobuf generated Serverless SDK Schema"
+readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
@@ -28,6 +29,11 @@ tests = [
     "pytest>=7.2",
     "ruff>=0.0.199",
 ]
+[project.urls]
+changelog = "https://github.com/serverless/console/blob/main/python/packages/sdk-schema/CHANGELOG.md"
+documentation = "https://github.com/serverless/console#readme"
+homepage = "https://www.serverless.com/console"
+repository = "https://github.com/serverless/console"
 
 [tool.ruff]
 ignore = ["F401"]

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -31,7 +31,7 @@ tests = [
 ]
 [project.urls]
 changelog = "https://github.com/serverless/console/blob/main/python/packages/sdk-schema/CHANGELOG.md"
-documentation = "https://github.com/serverless/console#readme"
+documentation = "https://github.com/serverless/console/tree/main/python/packages/sdk-schema"
 homepage = "https://www.serverless.com/console"
 repository = "https://github.com/serverless/console"
 

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -28,7 +28,7 @@ tests = [
 ]
 [project.urls]
 changelog = "https://github.com/serverless/console/blob/main/python/packages/sdk/CHANGELOG.md"
-documentation = "https://github.com/serverless/console#readme"
+documentation = "https://github.com/serverless/console/tree/main/python/packages/sdk"
 homepage = "https://www.serverless.com/console"
 repository = "https://github.com/serverless/console"
 

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
 name = "serverless-sdk"
 version = "0.1.1"
 description = "Serverless SDK for Python"
+readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
@@ -25,6 +26,11 @@ tests = [
     "pytest>=7.2",
     "ruff>=0.0.199",
 ]
+[project.urls]
+changelog = "https://github.com/serverless/console/blob/main/python/packages/sdk/CHANGELOG.md"
+documentation = "https://github.com/serverless/console#readme"
+homepage = "https://www.serverless.com/console"
+repository = "https://github.com/serverless/console"
 
 [tool.ruff]
 ignore = ["F401"]


### PR DESCRIPTION
### Description
The SDK packages on pypi do not display description and metadata currently https://pypi.org/project/serverless-sdk/#description

This fixes it by locating the readme file and also adding project urls like homepage.

### Testing done
Tried running `python3 -m build --wheel --sdist .` and the resulting egg-info/PKG-INFO lacked such metadata. With these changes it now includes these metadata:

```
Metadata-Version: 2.1
Name: serverless-sdk
Version: 0.1.1
Summary: Serverless SDK for Python
Author: serverlessinc
Project-URL: homepage, https://www.serverless.com/console
Project-URL: documentation, https://github.com/serverless/console#readme
Project-URL: repository, https://github.com/serverless/console
Project-URL: changelog, https://github.com/serverless/console/blob/main/python/packages/sdk/CHANGELOG.md
Requires-Python: >=3.7
Description-Content-Type: text/markdown
Provides-Extra: tests

... followed by the contents of README.md
```

@medikoo please review if the project-urls are correct, I've pointed homepage to https://www.serverless.com/console and I'm not sure if this is fine.