### PR TITLE
Code compatibility with Python 3.8+

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -10,8 +10,8 @@ on:
       - proto/**
 
 jobs:
-  linuxPython39:
-    name: "[Linux] Python 3.9: Unit Tests"
+  linuxPython37:
+    name: "[Linux] Python 3.7: Unit Tests"
     runs-on: ubuntu-latest
     outputs:
       pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
@@ -36,10 +36,10 @@ jobs:
             proto:
               - 'proto/**'
 
-      - name: Install Python 3.9
+      - name: Install Python 3.7
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:
@@ -110,8 +110,8 @@ jobs:
   integratePythonSdk:
     name: Integrate Python SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython39 ]
-    if: needs.linuxPython39.outputs.pathChangedSdk == 'true'
+    needs: [ linuxPython37 ]
+    if: needs.linuxPython37.outputs.pathChangedSdk == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository
@@ -136,8 +136,8 @@ jobs:
   integrateAwsLambdaSdk:
     name: Integrate Python AWS Lambda SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython39 ]
-    if: needs.linuxPython39.outputs.pathChangedAwsLambdaSdk == 'true'
+    needs: [ linuxPython37 ]
+    if: needs.linuxPython37.outputs.pathChangedAwsLambdaSdk == 'true'
     timeout-minutes: 5 # Default is 360
     env:
       AWS_REGION: us-east-1
@@ -155,10 +155,10 @@ jobs:
           # Hence we're passing 'serverless-ci' user authentication token
           token: ${{ secrets.USER_GITHUB_TOKEN }}
 
-      - name: Install Python 3.9
+      - name: Install Python 3.7
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
           cache: 'pip'
           cache-dependency-path: |
             **/pyproject.toml
@@ -196,8 +196,8 @@ jobs:
   integratePythonSdkSchema:
     name: Integrate Python SDK Schema
     runs-on: ubuntu-latest
