### PR TITLE
Include captured error events in trace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "cSpell.words": ["runtimes"],
-  "python.analysis.extraPaths": ["./python/packages/sdk"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cSpell.words": ["runtimes"],
+  "python.analysis.extraPaths": ["./python/packages/sdk"]
+}

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
-    "serverless-sdk~=0.2.0",
+    "serverless-sdk~=0.2.1",
     "serverless-sdk-schema~=0.1.0",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11

--- a/python/packages/aws-lambda-sdk/tests/__init__.py
+++ b/python/packages/aws-lambda-sdk/tests/__init__.py
@@ -4,7 +4,6 @@ import inspect
 import sys
 from pathlib import Path
 from typing import Callable, Dict
-from serverless_sdk_schema import TracePayload
 
 
 sys.path.append(str(Path(__file__).parent / "fixtures/lambdas"))
@@ -21,6 +20,7 @@ context.aws_request_id = "test-request"
 
 TEST_ORG = "test-org"
 TEST_FUNCTION = "test-function"
+TEST_FUNCTION_VERSION = "1"
 
 
 def get_params(func: Callable) -> Params:
@@ -39,33 +39,3 @@ def compare_handlers(original, instrumented):
     orig_result = original({}, context)
     instrumented_result = instrumented({}, context)
     assert orig_result == instrumented_result
-
-
-def assert_trace_payload(trace_payload: TracePayload, outcome: int):
-    assert [s.name for s in trace_payload.spans] == [
-        "aws.lambda",
-        "aws.lambda.initialization",
-        "aws.lambda.invocation",
-    ]
-    assert trace_payload.sls_tags.org_id == TEST_ORG
-    assert trace_payload.sls_tags.service == TEST_FUNCTION
-    aws_lambda = [x for x in trace_payload.spans if x.name == "aws.lambda"][0]
-    assert aws_lambda.tags.aws.lambda_.outcome == outcome
-    assert aws_lambda.tags.aws.lambda_.request_id == context.aws_request_id
-
-    aws_lambda_initialization = [
-        x for x in trace_payload.spans if x.name == "aws.lambda.initialization"
-    ][0]
-    aws_lambda_invocation = [
-        x for x in trace_payload.spans if x.name == "aws.lambda.invocation"
-    ][0]
-    assert (
-        aws_lambda_initialization.start_time_unix_nano
-        == aws_lambda.start_time_unix_nano
-    )
-    assert (
-        aws_lambda_invocation.start_time_unix_nano
-        > aws_lambda_initialization.start_time_unix_nano
-    )
-    for span in trace_payload.spans:
-        assert span.start_time_unix_nano < span.end_time_unix_nano

--- a/python/packages/aws-lambda-sdk/tests/conftest.py
+++ b/python/packages/aws-lambda-sdk/tests/conftest.py
@@ -1,11 +1,7 @@
 import pytest
 import sys
 import importlib
-
-
-TEST_ORG = "test-org"
-TEST_FUNCTION = "test-function"
-TEST_FUNCTION_VERSION = "1"
+from . import TEST_FUNCTION, TEST_FUNCTION_VERSION, TEST_ORG
 
 
 @pytest.fixture()

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
@@ -1,12 +1,26 @@
 from serverless_sdk import serverlessSdk as sdk
 
 
+counter = 0
+
+
 def handler(event, context):
+    global counter
+
+    counter += 1
+    invocation_id = counter
+
     from serverless_aws_lambda_sdk import serverlessSdk
 
     if sdk is not serverlessSdk:
         raise Exception("SDK exports mismatch")
     sdk._create_trace_span("user.span").close()
+
+    sdk.capture_error(
+        Exception("Captured error"),
+        tags={"user.tag": "example", "invocationid": invocation_id},
+    )
+
     return {
         "name": sdk.name,
         "version": sdk.version,

--- a/python/packages/aws-lambda-sdk/tests/test_assertions.py
+++ b/python/packages/aws-lambda-sdk/tests/test_assertions.py
@@ -1,0 +1,44 @@
+from typing import List
+from serverless_sdk_schema import TracePayload
+from serverless_sdk_schema.schema.serverless.instrumentation.v1 import Span
+from .conftest import TEST_FUNCTION, TEST_ORG
+from . import context
+
+
+def assert_error_event(
+    trace_payload: TracePayload, aws_lambda_invocation: Span, outcome
+):
+    event = trace_payload.events[0]
+    assert event.timestamp_unix_nano == aws_lambda_invocation.end_time_unix_nano
+    assert event.event_name == "telemetry.error.generated.v1"
+    assert event.tags.error.type == 1
+    assert event.tags.error.name == "Exception" if outcome == 5 else "SystemExit"
+
+
+def assert_trace_payload(trace_payload: TracePayload, spans: List[str], outcome: int):
+    assert [s.name for s in trace_payload.spans] == spans
+    assert trace_payload.sls_tags.org_id == TEST_ORG
+    assert trace_payload.sls_tags.service == TEST_FUNCTION
+    aws_lambda = [x for x in trace_payload.spans if x.name == "aws.lambda"][0]
+    assert aws_lambda.tags.aws.lambda_.outcome == outcome
+    assert aws_lambda.tags.aws.lambda_.request_id == context.aws_request_id
+
+    aws_lambda_initialization = [
+        x for x in trace_payload.spans if x.name == "aws.lambda.initialization"
+    ][0]
+    aws_lambda_invocation = [
+        x for x in trace_payload.spans if x.name == "aws.lambda.invocation"
+    ][0]
+    assert (
+        aws_lambda_initialization.start_time_unix_nano
+        == aws_lambda.start_time_unix_nano
+    )
+    assert (
+        aws_lambda_invocation.start_time_unix_nano
+        > aws_lambda_initialization.start_time_unix_nano
+    )
+    for span in trace_payload.spans:
+        assert span.start_time_unix_nano < span.end_time_unix_nano
+
+    if outcome != 1:
+        assert_error_event(trace_payload, aws_lambda_invocation, outcome)


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-561/report-detailed-error-information-in-case-of-error-resolution

### Description
* Include captured error events in trace

### Testing done
* Unit tested
* Integration tested

```
➜  node git:(lambda-sdk-use-capture-error) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-14T12:46:39.189Z ℹ test test uid: cdab


  Python: integration
2023-03-14T12:46:39.288Z ℹ test Creating core resources test-python-sdk-cdab
2023-03-14T12:47:14.059Z ℹ test Process function success-v3-8
2023-03-14T12:47:14.060Z ℹ test Process function success-v3-9
2023-03-14T12:47:14.061Z ℹ test Process function error-v3-8
2023-03-14T12:47:14.061Z ℹ test Process function error-v3-9
2023-03-14T12:47:14.061Z ℹ test Process function error_unhandled-v3-8
2023-03-14T12:47:14.062Z ℹ test Process function error_unhandled-v3-9
2023-03-14T12:47:14.062Z ℹ test Process function sdk-v3-8
2023-03-14T12:47:14.062Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (27552ms)
    ✔ success-v3-9
    ✔ error-v3-8 (2149ms)
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9 (271ms)
2023-03-14T12:47:44.066Z ℹ test Cleanup test-python-sdk-cdab
2023-03-14T12:47:44.456Z ℹ test Deleted 34 version of the layer test-python-sdk-cdab-internal
2023-03-14T12:47:45.267Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab from test-python-sdk-cdab
2023-03-14T12:47:45.466Z ℹ test Deleted IAM role test-python-sdk-cdab
2023-03-14T12:47:45.951Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cdab


  8 passing (1m)
```
