### PR TITLE
Initial integration tests for Python AWS Lambda SDK

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -70,6 +70,7 @@
     "standard-version": "^9.5.0",
     "stream-promise": "^3.2.0",
     "timers-ext": "^0.1.7",
+    "toml": "^3.0.0",
     "ts-proto": "^1.140.0",
     "tslib": "^2.5.0",
     "type": "^2.7.2",

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -20,6 +20,8 @@ const runEsbuild = require('../../../../lib/run-esbuild');
 const getProcessFunction = require('../../../../test/lib/get-process-function');
 const resolveTestVariantsConfig = require('../../../../test/lib/resolve-test-variants-config');
 const resolveDirZipBuffer = require('../../../../test/utils/resolve-dir-zip-buffer');
+const resolveOutcomeEnumValue = require('../../../../test/utils/resolve-outcome-enum-value');
+const normalizeEvents = require('../../../../test/utils/normalize-events');
 const resolveFileZipBuffer = require('../utils/resolve-file-zip-buffer');
 const awsRequest = require('../../../../test/utils/aws-request');
 const pkgJson = require('../../package');
@@ -1814,60 +1816,6 @@ describe('integration', function () {
       }));
     }
   });
-
-  const resolveOutcomeEnumValue = (value) => {
-    switch (value) {
-      case 'success':
-        return 1;
-      case 'error:handled':
-        return 5;
-      case 'error:unhandled':
-        return 3;
-      default:
-        throw new Error(`Unexpected outcome value: ${value}`);
-    }
-  };
-  const normalizeEvents = (events) =>
-    events.map(({ eventName: name, tags }) => ({
-      name,
-      type: (() => {
-        switch (name) {
-          case 'telemetry.error.generated.v1':
-            switch (tags.error.type) {
-              case 1:
-                return 'ERROR_TYPE_UNCAUGHT';
-              case 2:
-                return 'ERROR_TYPE_CAUGHT_USER';
-              case 3:
-                return 'ERROR_TYPE_CAUGHT_SDK_USER';
-              case 4:
-                return 'ERROR_TYPE_CAUGHT_SDK_INTERNAL';
-              default:
-                throw new Error(`Unexpected error type: ${tags.error.type}`);
-            }
-          case 'telemetry.warning.generated.v1':
-            switch (tags.warning.type) {
-              case 1:
-                return 'WARNING_TYPE_USER';
-              case 2:
-                return 'WARNING_TYPE_SDK_USER';
-              case 3:
-                return 'WARNING_TYPE_SDK_INTERNAL';
-              default:
-                throw new Error(`Unexpected warning type: ${tags.warning.type}`);
-            }
-          case 'telemetry.notice.generated.v1':
-            switch (tags.warning.type) {
-              case 1:
-                return 'NOTICE_TYPE_SDK_INTERNAL';
-              default:
-                throw new Error(`Unexpected notice type: ${tags.warning.type}`);
-            }
-          default:
-            throw new Error(`Unexpected event name: ${name}`);
-        }
-      })(),
-    }));
 
   for (const testConfig of testVariantsConfig) {
     it(testConfig.name, async () => {

--- a/node/packages/aws-lambda-sdk/test/lib/basename.js
+++ b/node/packages/aws-lambda-sdk/test/lib/basename.js
@@ -2,4 +2,4 @@
 
 const testUid = require('../../../../test/lib/test-uid');
 
-module.exports = `test-sdk-${testUid}`;
+module.exports = `test-node-sdk-${testUid}`;

--- a/node/test/go/dev-mode/test/lib/basename.js
+++ b/node/test/go/dev-mode/test/lib/basename.js
@@ -2,4 +2,4 @@
 
 const testUid = require('../../../../lib/test-uid');
 
-module.exports = `test-sdk-${testUid}`;
+module.exports = `test-dev-mode-${testUid}`;

--- a/node/test/lib/get-process-function.js
+++ b/node/test/lib/get-process-function.js
@@ -208,7 +208,6 @@ module.exports = async (basename, coreConfig, options) => {
       let currentProcessData;
       let startedMessage;
       let startedMessageType;
-      let isExternalExtensionLoaded = false;
       const getCurrentInvocationData = () => {
         if (!currentInvocationData) {
           log.error(
@@ -293,14 +292,7 @@ module.exports = async (basename, coreConfig, options) => {
         }
       };
       for (const { message } of events) {
-        if (message.startsWith('⚡ SDK: External initialization')) {
-          isExternalExtensionLoaded = true;
-          processesData.push(
-            (currentProcessData = { extensionOverheadDurations: {}, internalDurations: {} })
-          );
-          continue;
-        }
-        if (!isExternalExtensionLoaded && message.startsWith('⚡ SDK: Wrapper initialization')) {
+        if (message.startsWith('INIT_START Runtime Version: ')) {
           processesData.push(
             (currentProcessData = { extensionOverheadDurations: {}, internalDurations: {} })
           );

--- a/node/test/python/aws-lambda-sdk/cleanup.js
+++ b/node/test/python/aws-lambda-sdk/cleanup.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('essentials');
+require('log-node')();
+
+require('./lib/cleanup')();

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const fsp = require('fs').promises;
+const path = require('path');
+const log = require('log').get('test');
+const toml = require('toml');
+const { TracePayload } = require('@serverless/sdk-schema/dist/trace');
+const cleanup = require('./lib/cleanup');
+const createCoreResources = require('./lib/create-core-resources');
+const basename = require('./lib/basename');
+const getProcessFunction = require('../../lib/get-process-function');
+const resolveOutcomeEnumValue = require('../../utils/resolve-outcome-enum-value');
+const normalizeEvents = require('../../utils/normalize-events');
+const resolveTestVariantsConfig = require('../../lib/resolve-test-variants-config');
+
+const fixturesDirname = path.resolve(
+  __dirname,
+  '../../../../python/packages/aws-lambda-sdk/tests/fixtures/lambdas'
+);
+
+for (const name of ['TEST_EXTERNAL_LAYER_FILENAME']) {
+  // In tests, current working directory is mocked,
+  // so if relative path is provided in env var it won't be resolved properly
+  // with this patch we resolve it before cwd mocking
+  if (process.env[name]) process.env[name] = path.resolve(process.env[name]);
+}
+
+describe('Python: integration', function () {
+  this.timeout(120000);
+  const coreConfig = {};
+
+  const useCasesConfig = new Map([
+    [
+      'success',
+      {
+        variants: new Map([
+          // TODO: Cover v3.6 and v3.7 once support for those is fixed
+          ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+        ]),
+      },
+    ],
+    [
+      'error',
+      {
+        variants: new Map([
+          // TODO: Cover v3.6 and v3.7 once support for those is fixed
+          ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+        ]),
+        config: { expectedOutcome: 'error:handled' },
+      },
+    ],
+  ]);
+
+  const testVariantsConfig = resolveTestVariantsConfig(useCasesConfig);
+
+  let pyProjectToml;
+
+  before(async () => {
+    pyProjectToml = toml.parse(
+      await fsp.readFile(
+        path.resolve(__dirname, '../../../../python/packages/aws-lambda-sdk/pyproject.toml'),
+        'utf8'
+      )
+    );
+    await createCoreResources(coreConfig);
+
+    const processFunction = await getProcessFunction(basename, coreConfig, {
+      TracePayload,
+      fixturesDirname,
+      baseLambdaConfiguration: {
+        Runtime: 'python3.9',
+        Layers: [coreConfig.layerInternalArn],
+        Environment: {
+          Variables: {
+            AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-python/exec_wrapper.py',
+          },
+        },
+      },
+    });
+    for (const testConfig of testVariantsConfig) {
+      testConfig.deferredResult = processFunction(testConfig).catch((error) => ({
+        // As we process result promises sequentially step by step in next turn, allowing them to
+        // reject will generate unhandled rejection.
+        // Therefore this scenario is converted to successuful { error } resolution
+        error,
+      }));
+    }
+  });
+
+  for (const testConfig of testVariantsConfig) {
+    // eslint-disable-next-line no-loop-func
+    it(testConfig.name, async () => {
+      const testResult = await testConfig.deferredResult;
+      if (testResult.error) throw testResult.error;
+      log.debug('%s test result: %o', testConfig.name, testResult);
+      const { expectedOutcome, capturedEvents } = testConfig;
+      const { invocationsData } = testResult;
+      if (
+        expectedOutcome === 'success' ||
+        expectedOutcome === 'error:handled' ||
+        expectedOutcome === 'error:unhandled'
+      ) {
+        if (
+          expectedOutcome === 'success' &&
+          !testConfig.isAsyncInvocation &&
+          !testConfig.isCustomResponse
+        ) {
+          for (const { responsePayload } of invocationsData) {
+            expect(responsePayload.raw).to.equal('"ok"');
+          }
+        }
+        for (const [index, { trace }] of invocationsData.entries()) {
+          if (!trace) throw new Error('Missing trace payload');
+          const { spans, slsTags, events } = trace;
+          const lambdaSpan = spans[0];
+          if (index === 0 || expectedOutcome === 'error:unhandled') {
+            expect(spans.map(({ name }) => name).slice(0, 3)).to.deep.equal([
+              'aws.lambda',
+              'aws.lambda.initialization',
+              'aws.lambda.invocation',
+            ]);
+            expect(lambdaSpan.tags.aws.lambda.isColdstart).to.be.true;
+            const [, initializationSpan, invocationSpan] = spans;
+            expect(String(initializationSpan.parentSpanId)).to.equal(String(lambdaSpan.id));
+            expect(String(invocationSpan.parentSpanId)).to.equal(String(lambdaSpan.id));
+            expect(lambdaSpan.startTimeUnixNano).to.equal(initializationSpan.startTimeUnixNano);
+            expect(lambdaSpan.endTimeUnixNano).to.equal(invocationSpan.endTimeUnixNano);
+          } else {
+            if (!testConfig.hasOrphanedSpans) {
+              expect(spans.map(({ name }) => name).slice(0, 2)).to.deep.equal([
+                'aws.lambda',
+                'aws.lambda.invocation',
+              ]);
+              const [, invocationSpan] = spans;
+              expect(lambdaSpan.startTimeUnixNano).to.equal(invocationSpan.startTimeUnixNano);
+              expect(lambdaSpan.endTimeUnixNano).to.equal(invocationSpan.endTimeUnixNano);
+            }
+            expect(lambdaSpan.tags.aws.lambda.isColdstart).to.be.false;
+            const [, invocationSpan] = spans;
+            expect(String(invocationSpan.parentSpanId)).to.equal(String(lambdaSpan.id));
+          }
+          for (const span of spans) {
+            if (span.endTimeUnixNano <= span.startTimeUnixNano) {
+              throw new Error(
+                `Span ${span.name} has invalid time range: ${span.startTimeUnixNano} - ${span.endTimeUnixNano}`
+              );
+            }
+          }
+          expect(slsTags).to.deep.equal({
+            orgId: process.env.SLS_ORG_ID,
+            service: testConfig.configuration.FunctionName,
+            sdk: { name: pyProjectToml.project.name, version: pyProjectToml.project.version },
+          });
+          expect(lambdaSpan.tags.aws.lambda).to.have.property('arch');
+          expect(lambdaSpan.tags.aws.lambda.name).to.equal(testConfig.configuration.FunctionName);
+          expect(lambdaSpan.tags.aws.lambda).to.have.property('requestId');
+          expect(lambdaSpan.tags.aws.lambda).to.have.property('version');
+          expect(lambdaSpan.tags.aws.lambda.outcome).to.equal(
+            resolveOutcomeEnumValue(expectedOutcome)
+          );
+          const normalizedEvents = normalizeEvents(events);
+          if (!capturedEvents) expect(normalizedEvents).deep.equal([]);
+          else expect(normalizedEvents).deep.equal(capturedEvents);
+        }
+      }
+
+      if (testConfig.test) {
+        testConfig.test({ invocationsData, testConfig });
+      }
+    });
+  }
+
+  after(async () => cleanup({ mode: 'core' }));
+});

--- a/node/test/python/aws-lambda-sdk/lib/basename.js
+++ b/node/test/python/aws-lambda-sdk/lib/basename.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const testUid = require('../../../lib/test-uid');
+
+module.exports = `test-python-sdk-${testUid}`;

--- a/node/test/python/aws-lambda-sdk/lib/cleanup.js
+++ b/node/test/python/aws-lambda-sdk/lib/cleanup.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const cleanup = require('../../../lib/cleanup');
+const basename = require('./basename');
+
+module.exports = async (options = {}) => cleanup(basename, options);

--- a/node/test/python/aws-lambda-sdk/lib/create-core-resources.js
+++ b/node/test/python/aws-lambda-sdk/lib/create-core-resources.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const path = require('path');
+const spawn = require('child-process-ext/spawn');
+const createCoreResources = require('../../../lib/create-core-resources');
+
+const buildDummyDevMode = require('../../../../packages/aws-lambda-sdk/test/lib/build-dummy-dev-mode-extension');
+const basename = require('./basename');
+
+const awsLambdaSdkDirname = path.resolve(
+  __dirname,
+  '../../../../../python/packages/aws-lambda-sdk'
+);
+const layerBuildScriptFilename = path.resolve(
+  awsLambdaSdkDirname,
+  'scripts/build-layer-archive.sh'
+);
+
+module.exports = async (config, options = {}) => {
+  const layersConfig = new Map();
+  for (const layerType of options.layerTypes || ['internal']) {
+    switch (layerType) {
+      case 'external':
+        if (process.env.TEST_EXTERNAL_LAYER_FILENAME) {
+          layersConfig.set(layerType, {
+            build: () => path.resolve(process.env.TEST_EXTERNAL_LAYER_FILENAME),
+          });
+        } else {
+          layersConfig.set(layerType, { build: buildDummyDevMode });
+        }
+        break;
+      case 'internal':
+        if (process.env.TEST_INTERNAL_LAYER_FILENAME) {
+          layersConfig.set(layerType, {
+            build: () => path.resolve(process.env.TEST_INTERNAL_LAYER_FILENAME),
+          });
+        } else {
+          layersConfig.set(layerType, {
+            build: async () => {
+              const filename = path.resolve(awsLambdaSdkDirname, 'dist/extension.internal.zip');
+              await spawn(layerBuildScriptFilename, [filename]);
+              return filename;
+            },
+          });
+        }
+        break;
+      default:
+        throw new Error(`Unrecognized layer type: ${layerType}`);
+    }
+  }
+  return createCoreResources(basename, config, { layersConfig });
+};

--- a/node/test/utils/normalize-events.js
+++ b/node/test/utils/normalize-events.js
@@ -1,0 +1,43 @@
+'use strict';
+
+module.exports = (events) =>
+  events.map(({ eventName: name, tags }) => ({
+    name,
+    type: (() => {
+      switch (name) {
+        case 'telemetry.error.generated.v1':
+          switch (tags.error.type) {
+            case 1:
+              return 'ERROR_TYPE_UNCAUGHT';
+            case 2:
+              return 'ERROR_TYPE_CAUGHT_USER';
+            case 3:
+              return 'ERROR_TYPE_CAUGHT_SDK_USER';
+            case 4:
+              return 'ERROR_TYPE_CAUGHT_SDK_INTERNAL';
+            default:
+              throw new Error(`Unexpected error type: ${tags.error.type}`);
+          }
+        case 'telemetry.warning.generated.v1':
+          switch (tags.warning.type) {
+            case 1:
+              return 'WARNING_TYPE_USER';
+            case 2:
+              return 'WARNING_TYPE_SDK_USER';
+            case 3:
+              return 'WARNING_TYPE_SDK_INTERNAL';
+            default:
+              throw new Error(`Unexpected warning type: ${tags.warning.type}`);
+          }
+        case 'telemetry.notice.generated.v1':
+          switch (tags.warning.type) {
+            case 1:
+              return 'NOTICE_TYPE_SDK_INTERNAL';
+            default:
+              throw new Error(`Unexpected notice type: ${tags.warning.type}`);
+          }
+        default:
+          throw new Error(`Unexpected event name: ${name}`);
+      }
+    })(),
+  }));

--- a/node/test/utils/resolve-outcome-enum-value.js
+++ b/node/test/utils/resolve-outcome-enum-value.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (value) => {
+  switch (value) {
+    case 'success':
+      return 1;
+    case 'error:handled':
+      return 5;
+    case 'error:unhandled':
+      return 3;
+    default:
+      throw new Error(`Unexpected outcome value: ${value}`);
+  }
+};


### PR DESCRIPTION
/cc @selcukcihan 

Test basic _success_ and _error_ scenario in all AWS supported Python runtimes.

To have this test run successfully following needs to be ensured:
- Python layer build script (located at `python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh`) needs to be updated to:
  - Generate python lambda layer into `python/packages/aws-lambda-sdk/dist/<filename>` when run with `<filename>` arguments
  - Working directory in which script is run should not affect the path of destination file, may just influence resolution of `<filename>` of which path input may  be relative
- Fixtures for `success` and `error`  cases need to be sunred in `python/packages/aws-lambda-sdk/test/fixtures/lambdas`

Having above covered, it should be possible to have a successful test run (from context of `node` folder) by ensuring `SLS_ORG_ID` (can be anything, e.g. `test`), `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`and `AWS_REGION` environment variables and running:

```shell
npx mocha test/python/aws-lambda-sdk/integration.test.js
```

--- 

Additionally:
- Generalize few test utils
- Improve process start resolution in CW logs processing, which is easier since introduction of `INIT_START Runtime Version:..` log
- Rename test basenames, so all resources as created when  testing _node_, _dev mode_ and _python_ have different basename (rename _node_ basename from `test-sdk` to `test-node-sdk` and _dev mode_ basename from `test-sdk` to `test-dev-mode` - cc @Danwakeem )