### PR TITLE
Fix publish lambda sdk flow

### DIFF
--- a/.github/workflows/python-publish-aws-lambda-sdk.yml
+++ b/.github/workflows/python-publish-aws-lambda-sdk.yml
@@ -25,31 +25,31 @@ jobs:
           cache-dependency-path: |
             **/pyproject.toml
 
-      - name: Install main project dependencies
-        run: |
-          cd python/packages
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python3 -m pip install ./aws-lambda-sdk --target=dist
-
       - name: Publish New Version on PyPI
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_AUTH_TOKEN }}
         run: |
           cd python/packages
+          python3 -m venv .venv
           source .venv/bin/activate
-          cd ./aws-lambda-sdk
 
           python3 -m pip install --upgrade build twine wheel
-          python3 -m build --wheel --sdist .
+          python3 -m build --wheel --sdist ./aws-lambda-sdk --outdir dist
           twine upload dist/*.tar.gz dist/*.whl
+
+      - name: Install main project dependencies
+        run: |
+          cd python/packages/aws-lambda-sdk
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install . --target=dist
 
       - name: Create lambda layer package
         run: |
-          cd python/packages
+          cd python/packages/aws-lambda-sdk
 
-          ./aws-lambda-sdk/scripts/build-layer-archive.sh aws-lambda-sdk/dist/extension.internal.zip
+          ./scripts/build-layer-archive.sh dist/extension.internal.zip
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1


### PR DESCRIPTION
Fixes the CI workflow issue encountered in https://github.com/serverless/console/actions/runs/4354871821

### Description
Fixes the artifact directories to make sure correct paths are being used.
The flow can be summarized as:
1. Publish package to pypi, this uses python's build module to bundle the SDK code.
2. Install the SDK in a specific directory, which is used by the build-layer-archive script to build the lambda layer zip file
3. Publish the layer on AWS Lambda

### Testing done
I've reproduced the error by following CI steps locally and also verified that these steps run successfully after the fix, again verified locally.