### PR TITLE
Integration test sdk import

### DIFF
--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
@@ -1,0 +1,14 @@
+from serverless_sdk import serverlessSdk as sdk
+
+
+def handler(event, context):
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    if sdk is not serverlessSdk:
+        raise Exception("SDK exports mismatch")
+    sdk._create_trace_span("user.span").close()
+    return {
+        "name": sdk.name,
+        "version": sdk.version,
+        "rootSpanName": sdk.trace_spans.root.name,
+    }


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-565#comment-7a7e1fcb

### Description
Add integration test for testing sdk usage

### Testing done
Integration tested locally:

```
➜  node git:(SC-565-integration-test) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-10T06:49:11.181Z ℹ test test uid: cdab


  Python: integration
2023-03-10T06:49:11.289Z ℹ test Creating core resources test-python-sdk-cdab
2023-03-10T06:49:57.175Z ℹ test Process function success-v3-8
2023-03-10T06:49:57.177Z ℹ test Process function success-v3-9
2023-03-10T06:49:57.178Z ℹ test Process function error-v3-8
2023-03-10T06:49:57.178Z ℹ test Process function error-v3-9
2023-03-10T06:49:57.178Z ℹ test Process function sdk-v3-8
2023-03-10T06:49:57.179Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (28049ms)
    ✔ success-v3-9
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ sdk-v3-8 (4475ms)
    ✔ sdk-v3-9
2023-03-10T06:50:29.724Z ℹ test Cleanup test-python-sdk-cdab
2023-03-10T06:50:30.065Z ℹ test Deleted 27 version of the layer test-python-sdk-cdab-internal
2023-03-10T06:50:31.071Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab from test-python-sdk-cdab
2023-03-10T06:50:31.300Z ℹ test Deleted IAM role test-python-sdk-cdab
2023-03-10T06:50:31.763Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab


  6 passing (1m)
```