### PR TITLE
Fix unit test ci flow

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -55,59 +55,67 @@ jobs:
         if: steps.pathChanges.outputs.sdk == 'true'
         run: |
           cd python/packages/sdk
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install . pytest strenum
 
-          python3 -m pip install --editable .
-
-      - name: Unit tests /sdk
+      - name: Run SDK unit tests
         if: steps.pathChanges.outputs.sdk == 'true'
         run: |
           cd python/packages/sdk
-          python3 -m pip install pytest
+          source .venv/bin/activate
           python3 -m pytest
-
-      - name: Buf Setup
-        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
-        uses: bufbuild/buf-setup-action@v1
-      - name: Buf Lint
-        if: steps.pathChanges.outputs.proto == 'true'
-        uses: bufbuild/buf-lint-action@v1
-        with:
-          input: "proto"
-      - name: Build Protobufs
-        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
-        run: |
-          cd ./proto
-          python3 -m pip install "betterproto[compiler]"
-          buf generate --template=buf.gen.python.yaml 
 
       - name: Install SDK Schema
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
-
-          python3 -m pip install poethepoet
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install poethepoet pytest
           python3 -m poethepoet install
+
+      - name: Buf Setup
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+
+      - name: Buf Lint
+        if: steps.pathChanges.outputs.proto == 'true'
+        uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "proto"
+          github_token: ${{ github.token }}
+
+      - name: Build Protobufs
+        if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
+        run: |
+          source python/packages/sdk-schema/.venv/bin/activate
+          cd ./proto
+          python3 -m pip install "betterproto[compiler]"
+          buf generate --template=buf.gen.python.yaml 
 
       - name: Run SDK Schema unit tests
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
-
-          python3 -m pip install poethepoet pytest
+          source .venv/bin/activate
           python3 -m poethepoet test
 
       - name: Install AWS Lambda SDK project and dependencies
         if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
         run: |
           cd python/packages/aws-lambda-sdk
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install . pytest strenum
 
-          python3 -m pip install --editable .
-
-      - name: Unit tests /aws-lambda-sdk
+      - name: Run AWS Lambda SDK unit tests
         if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
         run: |
           cd python/packages/aws-lambda-sdk
-          python3 -m pip install pytest
+          source .venv/bin/activate
           python3 -m pytest
 
   integratePythonSdk:

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -55,13 +55,6 @@ jobs:
           cache-dependency-path: |
             **/pyproject.toml
 
-      - name: Install SDK project and dependencies
-        if: steps.pathChanges.outputs.sdk == 'true'
-        run: |
-          cd python/packages/sdk
-
-          python3 -m pip install --editable .
-
       - name: Validate code formatting
         if: steps.pathChanges.outputs.packages == 'true'
         run: |
@@ -91,20 +84,28 @@ jobs:
           python3 -m pip install ruff
           python3 -m ruff .
 
+      - name: Install SDK project and dependencies
+        if: steps.pathChanges.outputs.sdk == 'true'
+        run: |
+          cd python/packages/sdk
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install . pytest strenum
+
       - name: Run SDK unit tests
         if: steps.pathChanges.outputs.sdk == 'true'
         run: |
           cd python/packages/sdk
-
-          python3 -m pip install pytest
+          source .venv/bin/activate
           python3 -m pytest
 
       - name: Install SDK Schema
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
-
-          python3 -m pip install poethepoet
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install poethepoet pytest
           python3 -m poethepoet install
 
       - name: Buf Setup
@@ -123,6 +124,7 @@ jobs:
       - name: Build Protobufs
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
+          source python/packages/sdk-schema/.venv/bin/activate
           cd ./proto
           python3 -m pip install "betterproto[compiler]"
           buf generate --template=buf.gen.python.yaml 
@@ -131,8 +133,7 @@ jobs:
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
-
-          python3 -m pip install poethepoet pytest
+          source .venv/bin/activate
           python3 -m poethepoet test
 
       - name: Install AWS Lambda SDK project and dependencies
@@ -141,14 +142,11 @@ jobs:
           cd python/packages/aws-lambda-sdk
           python3 -m venv .venv
           source .venv/bin/activate
-
-          python3 -m pip install .
+          python3 -m pip install . pytest strenum
 
       - name: Run AWS Lambda SDK unit tests
         if: steps.pathChanges.outputs.awsLambdaSdk == 'true'
         run: |
           cd python/packages/aws-lambda-sdk
           source .venv/bin/activate
-
-          python3 -m pip install pytest strenum
           python3 -m pytest

--- a/python/packages/aws-lambda-sdk/README.md
+++ b/python/packages/aws-lambda-sdk/README.md
@@ -2,7 +2,7 @@
 
 ## AWS Lambda [Serverless Console](https://www.serverless.com/console) SDK for Python
 
-Instruments AWS Lambda functions, propagates traces to the [Serverless Console](https://www.serverless.com/console/docs) and exposes Serverless SDK to the function logic
+Instruments AWS Lambda functions, propagates traces to the [Serverless Console](https://www.serverless.com/console/docs) and exposes Serverless SDK to the function logic.
 
 ### Setup
 

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
-    "serverless-sdk~=0.1",
+    "serverless-sdk~=0.1.0",
     "serverless-sdk-schema~=0.1",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -14,7 +14,7 @@ authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
     "serverless-sdk~=0.1.0",
-    "serverless-sdk-schema~=0.1",
+    "serverless-sdk-schema~=0.1.0",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/sdk/README.md
+++ b/python/packages/sdk/README.md
@@ -23,6 +23,7 @@ pip install serverless-sdk
 ```python
 from serverless_sdk import serverlessSdk
 print(serverlessSdk.name)
+print(serverlessSdk.version)
 ```
 
 ### Setup


### PR DESCRIPTION
Related issue https://github.com/serverless/console/pull/512

### Description
* Unit tests should install dependencies from PyPI repository. Both integrate and validate flow unit tests are now adhering to this principle.
* I've noticed that we depend on `serverless-sdk~=0.1` which caused `serverless-sdk v0.2.0' to be pulled and that broke the CI. This is also fixed to make sure it does not upgrade to newer minor version.

### Testing done
To be tested on the CI.