### PR TITLE
SDK: Let native HTTP interface throw error of invalid listener

### DIFF
--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -164,15 +164,17 @@ const install = (protocol, httpModule) => {
     } else {
       options = Object.assign(url || {}, options);
     }
-    if (shouldIgnoreFollowingRequest || options._slsIgnore) {
+
+    const originalCb = args[cbIndex];
+    if (
+      shouldIgnoreFollowingRequest ||
+      options._slsIgnore ||
+      (originalCb && typeof originalCb !== 'function')
+    ) {
       shouldIgnoreFollowingRequest = false;
       return originalRequest.apply(this, args);
     }
 
-    const originalCb = args[cbIndex];
-    if (originalCb && typeof originalCb !== 'function') {
-      throw new TypeError('The "listener" argument must be of type function');
-    }
     let requestEndTime;
     let responseReadableState;
     args.splice(cbIndex, 1, (response) => {


### PR DESCRIPTION
If a Node.js HTTP request is invoked with a callback that's not a function, the request will fail with ` The "listener" argument must be of type function`. We can confirm that by following the internal Node.js logic:

- https://github.com/nodejs/node/blob/b3663e0262f68740078b90c55b1ffc0f8ac1ac76/lib/_http_client.js#L239-L240
- https://github.com/nodejs/node/blob/b3663e0262f68740078b90c55b1ffc0f8ac1ac76/lib/events.js#L643-L644
- https://github.com/nodejs/node/blob/b3663e0262f68740078b90c55b1ffc0f8ac1ac76/lib/events.js#L269-L270
- https://github.com/nodejs/node/blob/b3663e0262f68740078b90c55b1ffc0f8ac1ac76/lib/internal/validators.js#L419-L421

And while in SDK, we need to wrap the eventual passed-in callback,  we crash with the same error if we find that provided callback is not a function before providing it to a native HTTP request: 
https://github.com/serverless/console/blob/46a033b18b2bd8d2931c782fb99e9c104b855819/node/packages/sdk/lib/instrumentation/http.js#L173-L174

Still, we received the report (cc @garethmcc) stating for some lambda case, just with our SDK integration loaded, `The "listener" argument must be of type function` error surfaces. How it can happen is not clear at this point.

Yet, we can improve things to ensure that it's native HTTP request handling that throws that error and not our SDK, and this patch provides that.

Also, this will fix the scenarios where the HTTP request handler may throw with a different error instead (like https://github.com/nodejs/node/blob/b3663e0262f68740078b90c55b1ffc0f8ac1ac76/lib/_http_client.js#L164-L165), so on that level this change is a bug fix.