### PR TITLE
Fix debug log message

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -138,7 +138,7 @@ class Instrumenter:
                 )
 
                 diff = int((time.perf_counter_ns() - request_start_time) / 1000_000)
-                logger.debug("Overhead duration: Internal request:" + f"{diff}ms")
+                debug_log("Overhead duration: Internal request:" + f"{diff}ms")
 
             except Exception:
                 logger.exception("Unhandled exception during instrumentation.")


### PR DESCRIPTION
To ensure message is prefixed with "⚡ SDK: "
