### PR TITLE
feat: Support user defined spans in Go SDK

### DIFF
--- a/go/packages/slslambda/trace.go
+++ b/go/packages/slslambda/trace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	tagsv1 "go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/tags/v1"
 	instrumentationv1 "go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
@@ -25,8 +26,8 @@ const (
 
 var version = "undefined"
 
-func (w wrapper) printTrace(span *rootSpan) error {
-	payload, err := convert(span, w.tags, w.environment)
+func (w wrapper) printTrace(spanCtx *spanContext) error {
+	payload, err := convert(spanCtx, w.tags, w.environment)
 	if err != nil {
 		return fmt.Errorf("convert: %w", err)
 	}


### PR DESCRIPTION
To support tracing our clickhouse benchmarks, we need a way to create spans for each segment of the performance test. This PR introduces the ability to create spans through the Go SDK to meet that goal.