-    needs: [ linuxPython39 ]
-    if: needs.linuxPython39.outputs.pathChangedSdkSchema == 'true'
+    needs: [ linuxPython37 ]
+    if: needs.linuxPython37.outputs.pathChangedSdkSchema == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -10,9 +10,12 @@ on:
       - proto/**
 
 jobs:
-  linuxPython37:
-    name: "[Linux] Python 3.7: Unit Tests"
+  validate:
+    name: "[Linux] Python 3: Unit Tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.7", "3.8", "3.9"]
     outputs:
       pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
       pathChangedSdk: ${{ steps.pathChanges.outputs.sdk}}
@@ -36,10 +39,10 @@ jobs:
             proto:
               - 'proto/**'
 
-      - name: Install Python 3.7
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python_version }}
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:
@@ -110,8 +113,8 @@ jobs:
   integratePythonSdk:
     name: Integrate Python SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedSdk == 'true'
+    needs: [ validate ]
+    if: needs.validate.outputs.pathChangedSdk == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository
@@ -136,8 +139,8 @@ jobs:
   integrateAwsLambdaSdk:
     name: Integrate Python AWS Lambda SDK
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedAwsLambdaSdk == 'true'
+    needs: [ validate ]
+    if: needs.validate.outputs.pathChangedAwsLambdaSdk == 'true'
     timeout-minutes: 5 # Default is 360
     env:
       AWS_REGION: us-east-1
@@ -196,8 +199,8 @@ jobs:
   integratePythonSdkSchema:
     name: Integrate Python SDK Schema
     runs-on: ubuntu-latest
-    needs: [ linuxPython37 ]
-    if: needs.linuxPython37.outputs.pathChangedSdkSchema == 'true'
+    needs: [ validate ]
+    if: needs.validate.outputs.pathChangedSdkSchema == 'true'
     timeout-minutes: 5 # Default is 360
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-publish-aws-lambda-sdk.yml
+++ b/.github/workflows/python-publish-aws-lambda-sdk.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.7"
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-sdk-schema-publish.yaml
+++ b/.github/workflows/python-sdk-schema-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -8,8 +8,8 @@ on:
       - proto/**
 
 jobs:
-  linuxPython39:
-    name: "[Linux] Python 3.9: Lint, Formatting & Unit Tests"
+  linuxPython37:
+    name: "[Linux] Python 3.7: Lint, Formatting & Unit Tests"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -40,10 +40,10 @@ jobs:
             packages:
               - 'python/packages/**'
 
-      - name: Install Python 3.9
+      - name: Install Python 3.7
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -8,9 +8,12 @@ on:
       - proto/**
 
 jobs:
-  linuxPython37:
-    name: "[Linux] Python 3.7: Lint, Formatting & Unit Tests"
+  validate:
+    name: "[Linux] Python 3: Lint, Formatting & Unit Tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -40,10 +43,10 @@ jobs:
             packages:
               - 'python/packages/**'
 
-      - name: Install Python 3.7
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python_version }}
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -37,7 +37,6 @@ describe('Python: integration', function () {
       'success',
       {
         variants: new Map([
-          // TODO: Cover v3.7 once support for it is fixed
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
         ]),
@@ -47,7 +46,6 @@ describe('Python: integration', function () {
       'error',
       {
         variants: new Map([
-          // TODO: Cover v3.7 once support for it is fixed
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
         ]),

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -36,7 +36,8 @@ describe('Python: integration', function () {
       'success',
       {
         variants: new Map([
-          // TODO: Cover v3.6 and v3.7 once support for those is fixed
+          // TODO: Cover v3.7 once support for it is fixed
+          ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
         ]),
       },
@@ -45,7 +46,8 @@ describe('Python: integration', function () {
       'error',
       {
         variants: new Map([
-          // TODO: Cover v3.6 and v3.7 once support for those is fixed
+          // TODO: Cover v3.7 once support for it is fixed
+          ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
         ]),
         config: { expectedOutcome: 'error:handled' },

--- a/python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh
+++ b/python/packages/aws-lambda-sdk/scripts/build-layer-archive.sh
@@ -9,7 +9,7 @@ case $1 in
   *) OUTPUT=$CURRENT_DIR/$1 ;;
 esac
 
-SITE_PACKAGES_DIR=python/lib/python3.9/site-packages
+SITE_PACKAGES_DIR=python
 mkdir -p $DIST/{$SITE_PACKAGES_DIR,sls-sdk-python}
 
 

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
@@ -122,7 +122,7 @@ def initialize(handler: Optional[str] = HANDLER):
         )  # absolute path of the directory containing the module
 
         # Add the SDK installation folder to sys.path
-        sys.path.append("/opt/python/lib/python3.9/site-packages")
+        sys.path.append("/opt/python")
 
         # Try to import the client's handler module and check the handler
         # function if it is a callable. To do that, add the client's handler

--- a/python/packages/aws-lambda-sdk/tests/README.md
+++ b/python/packages/aws-lambda-sdk/tests/README.md
@@ -6,7 +6,7 @@ Unit tests are configured to be independent of any external infrastructure (AWS 
 
 ```bash
 cd python/packages/aws-lambda-sdk
-python3.9 -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 
 python3 -m pip install --editable .

--- a/python/packages/aws-lambda-sdk/tests/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/test_instrument.py
@@ -60,10 +60,8 @@ def test_instrument_adds_lambda_trace_spans(instrumenter, reset_sdk):
     # when
     with patch("builtins.print") as mocked_print:
         instrumented({}, context)
-        serialized = (
-            mocked_print.call_args_list[0]
-            .args[0]
-            .replace("SERVERLESS_TELEMETRY.T.", "")
+        serialized = mocked_print.call_args_list[0][0][0].replace(
+            "SERVERLESS_TELEMETRY.T.", ""
         )
 
     # then
@@ -111,15 +109,11 @@ def test_instrument_subsequent_calls(instrumenter):
     with patch("builtins.print") as mocked_print:
         instrumented({}, context)
         instrumented({}, context)
-        first = (
-            mocked_print.call_args_list[0]
-            .args[0]
-            .replace("SERVERLESS_TELEMETRY.T.", "")
+        first = mocked_print.call_args_list[0][0][0].replace(
+            "SERVERLESS_TELEMETRY.T.", ""
         )
-        second = (
-            mocked_print.call_args_list[1]
-            .args[0]
-            .replace("SERVERLESS_TELEMETRY.T.", "")
+        second = mocked_print.call_args_list[1][0][0].replace(
+            "SERVERLESS_TELEMETRY.T.", ""
         )
 
     # then


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-560/ensure-support-for-python-37-and-38

### Description
1. Make sure the code is compatible with Python v3.7 by running the unit tests in v3.7 environment. Turns out the only problem is with a unit test mock setup and it's fixed now.
2. Paths should not use specific python version, instead the extension is installed in `/opt/python`
3. CI flows are updated to use v3.7
4. v3.8 is added to the Integration tests.

### Testing done
1. Unit tested
2. Integration tested:
```
(.venv) ➜  node git:(python37-compatibility) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js             
2023-03-08T12:37:06.701Z ℹ test test uid: cdab


  Python: integration
2023-03-08T12:37:06.812Z ℹ test Creating core resources test-python-sdk-cdab
2023-03-08T12:37:36.492Z ℹ test Process function success-v3-8
2023-03-08T12:37:36.492Z ℹ test Process function success-v3-9
2023-03-08T12:37:36.493Z ℹ test Process function error-v3-8
2023-03-08T12:37:36.493Z ℹ test Process function error-v3-9
2023-03-08T12:37:36.751Z ℹ test Function success-v3-8 already exists, deleting and re-creating
    ✔ success-v3-8 (22946ms)
    ✔ success-v3-9 (2422ms)
    ✔ error-v3-8
    ✔ error-v3-9
2023-03-08T12:38:01.871Z ℹ test Cleanup test-python-sdk-cdab
2023-03-08T12:38:02.200Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab from test-python-sdk-cdab
2023-03-08T12:38:02.228Z ℹ test Deleted 18 version of the layer test-python-sdk-cdab-internal
2023-03-08T12:38:02.383Z ℹ test Deleted IAM role test-python-sdk-cdab
2023-03-08T12:38:02.442Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab


  4 passing (56s)
```
3. Manual testing on my AWS account just to make sure.

### Out of Scope
Unfortunately, this setup does not work with AWS Lambda Python3.7 runtime. It seems this particular runtime does not care about `AWS_LAMBDA_EXEC_WRAPPER` and thus it won't ever run the exec-wrapper script. Docs around AWS_LAMBDA_EXEC_WRAPPER always mention Python3.8 and this is in agreement with my findings.

For the case of codeguru, they instruct that the customer sets their handler to a function bundled in the layer:
> Change the Lambda handler function to codeguru_profiler_agent.aws_lambda.lambda_handler.call_handler.

So, we still need to figure out how to auto instrument Python3.7 runtime.

**Docs:**
1. https://d1.awsstatic.com/events/reinvent/2020/Observability_logging_and_more_with_AWS_Lambda_extensions_SVS317.pdf
2. https://docs.aws.amazon.com/codeguru/latest/profiler-ug/python-lambda-layers.html