### PR TITLE
Create layers registry if it doesn't exist yet

### DIFF
--- a/node/lib/publish-public-layers.js
+++ b/node/lib/publish-public-layers.js
@@ -38,7 +38,10 @@ module.exports = async ({ bucketName, layerBasename, version, content, githubTag
             (
               await awsRequest(S3, 'getObject', { Bucket: bucketName, Key: registryName })
             ).Body
-          )
+          ).catch((error) => {
+            if (error.Code === 'AccessDenied') return '{}'; // Registry does not exist yet
+            throw error;
+          })
         );
         _.merge(layersRegistry, newMeta);
         await awsRequest(S3, 'putObject', {


### PR DESCRIPTION
When publishing to Python registry, CI failed as expected registry file to exist already.

This patch improves script so it doesn't assume already existing registry, and creates one if it isn't there yet