### PR TITLE
Add env variables to python integrate flow

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -139,6 +139,11 @@ jobs:
     needs: [ linuxPython39 ]
     if: needs.linuxPython39.outputs.pathChangedAwsLambdaSdk == 'true'
     timeout-minutes: 5 # Default is 360
+    env:
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SLS_ORG_ID: ${{ secrets.SLS_ORG_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Related https://github.com/serverless/console/pull/486#issuecomment-1458136833

### Description
Add env. variables that are required by python AWS Lambda sdk integrate flow.

### Testing done
Tested on my github https://github.com/selcukcihan/console/actions/runs/4354436080/jobs/7609742701