### PR TITLE
feat(Go SDK): Support user defined spans in Go SDK

### DIFF
--- a/go/packages/slslambda/basicspan.go
+++ b/go/packages/slslambda/basicspan.go
@@ -1,0 +1,120 @@
+package slslambda
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/aws"
+	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/tags/v1"
+	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
+	"sync"
+	"time"
+)
+
+type basicSpan struct {
+	name       string
+	start      time.Time
+	end        time.Time
+	children   []span
+	customTags map[string]string
+	errors     []errorEvent
+	warnings   []warningEvent
+
+	// Mutex is needed because the consumer may add data to the span from multiple goroutines.
+	sync.Mutex
+}
+
+func (s *basicSpan) Span() *basicSpan {
+	return s
+}
+
+func newSpan(name string) *basicSpan {
+	return &basicSpan{name: name, start: time.Now(), customTags: map[string]string{}}
+}
+
+func newSpanWithStartTime(name string, start time.Time) *basicSpan {
+	return &basicSpan{name: name, start: start, customTags: map[string]string{}}
+}
+
+func (s *basicSpan) Close() {
+	s.Lock()
+	defer s.Unlock()
+	if s.end.IsZero() {
+		s.end = time.Now()
+		for _, child := range s.children {
+			child.Close()
+		}
+	}
+}
+
+func (s *basicSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID string, tags tags) *instrumentationv1.Span {
+	return &instrumentationv1.Span{
+		Id:                spanID,
+		TraceId:           traceID,
+		ParentSpanId:      parentSpanID,
+		Name:              s.name,
+		StartTimeUnixNano: uint64(s.start.UnixNano()),
+		EndTimeUnixNano:   uint64(s.end.UnixNano()),
+		CustomTags:        convertCustomTags(s.customTags),
+		Tags: &tagsv1.Tags{
+			OrgId: (*string)(&tags.OrganizationID),
+			Aws: &tagsv1.AwsTags{
+				Lambda: &tagsv1.AwsLambdaTags{
+					Arch:          string(tags.Architecture),
+					LogGroup:      (*string)(&tags.LogGroupName),
+					LogStreamName: (*string)(&tags.LogStreamName),
+					MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
+					Name:          string(tags.FunctionName),
+					RequestId:     requestID,
+					Version:       string(tags.FunctionVersion),
+				},
+				Region:       (*string)(&tags.AWSRegion),
+				RequestId:    &requestID,
+				ResourceName: (*string)(&tags.FunctionName),
+				LogGroup:     (*string)(&tags.LogGroupName),
+				LogStream:    (*string)(&tags.LogStreamName),
+			},
+		},
+	}
+}
+
+func (s *basicSpan) newChild(ctx context.Context, name string) context.Context {
+	s.Lock()
+	defer s.Unlock()
+	span := newSpan(name)
+	s.children = append(s.children, span)
+	return context.WithValue(ctx, currentSpanContextKey, span)
+}
+func (s *basicSpan) captureError(err error) {
+	s.Lock()
+	defer s.Unlock()
+	s.errors = append(s.errors, errorEvent{
+		timestamp: time.Now(),
+		error:     err,
+	})
+}
+
+func (s *basicSpan) captureWarning(msg string) {
+	s.Lock()
+	defer s.Unlock()
+	s.warnings = append(s.warnings, warningEvent{
+		timestamp: time.Now(),
+		message:   msg,
+	})
+}
+
+func (s *basicSpan) addTags(tags map[string]string) {
+	s.Lock()
+	defer s.Unlock()
+	for k, v := range tags {
+		s.customTags[k] = v
+	}
+}
+
+func convertCustomTags(customTags map[string]string) *string {
+	b, err := json.Marshal(customTags)
+	if err != nil {
+		debugLog("marshalCustomTags:", err)
+		return nil
+	}
+	return aws.String(string(b))
+}

--- a/go/packages/slslambda/basicspan.go
+++ b/go/packages/slslambda/basicspan.go
@@ -46,7 +46,7 @@ func (s *basicSpan) Close() {
 	}
 }
 
