### PR TITLE
AWS Lambda SDK: Ensure not to capture logs as issued by the AWS runtime

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -9,6 +9,7 @@ const resolveEventTags = require('./lib/resolve-event-tags');
 const resolveResponseTags = require('./lib/resolve-response-tags');
 const sendTelemetry = require('./lib/send-telemetry');
 const flushSpans = require('./lib/auto-send-spans').flush;
+const filterCapturedEvent = require('./lib/filter-captured-event');
 const invocationContextAccessor = require('./lib/invocation-context-accessor');
 const pkgJson = require('../package');
 
@@ -103,7 +104,9 @@ const reportTrace = () => {
       delete spanPayload.output;
       return spanPayload;
     }),
-    events: capturedEvents.map((capturedEvent) => capturedEvent.toProtobufObject()),
+    events: capturedEvents
+      .filter(filterCapturedEvent)
+      .map((capturedEvent) => capturedEvent.toProtobufObject()),
     customTags: objHasOwnProperty.call(serverlessSdk, '_customTags')
       ? JSON.stringify(serverlessSdk._customTags)
       : undefined,

--- a/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/auto-send-spans.js
@@ -15,15 +15,17 @@ if (!serverlessSdk._isDevMode) {
 const traceProto = require('@serverless/sdk-schema/dist/trace');
 const sendTelemetry = require('./send-telemetry');
 const invocationContextAccessor = require('./invocation-context-accessor');
+const filterCapturedEvent = require('./filter-captured-event');
 
 const pendingSpans = [];
-const pendingCapturedEvents = [];
+let pendingCapturedEvents = [];
 let isScheduled = false;
 let timeoutId = null;
 const sendData = () => {
   try {
     isScheduled = false;
     clearTimeout(timeoutId);
+    pendingCapturedEvents = pendingCapturedEvents.filter(filterCapturedEvent);
     if (!pendingSpans.length && !pendingCapturedEvents.length) return;
     const payload = {
       slsTags: {

--- a/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = (capturedEvent) => {
+  // Skip on errors logged via `console.error` in AWS Lambda runtime
+  if (capturedEvent.name !== 'telemetry.error.generated.v1') return true;
+  return !capturedEvent.tags.get('error.stacktrace').split('\n')[0].includes('/var/runtime/');
+};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
@@ -7,5 +7,7 @@ const lambda = new Lambda();
 
 module.exports.handler = async () => {
   await lambda.listFunctions({}, () => {}).promise();
+  // Ensure that second resolution happens in scope of this invocation
+  await new Promise((resolve) => setTimeout(resolve, 100));
   return 'ok';
 };


### PR DESCRIPTION
Reported internally by @eahefnawy 

On function crash AWS runtime logs the error to stdout via `console.error` call, which we instrument. In result we've observed that error is also captured as _user caught_ error, which is not true.

This patch ensures we do not capture `console.*` calls as issued by the runtime.

Additionally improved tests to confirm on whole set of captured events