### PR TITLE
Release AWS Lambda SDK v0.1.6

### DIFF
--- a/python/packages/aws-lambda-sdk/CHANGELOG.md
+++ b/python/packages/aws-lambda-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.1.6 (2023-03-09)
+
+### Bug Fixes
+
+- Ensure support for Python v3.8+
+- Fix log messages appearing twice
+- Ensure debug message is prefixed with "⚡ SDK: "
+
 ## 0.1.5 (2023-03-07)
 
 _Re-release due to broken publication process_

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-aws-lambda-sdk"
-version = "0.1.5"
+version = "0.1.6"
 description = "Serverless AWS Lambda SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-560/ensure-support-for-python-38#comment-76ad2b27