### PR TITLE
Fix trace span logic for Python base SDK

### DIFF
--- a/python/packages/sdk/serverless_sdk/sdk/base.py
+++ b/python/packages/sdk/serverless_sdk/sdk/base.py
@@ -40,8 +40,8 @@ class ServerlessSdk:
     def _create_trace_span(
         self,
         name: str,
-        input: str,
-        output: str,
+        input: Optional[str] = None,
+        output: Optional[str] = None,
         start_time: Optional[Nanoseconds] = None,
         tags: Optional[Tags] = None,
     ) -> TraceSpan:


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-356/aws-lambda-sdk-create-lambda-process-trace-spans-with-related-tags
* Fix trace timer by using the high resolution nanosecond timer
* Fix trace span close logic such that the context is updated to the first open ancestor, in case the closing span is the current span.
* Add base sdk to vscode python path so that intellisense works.

### Testing done
I've tested it on the cloud and was able to create traces together with the aws-serverless-sdk (which is wip, PR dedicated to it will be provided separately).