### PR TITLE
Ensure spans are ordered by creation time

### DIFF
--- a/python/packages/sdk/serverless_sdk/span/trace.py
+++ b/python/packages/sdk/serverless_sdk/span/trace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import logging
 from timeit import default_timer
-from typing import List, Optional, Set
+from typing import List, Optional
 from contextvars import ContextVar
 import json
 from backports.cached_property import cached_property  # available in Python >=3.8
@@ -69,7 +69,7 @@ class TraceSpan:
     input: Optional[str] = None
     output: Optional[str] = None
     tags: Tags
-    sub_spans: Set[Self]
+    sub_spans: List[Self]
 
     def __init__(
         self,
@@ -83,7 +83,7 @@ class TraceSpan:
         self.name = get_resource_name(name)
         self.input = input
         self.output = output
-        self.sub_spans = set()
+        self.sub_spans = []
 
         self._set_start_time(start_time)
         self._set_tags(tags)
@@ -134,7 +134,7 @@ class TraceSpan:
                 self.parent_span = self.parent_span.parent_span or root_span
 
         if self.parent_span:
-            self.parent_span.sub_spans.add(self)
+            self.parent_span.sub_spans.append(self)
 
     def _set_ctx(self, override: Optional[TraceSpan] = None):
         global ctx
@@ -172,8 +172,8 @@ class TraceSpan:
         return parent.trace_id if parent else generate_id()
 
     @property
-    def spans(self) -> Set[TraceSpan]:
-        return set([self] + list(_flatten([s.spans for s in self.sub_spans])))
+    def spans(self) -> List[TraceSpan]:
+        return [self] + list(_flatten([s.spans for s in self.sub_spans]))
 
     @property
     def output(self) -> str:

--- a/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
+++ b/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
@@ -194,13 +194,14 @@ def test_leaf_span():
 def test_spans():
     # given
     span = TraceSpan("child")
-    sub_span = TraceSpan("subchild")
+    sub_span_1 = TraceSpan("subchild1")
     sub_sub_span = TraceSpan("subsubchild").close()
-    sub_span.close()
+    sub_span_1.close()
+    sub_span_2 = TraceSpan("subchild2")
     span.close()
 
     # then
-    assert not set(span.spans) ^ set([span, sub_span, sub_sub_span])
+    assert span.spans == [span, sub_span_1, sub_sub_span, sub_span_2]
 
 
 def test_span_closure():


### PR DESCRIPTION
Related issue  https://github.com/serverless/console/pull/486#pullrequestreview-1324005295

### Description
Python "set" is not guaranteed to be ordered, so spans are now stored in a list that ensures they are sorted by the time of creation.

### Testing done
Enhanced the test case to assert on list equality, which validates order of the list.