### PR TITLE
Fix logging messages appearing twice

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -9,17 +9,10 @@ from serverless_sdk.span.trace import TraceSpan
 from .base import NAME, __version__
 
 
-def _initialize_logger():
-    logger = logging.getLogger(__name__)
-    logger.addHandler(logging.NullHandler())
+logger = logging.getLogger(__name__)
 
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("⚡ SDK: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    if os.environ.get("SLS_SDK_DEBUG", None):
-        logger.setLevel(logging.DEBUG)
-    return logger
+if os.environ.get("SLS_SDK_DEBUG", None):
+    logger.setLevel(logging.DEBUG)
 
 
 __all__ = [
@@ -54,5 +47,3 @@ class AwsLambdaSdk(ServerlessSdk):
 
 
 serverlessSdk: AwsLambdaSdk = baseSdk
-
-_initialize_logger()

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -15,6 +15,10 @@ import base64
 logger = logging.getLogger(__name__)
 
 
+def debug_log(msg):
+    return logger.debug(f"⚡ SDK: {msg}")
+
+
 __all__: Final[List[str]] = [
     "instrument",
 ]
@@ -105,7 +109,7 @@ class Instrumenter:
 
             self._report_trace()
             self._clear_root_span()
-            logger.debug(
+            debug_log(
                 "Overhead duration: Internal response:"
                 + f"{int((timer() - end_time) / 1000_000)}ms"
             )
@@ -126,7 +130,7 @@ class Instrumenter:
             request_start_time = timer()
             self.current_invocation_id += 1
             try:
-                logger.debug("Invocation: start")
+                debug_log("Invocation: start")
                 if self.current_invocation_id > 1:
                     self.aws_lambda.start_time = request_start_time
 
@@ -137,7 +141,7 @@ class Instrumenter:
                     )
                 )
 
-                logger.debug(
+                debug_log(
                     "Overhead duration: Internal request:"
                     + f"{int((timer() - request_start_time) / 1000_000)}ms"
                 )

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import logging
 from os import environ
 from pathlib import Path
@@ -7,9 +6,7 @@ from typing import Optional, Tuple
 from importlib import import_module
 import sys
 from timeit import default_timer
-
 from strenum import StrEnum
-
 from typing_extensions import Final, Self
 
 
@@ -49,20 +46,14 @@ SLS_SDK_DEBUG: Final[Optional[str]] = environ.get(Env.SLS_SDK_DEBUG)
 DEFAULT_TASK_ROOT: Final[str] = "/var/task"
 
 
-def _configure_logger(debug):
-    # Configures module level logger.
+logger = logging.getLogger(__name__)
 
-    logger = logging.getLogger(__name__)
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("⚡ SDK: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    if debug:
-        logger.setLevel(logging.DEBUG)
-    return logger
+if SLS_SDK_DEBUG:
+    logger.setLevel(logging.DEBUG)
 
 
-_logger = _configure_logger(SLS_SDK_DEBUG)
+def debug_log(msg):
+    return logger.debug(f"⚡ SDK: {msg}")
 
 
 def timer():
@@ -87,14 +78,14 @@ def initialize(handler: Optional[str] = HANDLER):
         handler = handler.replace("/", ".")
 
         if not SLS_ORG_ID:
-            _logger.error(
+            logger.error(
                 "Serverless SDK Warning: "
                 "Cannot instrument function: "
                 'Missing "SLS_ORG_ID" environment variable',
             )
             return
 
-        _logger.debug("Wrapper initialization")
+        debug_log("Wrapper initialization")
 
         task_root = Path(LAMBDA_TASK_ROOT).resolve()
         if not task_root.exists():
@@ -153,9 +144,9 @@ def initialize(handler: Optional[str] = HANDLER):
         end = timer()
         ms = round((end - process_start_time) / NS_IN_MS)
 
-        _logger.debug(f"Overhead duration: Internal initialization: {ms}ms")
+        debug_log(f"Overhead duration: Internal initialization: {ms}ms")
     except Exception:
-        _logger.exception(
+        logger.exception(
             "Fatal Serverless SDK Error: "
             "Please report at https://github.com/serverless/console/issues: "
             "Internal extension setup failed."


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-220#comment-a254c9d9

### TLDR;
* Remove custom log handlers, rely on the root logger configured by AWS Lambda Runtime.

### Description
AWS Lambda sets up logging configuration for the root logger. Previously, we were setting up the SDK level logger configuration by attaching a log handler to format our log messages to begin with the string "⚡ SDK: ". This resulted in logs appearing twice, because it was being logged by our handler as well as the handler attached to the root level logger. AWS configures the root level logger to include additional data in log messages such as a timestamp, request id, log level etc.

It's best practice that libraries do not add log handlers and respect the upstream logging configuration: https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
> It is strongly advised that you do not add any handlers other than [NullHandler](https://docs.python.org/3/library/logging.handlers.html#logging.NullHandler) to your library’s loggers.

In our case, since AWS Lambda runtime is already configuring a handler, there is no point in attaching a `NullHandler` either. Since the root logger has formatting already, it makes the most sense for the SDK to not break that format that is why I've removed the stream handler. There is more information on this matter at https://stackoverflow.com/a/50910770/4281182

### Testing done
Uploaded a custom layer on my AWS account and tested to make sure logs appear once (when SLS_SDK_DEBUG is set):
```
START RequestId: dd3d56e1-ce67-4630-ab1c-d08e4cace4ff Version: $LATEST
[DEBUG]	2023-03-08T09:32:24.670Z	dd3d56e1-ce67-4630-ab1c-d08e4cace4ff	⚡ SDK: Invocation: start
[DEBUG]	2023-03-08T09:32:24.671Z	dd3d56e1-ce67-4630-ab1c-d08e4cace4ff	⚡ SDK: Overhead duration: Internal request:0ms
SERVERLESS_TELEMETRY.T.CkYKEkJCNzE2enN0WlRkTTc5bXBqZhoMdGVzdC1sb2dnaW5nKiIKGXNlcnZlcmxlc3MtYXdzLWxhbWJkYS1zZGsSBTAuMS41GrEBCiA5MGE5ZjRmOWZjYzYxMmQxZGI4M2ZjMzVjYWZlNTdkYxIgMTBlZDczYjkyNzc5NWE3N2JkYWNlYWM1OWE2NWQ3MzQiCmF3cy5sYW1iZGEpPqgsUl4AAAAxWxgyUl4AAAA6TaIGSqIGRwoGeDg2XzY0Qgx0ZXN0LWxvZ2dpbmdKJGRkM2Q1NmUxLWNlNjctNDYzMC1hYjFjLWQwOGU0Y2FjZTRmZloHJExBVEVTVHABGpEBCiBhNGY2MDg2NjIyOWYxMGE1YWQwMjU2NzQ0ZmExODRiYhIgMTBlZDczYjkyNzc5NWE3N2JkYWNlYWM1OWE2NWQ3MzQaIDkwYTlmNGY5ZmNjNjEyZDFkYjgzZmMzNWNhZmU1N2RjIhVhd3MubGFtYmRhLmludm9jYXRpb24pPqgsUl4AAAAxWxgyUl4AAAA6AA==
[DEBUG]	2023-03-08T09:32:24.685Z	dd3d56e1-ce67-4630-ab1c-d08e4cace4ff	⚡ SDK: Overhead duration: Internal response:14ms
END RequestId: dd3d56e1-ce67-4630-ab1c-d08e4cace4ff
REPORT RequestId: dd3d56e1-ce67-4630-ab1c-d08e4cace4ff	Duration: 38.22 ms	Billed Duration: 39 ms	Memory Size: 128 MB	Max Memory Used: 85 MB
```
