### PR TITLE
Release python base sdk v0.3.0

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.2.2 (2023-03-15)
+
+### Features
+
+- Add `serverlessSdk.set_tag` method, providing a way to set custom tags on the trace.
+
 ## 0.2.1 (2023-03-14)
 
 ### Features

--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.2.2 (2023-03-15)
+## 0.3.0 (2023-03-15)
 
 ### Features
 
 - Add `serverlessSdk.set_tag` method, providing a way to set custom tags on the trace.
+
+### ⚠ BREAKING CHANGES
+
+- List of captured events are removed
 
 ## 0.2.1 (2023-03-14)
 

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.2.1"
+version = "0.2.2"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.2.2"
+version = "0.3.0"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-564/python-sdk-custom-tags-api

@medikoo This should be merged after https://github.com/serverless/console/pull/526 to make sure lambda SDK does not break with the base v0.2.2, because this release contains a change that pushes storage of captured events to the lambda SDK. It's not a breaking change if we get https://github.com/serverless/console/pull/526 in first.