### PR TITLE
Python SDK release v0.1.3

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.1.3 (2023-03-07)
+
+### Bug Fixes
+
+- Fix root trace span handling
+- Maintain deterministic ordering of trace spans
+
 ## 0.1.2 (2023-03-03)
 
 ### Bug Fixes

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related https://github.com/serverless/console/pull/486

### Description
This release is needed, to build the AWS Lambda SDK up on in the linked PR above.