### PR TITLE
Fix span timing

### DIFF
--- a/python/packages/sdk/serverless_sdk/lib/timing.py
+++ b/python/packages/sdk/serverless_sdk/lib/timing.py
@@ -1,0 +1,12 @@
+import time
+from typing import Optional
+
+
+_DIFF = time.time_ns() - time.perf_counter_ns()
+
+
+def to_protobuf_epoch_timestamp(relative_time: Optional[int]) -> Optional[int]:
+    if relative_time is not None:
+        return _DIFF + relative_time
+    else:
+        return None

--- a/python/packages/sdk/serverless_sdk/span/trace.py
+++ b/python/packages/sdk/serverless_sdk/span/trace.py
@@ -4,7 +4,6 @@ import logging
 import time
 from typing import List, Optional
 from contextvars import ContextVar
-import json
 from backports.cached_property import cached_property  # available in Python >=3.8
 from typing_extensions import Final, Self
 from ..lib.timing import to_protobuf_epoch_timestamp
@@ -106,7 +105,7 @@ class TraceSpan:
             self.tags.update(tags)
 
     def _set_start_time(self, start_time: Optional[Nanoseconds]):
-        default_start = time.time_ns()
+        default_start = time.perf_counter_ns()
 
         if start_time is not None and not isinstance(start_time, Nanoseconds):
             raise InvalidType("`start_time` must be an integer.")
@@ -147,7 +146,7 @@ class TraceSpan:
 
     def close(self, end_time: Optional[Nanoseconds] = None):
         global root_span, ctx
-        default: Nanoseconds = time.time_ns()
+        default: Nanoseconds = time.perf_counter_ns()
         target_end_time = end_time
 
         if self.end_time is not None:

--- a/python/packages/sdk/serverless_sdk/tests/test_timing.py
+++ b/python/packages/sdk/serverless_sdk/tests/test_timing.py
@@ -1,0 +1,30 @@
+from serverless_sdk.lib.timing import to_protobuf_epoch_timestamp
+import time
+
+
+def test_protobuf_epoch_timestamp_conversion():
+    # given
+    start = time.time_ns()
+    time.sleep(0.5)
+
+    point_in_time = time.perf_counter_ns()
+
+    # when
+    time.sleep(0.5)
+    end = time.time_ns()
+
+    point_in_time = to_protobuf_epoch_timestamp(point_in_time)
+
+    # then
+    assert point_in_time > start and point_in_time < end
+
+
+def test_protobuf_epoch_timestamp_none():
+    # given
+    point_in_time = None
+
+    # when
+    point_in_time = to_protobuf_epoch_timestamp(point_in_time)
+
+    # then
+    assert point_in_time is None

--- a/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
+++ b/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
@@ -45,7 +45,7 @@ def test_sub_span(root_span: TraceSpan):
 
 def test_span_init_start_time():
     # given
-    start_time = time.time_ns()
+    start_time = time.perf_counter_ns()
 
     # when
     span = TraceSpan("child", start_time=start_time).close()
@@ -68,7 +68,7 @@ def test_span_init_tags():
 def test_span_init_end_time():
     # given
     span = TraceSpan("child")
-    end_time = time.time_ns()
+    end_time = time.perf_counter_ns()
 
     # when
     span.close(end_time=end_time)
@@ -210,7 +210,7 @@ def test_root_span_reuse():
     del serverless_sdk.span.trace.root_span.end_time
 
     # when
-    span.start_time = time.time_ns()
+    span.start_time = time.perf_counter_ns()
     TraceSpan("otherchild").close()
     serverless_sdk.span.trace.root_span.close()
 

--- a/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
+++ b/python/packages/sdk/serverless_sdk/tests/test_trace_span.py
@@ -1,11 +1,7 @@
 import pytest
-from timeit import default_timer
-import json
+import time
+from serverless_sdk.lib.timing import to_protobuf_epoch_timestamp
 from serverless_sdk.span.trace import TraceSpan
-
-
-def timer():
-    return int(default_timer() * 1000000000)
 
 
 # root span that lives throughout the test session
@@ -49,7 +45,7 @@ def test_sub_span(root_span: TraceSpan):
 
 def test_span_init_start_time():
     # given
-    start_time = timer()
+    start_time = time.time_ns()
 
     # when
     span = TraceSpan("child", start_time=start_time).close()
@@ -72,7 +68,7 @@ def test_span_init_tags():
 def test_span_init_end_time():
     # given
     span = TraceSpan("child")
-    end_time = timer()
+    end_time = time.time_ns()
 
     # when
     span.close(end_time=end_time)
@@ -92,28 +88,6 @@ def test_span_init_input():
     assert span.input == input, "should support `input`"
 
 
-def test_span_stringify_to_json():
-    # given
-    child_span = TraceSpan("child")
-    child_span.tags["foo"] = 12
-    child_span.close()
-
-    # when
-    json_value = json.loads(child_span.toJSON())
-
-    # then
-    assert json_value == {
-        "traceId": child_span.trace_id,
-        "id": child_span.id,
-        "name": child_span.name,
-        "startTime": child_span.start_time,
-        "endTime": child_span.end_time,
-        "input": child_span.input,
-        "output": child_span.output,
-        "tags": child_span.tags,
-    }, "should stringify to JSON"
-
-
 def test_span_protobuf():
     # given
     child_span = TraceSpan("child")
@@ -130,16 +104,16 @@ def test_span_protobuf():
     child_span.close()
 
     # when
-    proto_json = child_span.to_protobuf_dict()
+    proto_dict = child_span.to_protobuf_dict()
 
     # then
-    assert proto_json == {
+    assert proto_dict == {
         "traceId": child_span.trace_id,
         "parentSpanId": child_span.parent_span.id,
         "id": child_span.id,
         "name": child_span.name,
-        "startTimeUnixNano": child_span.start_time,
-        "endTimeUnixNano": child_span.end_time,
+        "startTimeUnixNano": to_protobuf_epoch_timestamp(child_span.start_time),
+        "endTimeUnixNano": to_protobuf_epoch_timestamp(child_span.end_time),
         "input": child_span.input,
         "output": child_span.output,
         "tags": {
@@ -236,7 +210,7 @@ def test_root_span_reuse():
     del serverless_sdk.span.trace.root_span.end_time
 
     # when
-    span.start_time = timer()
+    span.start_time = time.time_ns()
     TraceSpan("otherchild").close()
     serverless_sdk.span.trace.root_span.close()
 


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-220#comment-7e344a99

### Description
* Trace span end & start time are stored as nanoseconds but from an arbitrary point in time. This fix will make sure to convert those values to epoch nanoseconds when serializing the protobuf object.
* Unused protobuf JSON method and class representation are removed.

### Testing done
Unit tested