### PR TITLE
SDK: Ensure full stack traces in debug mode

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/aws-sdk-v2-doubled-resolution.js
@@ -8,6 +8,6 @@ const lambda = new Lambda();
 module.exports.handler = async () => {
   await lambda.listFunctions({}, () => {}).promise();
   // Ensure that second resolution happens in scope of this invocation
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  await new Promise((resolve) => setTimeout(resolve, 200));
   return 'ok';
 };

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -120,6 +120,9 @@ serverlessSdk._debugLog = (...args) => {
 };
 serverlessSdk._maximumBodyByteLength = 1024 * 127; // 127 KB
 
+// Ensure full stack traces in debug mode
+if (serverlessSdk._isDebugMode) Error.stackTraceLimit = Infinity;
+
 serverlessSdk._eventEmitter = require('./lib/emitter');
 
 Object.defineProperties(

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -144,7 +144,11 @@ const install = (protocol, httpModule) => {
 
   const request = function request(...args) {
     const startTime = process.hrtime.bigint();
-    serverlessSdk._debugLog('HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
+    serverlessSdk._debugLog(
+      'HTTP request',
+      shouldIgnoreFollowingRequest,
+      !shouldIgnoreFollowingRequest && new Error().stack
+    );
     let [url, options] = args;
 
     let cbIndex = 2;
@@ -262,7 +266,7 @@ module.exports.install = () => {
 
 module.exports.ignoreFollowingRequest = () => {
   if (!isInstalled) return;
-  serverlessSdk._debugLog('ignore HTTP request', shouldIgnoreFollowingRequest, new Error().stack);
+  serverlessSdk._debugLog('ignore HTTP request', shouldIgnoreFollowingRequest);
   shouldIgnoreFollowingRequest = true;
   process.nextTick(() => {
     serverlessSdk._debugLog('reset ignore HTTP request', shouldIgnoreFollowingRequest);


### PR DESCRIPTION
When inspecting the issue related to the delayed AWS SDK requests, I've approached truncated stack traces in gathered logs, which weren't informative enough. This patch will ensure full stack traces when next case is recorded