### PR TITLE
Add capture_error method to Python base SDK

### DIFF
--- a/python/packages/sdk/README.md
+++ b/python/packages/sdk/README.md
@@ -24,6 +24,8 @@ pip install serverless-sdk
 from serverless_sdk import serverlessSdk
 print(serverlessSdk.name)
 print(serverlessSdk.version)
+
+serverlessSdk.capture_error(Exception("Unexpected"))
 ```
 
 ### Setup
@@ -41,6 +43,10 @@ _Common options supported by all environments:_
 ###### `SLS_ORG_ID` (or `options.orgId`)
 
 Required setting. Id of your organization in Serverless Console.
+
+##### `SLS_DISABLE_CAPTURED_EVENTS_STDOUT` (or `options.disableCapturedEventsStdout`)
+
+Disable writing captured events registered via `.capture_error` to stdout
 
 ### Instrumentation
 

--- a/python/packages/sdk/docs/sdk.md
+++ b/python/packages/sdk/docs/sdk.md
@@ -13,3 +13,14 @@ Package version
 ### `.org_id`
 
 Authenticated Serverless Console organization id
+
+### `.trace_spans`
+
+Dictionary of common spans created in context of given environment
+
+### `.capture_error(error[, tags])`
+
+Record captured error. Captured error is sent to Serverless Console backend and printed to the stdout in structured format (writing to stdout can be disabled with `SLS_DISABLE_CAPTURED_EVENTS_STDOUT` env var)
+
+- `error` - Captured error
+- `tags` _(object)_ - User tags object. Tag names can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters. Values can be _string_, _boolean_, _number_, Date or Array containing any values of prior listed types

--- a/python/packages/sdk/serverless_sdk/__init__.py
+++ b/python/packages/sdk/serverless_sdk/__init__.py
@@ -9,6 +9,8 @@ from .base import Nanoseconds, SLS_ORG_ID, __version__, __name__
 from .lib import trace
 from .lib.captured_event import CapturedEvent
 from .lib.tags import Tags
+from .lib.error_captured_event import create as create_error_captured_event
+from .lib.error import report as report_error
 
 
 __all__: Final[List[str]] = [
@@ -58,6 +60,14 @@ class ServerlessSdk:
         tags: Optional[Tags] = None,
     ) -> trace.TraceSpan:
         return trace.TraceSpan(name, input, output, start_time, tags)
+
+    def capture_error(self, error, **kwargs) -> CapturedEvent:
+        try:
+            _error = create_error_captured_event(error, **kwargs)
+            self._captured_events.append(_error)
+            return _error
+        except Exception as ex:
+            self._captured_events.append(report_error(ex))
 
 
 serverlessSdk: Final[ServerlessSdk] = ServerlessSdk()

--- a/python/packages/sdk/serverless_sdk/lib/error.py
+++ b/python/packages/sdk/serverless_sdk/lib/error.py
@@ -1,6 +1,7 @@
 import os
 from builtins import type as builtins_type
 from .stack_trace_string import resolve as resolve_stack_trace_string
+
 from .error_captured_event import create as create_error_captured_event
 import logging
 

--- a/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
@@ -5,7 +5,6 @@ from typing import Optional
 from .tags import Tags
 from .captured_event import CapturedEvent
 from .stack_trace_string import resolve as resolve_stack_trace_string
-from .. import serverlessSdk
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +46,9 @@ def create(
         _tags["message"] = str(error)
     _tags["stacktrace"] = stack or resolve_stack_trace_string(error)
     captured_event.tags.update(_tags, prefix="error")
+
+    # to avoid circular dependency, require inline
+    from .. import serverlessSdk
 
     if (
         origin == "nodeConsole"

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -6,6 +6,7 @@ import pytest
 from . import get_params
 from serverless_sdk import ServerlessSdk
 from serverless_sdk.base import SLS_ORG_ID
+from serverless_sdk.lib.error_captured_event import TYPE_MAP
 
 
 @pytest.fixture
@@ -102,3 +103,4 @@ def test_sdk_exposes_capture_error(sdk: ServerlessSdk):
     # then
     assert captured.tags["error.message"] == "My error"
     assert captured.custom_tags["user.tag"] == "somevalue"
+    assert captured.tags["error.type"] == TYPE_MAP["handledUser"]

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -90,3 +90,15 @@ def test_create_trace_span_returns_trace_span(sdk: ServerlessSdk):
     span = sdk._create_trace_span("name", "input", "output")
 
     assert isinstance(span, TraceSpan)
+
+
+def test_sdk_exposes_capture_error(sdk: ServerlessSdk):
+    # given
+    error = Exception("My error")
+
+    # when
+    captured = sdk.capture_error(error, tags={"user.tag": "somevalue"})
+
+    # then
+    assert captured.tags["error.message"] == "My error"
+    assert captured.custom_tags["user.tag"] == "somevalue"


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-561/report-detailed-error-information-in-case-of-error-resolution

### Description
* Add `serverlessSdk.capture_error` method
* Add documentation for the new method

### Testing done
Unit tested