-func (s *basicSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID string, tags tags) *instrumentationv1.Span {
+func (s *basicSpan) ToProto(traceID, spanID, parentSpanID []byte, _ string, tags tags) *instrumentationv1.Span {
 	return &instrumentationv1.Span{
 		Id:                spanID,
 		TraceId:           traceID,
@@ -57,22 +57,6 @@ func (s *basicSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID stri
 		CustomTags:        convertCustomTags(s.customTags),
 		Tags: &tagsv1.Tags{
 			OrgId: (*string)(&tags.OrganizationID),
-			Aws: &tagsv1.AwsTags{
-				Lambda: &tagsv1.AwsLambdaTags{
-					Arch:          string(tags.Architecture),
-					LogGroup:      (*string)(&tags.LogGroupName),
-					LogStreamName: (*string)(&tags.LogStreamName),
-					MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
-					Name:          string(tags.FunctionName),
-					RequestId:     requestID,
-					Version:       string(tags.FunctionVersion),
-				},
-				Region:       (*string)(&tags.AWSRegion),
-				RequestId:    &requestID,
-				ResourceName: (*string)(&tags.FunctionName),
-				LogGroup:     (*string)(&tags.LogGroupName),
-				LogStream:    (*string)(&tags.LogStreamName),
-			},
 		},
 	}
 }

--- a/go/packages/slslambda/example/main.go
+++ b/go/packages/slslambda/example/main.go
@@ -16,15 +16,42 @@ func handle(ctx context.Context) {
 	fmt.Println("hello from lambda!")
 	time.Sleep(100 * time.Millisecond)
 
+	// using context from handler, error is captured in aws.lambda.invocation span
 	err := errors.New("something went wrong")
 	slslambda.CaptureError(ctx, err)
 	fmt.Println("error captured!")
 
 	time.Sleep(100 * time.Millisecond)
 
+	// using context from handler, warning is captured in aws.lambda.invocation span
 	msg := "something bad will happen soon"
 	slslambda.CaptureWarning(ctx, msg)
 	fmt.Println("warning captured!")
+
+	// using context from handler, tags are added to aws.lambda.invocation span
+	slslambda.AddTags(ctx, map[string]string{"tag on invocation": "yes"})
+
+	// using context from handler, a new child span is added to aws.lambda.invocation
+	childCtx := slslambda.WithSpan(ctx, "child of invocation span")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// using child context, error is captured in "child of invocation span" span
+	err = errors.New("something went wrong in new span")
+	slslambda.CaptureError(childCtx, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// using child context, a new child span is added to "child of invocation span" span
+	childOfChildCtx := slslambda.WithSpan(childCtx, "child of child")
+
+	// using child of child context, tags are added to "child of child" span
+	slslambda.AddTags(childOfChildCtx, map[string]string{"tag on span 2": "yes"})
+
+	time.Sleep(50 * time.Millisecond)
+
+	// closing parent span also closes all children spans (in this case "child of child" span)
+	slslambda.Close(childCtx)
 
 	time.Sleep(100 * time.Millisecond)
 	fmt.Println("goodbye!")

--- a/go/packages/slslambda/initializationspan.go
+++ b/go/packages/slslambda/initializationspan.go
@@ -27,7 +27,5 @@ func (is *initializationSpan) Close() {
 }
 
 func (is *initializationSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID string, tags tags) *instrumentationv1.Span {
-	proto := is.basicSpan.ToProto(traceID, spanID, parentSpanID, requestID, tags)
-	proto.Tags.Aws.Lambda.IsColdstart = true
-	return proto
+	return is.basicSpan.ToProto(traceID, spanID, parentSpanID, requestID, tags)
 }

--- a/go/packages/slslambda/initializationspan.go
+++ b/go/packages/slslambda/initializationspan.go
@@ -1,0 +1,33 @@
+package slslambda
+
+import (
+	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
+	"time"
+)
+
+type initializationSpan struct {
+	*basicSpan
+}
+
+func (is *initializationSpan) Span() *basicSpan {
+	return is.basicSpan
+}
+
+func newInitializationSpan(start, end time.Time) *initializationSpan {
+	return &initializationSpan{&basicSpan{
+		name:       initializationSpanName,
+		start:      start,
+		end:        end,
+		customTags: map[string]string{},
+	}}
+}
+
+func (is *initializationSpan) Close() {
+	is.basicSpan.Close()
+}
+
+func (is *initializationSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID string, tags tags) *instrumentationv1.Span {
+	proto := is.basicSpan.ToProto(traceID, spanID, parentSpanID, requestID, tags)
+	proto.Tags.Aws.Lambda.IsColdstart = true
+	return proto
+}

--- a/go/packages/slslambda/rootspan.go
+++ b/go/packages/slslambda/rootspan.go
@@ -1,0 +1,60 @@
+package slslambda
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	tagsv1 "go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/tags/v1"
+	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
+	"time"
+)
+
+type rootSpan struct {
+	*basicSpan
+	isColdStart bool
+}
+
+func (rs *rootSpan) Span() *basicSpan {
+	return rs.basicSpan
+}
+
+func newRootSpan(initializationStart, invocationStart time.Time, isColdStart bool) *rootSpan {
+	return &rootSpan{
+		&basicSpan{
+			name:       rootSpanName,
+			start:      rootSpanStartTime(isColdStart, initializationStart, invocationStart),
+			customTags: map[string]string{}},
+		isColdStart}
+}
+
+func (rs *rootSpan) Close() {
+	rs.basicSpan.Close()
+}
+
+func (rs *rootSpan) ToProto(traceID, spanID, parentSpanID []byte, requestID string, tags tags) *instrumentationv1.Span {
+	proto := rs.basicSpan.ToProto(traceID, spanID, parentSpanID, requestID, tags)
+	proto.Tags.Aws = &tagsv1.AwsTags{
+		Lambda: &tagsv1.AwsLambdaTags{
+			Arch:          string(tags.Architecture),
+			LogGroup:      (*string)(&tags.LogGroupName),
+			LogStreamName: (*string)(&tags.LogStreamName),
+			MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
+			Name:          string(tags.FunctionName),
+			RequestId:     requestID,
+			IsColdstart:   rs.isColdStart,
+			Version:       string(tags.FunctionVersion),
+		},
+		Region:       (*string)(&tags.AWSRegion),
+		RequestId:    &requestID,
+		ResourceName: (*string)(&tags.FunctionName),
+		LogGroup:     (*string)(&tags.LogGroupName),
+		LogStream:    (*string)(&tags.LogStreamName),
+	}
+	return proto
+}
+
+func rootSpanStartTime(isColdStart bool, initializationStart, invocationStart time.Time) time.Time {
+	if isColdStart {
+		return initializationStart
+	} else {
+		return invocationStart
+	}
+}

--- a/go/packages/slslambda/slslambda.go
+++ b/go/packages/slslambda/slslambda.go
@@ -42,7 +42,7 @@ func WithEnvironment(env string) Option {
 }
 
 func CaptureError(ctx context.Context, err error) {
-	span, ctxErr := fromContext(ctx)
+	span, ctxErr := currentSpanFromContext(ctx)
 	if ctxErr != nil {
 		debugLog("capture error:", ctxErr)
 		return
@@ -51,10 +51,41 @@ func CaptureError(ctx context.Context, err error) {
 }
 
 func CaptureWarning(ctx context.Context, msg string) {
-	span, ctxErr := fromContext(ctx)
+	span, ctxErr := currentSpanFromContext(ctx)
 	if ctxErr != nil {
 		debugLog("capture warning:", ctxErr)
 		return
 	}
 	span.captureWarning(msg)
+}
+
+func WithSpan(ctx context.Context, name string) context.Context {
+	span, ctxErr := currentSpanFromContext(ctx)
+	if ctxErr != nil {
+		debugLog("with span:", ctxErr)
+		return ctx
+	}
+	return span.newChild(ctx, name)
+}
+
+func Close(ctx context.Context) {
+	span, ctxErr := currentSpanFromContext(ctx)
+	if ctxErr != nil {
+		debugLog("close:", ctxErr)
+		return
+	}
+	span.Close()
+}
+
+func AddTags(ctx context.Context, tags map[string]string) {
+	span, ctxErr := currentSpanFromContext(ctx)
+	if ctxErr != nil {
+		debugLog("add tag:", ctxErr)
+		return
+	}
+	span.addTags(tags)
+}
+
+func AddTag(ctx context.Context, key, value string) {
+	AddTags(ctx, map[string]string{key: value})
 }

--- a/go/packages/slslambda/trace.go
+++ b/go/packages/slslambda/trace.go
@@ -25,8 +25,8 @@ const (
 
 var version = "undefined"
 
-func (w wrapper) printTrace(span *rootSpan) error {
-	payload, err := convert(span, w.tags, w.environment)
+func (w wrapper) printTrace(root *rootContext) error {
+	payload, err := convertToPayload(root.spanTreeRoot, root.requestID, w.environment, w.tags)
 	if err != nil {
 		return fmt.Errorf("convert: %w", err)
 	}

--- a/go/packages/slslambda/wrapper.go
+++ b/go/packages/slslambda/wrapper.go
@@ -2,11 +2,8 @@ package slslambda
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go/aws"
-	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/tags/v1"
 	"go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
 	"runtime/debug"
 	"time"
@@ -23,14 +20,25 @@ type wrapper struct {
 	tags        tags
 }
 
-// An unexported type to be used as the key for types in this package.
-// This prevents collisions with keys defined in other packages.
-type key struct{}
+type (
+	// An unexported type to be used as the key for types in this package.
+	// This prevents collisions with keys defined in other packages.
+	rootContextKeyStruct        struct{}
+	currentSpanContextKeyStruct struct{}
+)
 
-// contextKey is the key for a rootSpan in Contexts.
-// Users of this package must use slslambda.FromContext
-// instead of using this key directly.
-var contextKey = &key{}
+var (
+	// rootContextKey is the key for a rootContext in Contexts.
+	// Users of this package must use slslambda.FromContext
+	// instead of using this key directly.
+	rootContextKey        = &rootContextKeyStruct{}
+	currentSpanContextKey = &currentSpanContextKeyStruct{}
+)
+
+type spansEvents struct {
+	spans  []*instrumentationv1.Span
+	events []*instrumentationv1.Event
+}
 
 func newWrapper(options ...func(c *wrapper)) (*wrapper, error) {
 	tags, err := getTags()
@@ -76,160 +84,57 @@ func (w wrapper) Wrap(userHandler lambda.Handler, initializationStart time.Time)
 }
 
 func ctxWithRootSpan(ctx context.Context, initializationStart time.Time) context.Context {
-	rootSpan := newRootSpan(ctx, initializationStart, time.Now())
-	return context.WithValue(ctx, contextKey, rootSpan)
+	rootCtx := newRootContext(ctx, initializationStart, time.Now())
+	withRootCtx := context.WithValue(ctx, rootContextKey, rootCtx)
+	return context.WithValue(withRootCtx, currentSpanContextKey, rootCtx.invocation)
 }
 
 func (w wrapper) closeRootSpan(ctx context.Context) error {
-	span, err := fromContext(ctx)
+	root, err := rootFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("close root span: %w", err)
 	}
-	span.close()
-	if err := w.printTrace(span); err != nil {
+	root.spanTreeRoot.Close()
+	if err := w.printTrace(root); err != nil {
 		return fmt.Errorf("print trace: %w", err)
 	}
 	return nil
 }
 
-func convert(span *rootSpan, tags tags, environment string) (*instrumentationv1.TracePayload, error) {
-	protoSpans, err := convertToProtoSpans(span, tags)
-	if err != nil {
-		return nil, fmt.Errorf("convert to proto spans: %w", err)
-	}
-	invocationSpan := invocationProtoSpan(protoSpans)
-	if invocationSpan == nil {
-		return nil, errors.New("invocation proto span not found")
-	}
-	protoEvents, err := convertToProtoEvents(span.errorEvents, span.warningEvents, invocationSpan.TraceId, invocationSpan.Id)
-	if err != nil {
-		return nil, fmt.Errorf("convert error events to proto events: %w", err)
-	}
-	payload := instrumentationv1.TracePayload{
-		SlsTags: slsTags(tags, environment),
-		Spans:   protoSpans,
-		Events:  protoEvents,
-	}
-	return &payload, nil
-}
-
-func convertToProtoSpans(rootSpan *rootSpan, tags tags) ([]*instrumentationv1.Span, error) {
-	var spans []*instrumentationv1.Span
-	rootSpanID, err := generateSpanID()
-	if err != nil {
-		return nil, fmt.Errorf("generate span ID: %w", err)
-	}
+func convertToPayload(spanTreeRoot *basicSpan, requestID, environment string, tags tags) (*instrumentationv1.TracePayload, error) {
 	traceID, err := generateTraceID()
 	if err != nil {
 		return nil, fmt.Errorf("generate trace ID: %w", err)
 	}
-	rootProtoSpan := instrumentationv1.Span{
-		Id:                rootSpanID,
-		TraceId:           traceID,
-		ParentSpanId:      nil,
-		Name:              rootSpanName,
-		StartTimeUnixNano: uint64(rootSpan.startTime.UnixNano()),
-		EndTimeUnixNano:   uint64(rootSpan.endTime.UnixNano()),
-		Tags: &tagsv1.Tags{
-			OrgId: (*string)(&tags.OrganizationID),
-			Aws: &tagsv1.AwsTags{
-				Lambda: &tagsv1.AwsLambdaTags{
-					Arch:          string(tags.Architecture),
-					LogGroup:      (*string)(&tags.LogGroupName),
-					LogStreamName: (*string)(&tags.LogStreamName),
-					MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
-					Name:          string(tags.FunctionName),
-					RequestId:     rootSpan.requestID,
-					Version:       string(tags.FunctionVersion),
-				},
-				Region:       (*string)(&tags.AWSRegion),
-				RequestId:    &rootSpan.requestID,
-				ResourceName: (*string)(&tags.FunctionName),
-				LogGroup:     (*string)(&tags.LogGroupName),
-				LogStream:    (*string)(&tags.LogStreamName),
-			},
-		},
-	}
-	spans = append(spans, &rootProtoSpan)
-
-	if isColdStart := rootSpan.startTime != rootSpan.invocationStartTime; isColdStart {
-		spanID, err := generateSpanID()
-		if err != nil {
-			return nil, fmt.Errorf("generate span ID: %w", err)
-		}
-		initializationProtoSpan := instrumentationv1.Span{
-			Id:                spanID,
-			TraceId:           traceID,
-			ParentSpanId:      rootProtoSpan.Id,
-			Name:              initializationSpanName,
-			StartTimeUnixNano: rootProtoSpan.StartTimeUnixNano,
-			EndTimeUnixNano:   uint64(rootSpan.invocationStartTime.UnixNano()),
-			Tags: &tagsv1.Tags{
-				OrgId: (*string)(&tags.OrganizationID),
-				Aws: &tagsv1.AwsTags{
-					Lambda: &tagsv1.AwsLambdaTags{
-						Arch:          string(tags.Architecture),
-						IsColdstart:   true,
-						LogGroup:      (*string)(&tags.LogGroupName),
-						LogStreamName: (*string)(&tags.LogStreamName),
-						MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
-						Name:          string(tags.FunctionName),
-						RequestId:     rootSpan.requestID,
-						Version:       string(tags.FunctionVersion),
-						Initialization: &tagsv1.AwsLambdaInitializationTags{
-							InitializationDuration: uint32(rootSpan.invocationStartTime.Sub(rootSpan.startTime).Milliseconds()),
-						},
-					},
-					Region:       (*string)(&tags.AWSRegion),
-					RequestId:    &rootSpan.requestID,
-					ResourceName: (*string)(&tags.FunctionName),
-					LogGroup:     (*string)(&tags.LogGroupName),
-					LogStream:    (*string)(&tags.LogStreamName),
-				},
-			},
-		}
-		spans = append(spans, &initializationProtoSpan)
-	}
-	spanID, err := generateSpanID()
+	proto, err := convertToProto(spanTreeRoot, traceID, nil, requestID, tags)
 	if err != nil {
-		return nil, fmt.Errorf("generate span ID: %w", err)
+		return nil, fmt.Errorf("convert span tree root to proto: %w", err)
 	}
-	invocationProtoSpan := instrumentationv1.Span{
-		Id:                spanID,
-		TraceId:           traceID,
-		ParentSpanId:      rootProtoSpan.Id,
-		Name:              invocationSpanName,
-		StartTimeUnixNano: uint64(rootSpan.invocationStartTime.UnixNano()),
-		EndTimeUnixNano:   uint64(rootSpan.endTime.UnixNano()),
-		Tags: &tagsv1.Tags{
-			OrgId: (*string)(&tags.OrganizationID),
-			Aws: &tagsv1.AwsTags{
-				Lambda: &tagsv1.AwsLambdaTags{
-					Arch:          string(tags.Architecture),
-					LogGroup:      (*string)(&tags.LogGroupName),
-					LogStreamName: (*string)(&tags.LogStreamName),
-					MaxMemory:     aws.Uint32(uint32(tags.MemorySize)),
-					Name:          string(tags.FunctionName),
-					RequestId:     rootSpan.requestID,
-					Version:       string(tags.FunctionVersion),
-				},
-				Region:       (*string)(&tags.AWSRegion),
-				RequestId:    &rootSpan.requestID,
-				ResourceName: (*string)(&tags.FunctionName),
-				LogGroup:     (*string)(&tags.LogGroupName),
-				LogStream:    (*string)(&tags.LogStreamName),
-			},
-		},
-	}
-	spans = append(spans, &invocationProtoSpan)
-	return spans, nil
+	return &instrumentationv1.TracePayload{
+		SlsTags: slsTags(tags, environment),
+		Spans:   proto.spans,
+		Events:  proto.events,
+	}, nil
 }
 
-func invocationProtoSpan(spans []*instrumentationv1.Span) *instrumentationv1.Span {
-	for _, span := range spans {
-		if span.Name == invocationSpanName {
-			return span
-		}
+func convertToProto(span span, traceID, parentSpanID []byte, requestID string, tags tags) (spansEvents, error) {
+	spanID, err := generateSpanID()
+	if err != nil {
+		return spansEvents{}, fmt.Errorf("generate span ID: %w", err)
 	}
-	return nil
+	protoSpan := span.ToProto(traceID, spanID, parentSpanID, requestID, tags)
+	protoEvents, err := convertToProtoEvents(span.Span().errors, span.Span().warnings, traceID, spanID)
+	if err != nil {
+		return spansEvents{}, fmt.Errorf("convert to proto events: %w", err)
+	}
+	protoSpans := []*instrumentationv1.Span{protoSpan}
+	for _, span := range span.Span().children {
+		childrenProto, err := convertToProto(span, traceID, protoSpan.Id, requestID, tags)
+		if err != nil {
+			return spansEvents{}, fmt.Errorf("convert span to proto: %w", err)
+		}
+		protoSpans = append(protoSpans, childrenProto.spans...)
+		protoEvents = append(protoEvents, childrenProto.events...)
+	}
+	return spansEvents{spans: protoSpans, events: protoEvents}, nil
 }

--- a/go/packages/slslambda/wrapper.go
+++ b/go/packages/slslambda/wrapper.go
@@ -101,7 +101,7 @@ func (w wrapper) closeRootSpan(ctx context.Context) error {
 	return nil
 }
 
-func convertToPayload(spanTreeRoot *basicSpan, requestID, environment string, tags tags) (*instrumentationv1.TracePayload, error) {
+func convertToPayload(spanTreeRoot *rootSpan, requestID, environment string, tags tags) (*instrumentationv1.TracePayload, error) {
 	traceID, err := generateTraceID()
 	if err != nil {
 		return nil, fmt.Errorf("generate trace ID: %w", err)


### PR DESCRIPTION
PR created based on https://github.com/serverless/console/pull/500
> To support tracing our clickhouse benchmarks, we need a way to create spans for each segment of the performance test. This PR introduces the ability to create spans through the Go SDK to meet that goal.

![image](https://user-images.githubusercontent.com/23511767/223757308-d25f3033-d2b2-4bf6-9450-220e4f7f0e49.png)
