### PR TITLE
AWS Lambda SDK: Test against AWS SDK that doesn't issue deprecation error

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/package.json
@@ -9,7 +9,7 @@
     "@aws-sdk/client-sts": "^3.267.0",
     "@aws-sdk/lib-dynamodb": "^3.267.0",
     "@aws-sdk/s3-request-presigner": "^3.267.0",
-    "aws-sdk": "^2.1312.0",
+    "aws-sdk": "2.1313.0",
     "express": "^4.18.2",
     "serverless-http": "^3.1.1"
   }


### PR DESCRIPTION
Addresses CI fail: https://github.com/serverless/console/actions/runs/4263772005

Recent version of AWS SDK v2 started to issue deprecation warning which is logged via `console.error` (more information at https://github.com/serverless/serverless/issues/11753), and that started to issue capture warning events which broke our tests.

This patch ensures we rely on latest AWS SDK v2 version that doesn't print that warning