### PR TITLE
Use python v3.9 on the CI pipeline

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -10,8 +10,8 @@ on:
       - proto/**
 
 jobs:
-  linuxPython37:
-    name: "[Linux] Python 3.7: Unit Tests"
+  linuxPython39:
+    name: "[Linux] Python 3.9: Unit Tests"
     runs-on: ubuntu-latest
     outputs:
       pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
@@ -36,10 +36,10 @@ jobs:
             proto:
               - 'proto/**'
 
-      - name: Install Python 3.7
+      - name: Install Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:
@@ -110,8 +110,8 @@ jobs:
   integratePythonSdk:
     name: Integrate Python SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedSdk == 'true'
+    needs: [ linuxPython39 ]
+    if: needs.linuxPython39.outputs.pathChangedSdk == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository
@@ -136,8 +136,8 @@ jobs:
   integrateAwsLambdaSdk:
     name: Integrate Python AWS Lambda SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedAwsLambdaSdk == 'true'
+    needs: [ linuxPython39 ]
+    if: needs.linuxPython39.outputs.pathChangedAwsLambdaSdk == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository
@@ -150,10 +150,10 @@ jobs:
           # Hence we're passing 'serverless-ci' user authentication token
           token: ${{ secrets.USER_GITHUB_TOKEN }}
 
-      - name: Install Python 3.7
+      - name: Install Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
           cache: 'pip'
           cache-dependency-path: |
             **/pyproject.toml
@@ -191,8 +191,8 @@ jobs:
   integratePythonSdkSchema:
     name: Integrate Python SDK Schema
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedSdkSchema == 'true'
+    needs: [ linuxPython39 ]
+    if: needs.linuxPython39.outputs.pathChangedSdkSchema == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-sdk-schema-publish.yaml
+++ b/.github/workflows/python-sdk-schema-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:


### PR DESCRIPTION
Related issue https://github.com/serverless/console/pull/486#issuecomment-1458029410

### Description
Upgrade python version from v3.7 to v3.9 in the python package CI workflows.

### Testing done
N/A