### PR TITLE
Build Lambda SDK from local when packaging layer

### DIFF
--- a/python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh
+++ b/python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh
@@ -13,7 +13,9 @@ SITE_PACKAGES_DIR=python/lib/python3.9/site-packages
 mkdir -p $DIST/{$SITE_PACKAGES_DIR,sls-sdk-python}
 
 INSTALL_DIR=$DIST/$SITE_PACKAGES_DIR
-python3 -m pip install serverless-aws-lambda-sdk --target=$INSTALL_DIR
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+python3 -m pip install $SCRIPT_DIR/.. --target=$INSTALL_DIR
 
 cp $INSTALL_DIR/serverless_aws_lambda_sdk/internal_extension/__init__.py $DIST/sls-sdk-python
 cp $INSTALL_DIR/serverless_aws_lambda_sdk/internal_extension/base.py $DIST/sls-sdk-python


### PR DESCRIPTION
### Description
* Install `aws-lambda-sdk` from local instead of pypi when build script executes
* Determine directory of local source for the package relatively to the script. This implies that we should not copy the script to another directory. It can be executed from any directory though.

### Testing done
I've tested the script as used in https://github.com/serverless/console/pull/483

`/Users/selcukcihan/serverless/console/python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh /Users/selcukcihan/serverless/console/python/packages/aws-lambda-sdk/dist/extension.internal.zip`

Which resulted in `/Users/selcukcihan/serverless/console/python/packages/aws-lambda-sdk/dist/extension.internal.zip`

The build used local version of aws-lambda-sdk for sure, because it's not yet published on pypi.