### PR TITLE
Add set_tag API method to Python SDK

### DIFF
--- a/python/packages/sdk/docs/sdk.md
+++ b/python/packages/sdk/docs/sdk.md
@@ -23,4 +23,11 @@ Dictionary of common spans created in context of given environment
 Record captured error. Captured error is sent to Serverless Console backend and printed to the stdout in structured format (writing to stdout can be disabled with `SLS_DISABLE_CAPTURED_EVENTS_STDOUT` env var)
 
 - `error` - Captured error
-- `tags` _(object)_ - User tags object. Tag names can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters. Values can be _string_, _boolean_, _number_, Date or Array containing any values of prior listed types
+- `tags` _(object)_ - User tags object. Tag names can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters. Values can be _str_, _bool_, _int_, _float_, _datetime_ or _List_ containing any values of prior listed types
+
+### `.set_tag(name, value)`
+
+Set custom (user defined) trace tag
+
+- `name` _(str)_ - Tag name, can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters
+- `value` (any) - Tag value. Can be _str_, _bool_, _int_, _float_, _datetime_ or _List_ containing any values of prior listed types

--- a/python/packages/sdk/serverless_sdk/lib/captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/captured_event.py
@@ -10,6 +10,7 @@ from .name import get_resource_name
 from .tags import Tags, convert_tags_to_protobuf
 from .trace import TraceSpan
 from ..exceptions import FutureEventTimestamp
+from .emitter import event_emitter
 
 
 __all__: Final[List[str]] = [
@@ -55,6 +56,7 @@ class CapturedEvent:
             self.custom_tags.update(custom_tags)
 
         self.trace_span = trace_span
+        event_emitter.emit("captured-event", self)
 
     @cached_property
     def id(self) -> str:

--- a/python/packages/sdk/serverless_sdk/lib/trace.py
+++ b/python/packages/sdk/serverless_sdk/lib/trace.py
@@ -43,6 +43,7 @@ class TraceSpan:
     input: Optional[str] = None
     output: Optional[str] = None
     tags: Tags
+    custom_tags: Tags
     sub_spans: List[Self]
 
     def __init__(
@@ -102,6 +103,7 @@ class TraceSpan:
 
     def _set_tags(self, tags: Optional[Tags]):
         self.tags = Tags()
+        self.custom_tags = Tags()
 
         if tags is not None:
             self.tags.update(tags)
@@ -213,6 +215,7 @@ class TraceSpan:
             "input": self.input,
             "output": self.output,
             "tags": convert_tags_to_protobuf(self.tags),
+            "customTags": convert_tags_to_protobuf(self.custom_tags),
         }
 
 

--- a/python/packages/sdk/tests/lib/test_trace_span.py
+++ b/python/packages/sdk/tests/lib/test_trace_span.py
@@ -101,6 +101,7 @@ def test_span_protobuf():
     child_span.tags["some.number"] = 123
     child_span.tags["some.strings"] = ["foo", "bar"]
     child_span.tags["some.numbers"] = [12, 23]
+    child_span.custom_tags["elo"] = "marko"
     child_span.close()
 
     # when
@@ -127,6 +128,7 @@ def test_span_protobuf():
                 "numbers": [12, 23],
             },
         },
+        "customTags": {"elo": "marko"},
     }, "should stringify to JSON"
 
 


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-564/python-sdk-custom-tags-api

### Description
* Add `set_tag` method to base SDK.
* Add `custom_tags` on `TraceSpan`.
* Add/fix documentation
* Use event emitter for captured events, otherwise the `set_tag` API would have needed to return the error value in case of errors
* `_captured_events` list is removed from the base SDK, consumers can rely on the event being emitted.

### Testing done
* Unit tested
* Integration tests will be updated once `set_tag` is released.