### PR TITLE
Improve wrapper script

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec_wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec_wrapper.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
 import sys
 import os
+import importlib
+from pathlib import Path
 
 
+# This script is executed by AWS Lambda Runtime as follows:
+# /opt/sls-sdk-python/exec_wrapper.py /var/lang/bin/python3 /var/runtime/bootstrap.py
 def main():
     from base import initialize
 
     initialize()
 
-    _, *args = sys.argv
-    command = " ".join(args)
-    os.system(command)
+    # AWS Lambda Runtime sets "LAMBDA_RUNTIME_DIR" env variable to "/var/runtime"
+    # which is needed in the path for the import to work.
+    sys.path.append(os.environ["LAMBDA_RUNTIME_DIR"])
+
+    module_name = Path(sys.argv[2]).stem
+    bootstrap = importlib.import_module(module_name)
+    bootstrap.main()
 
 
 if __name__ == "__main__":

--- a/python/packages/aws-lambda-sdk/tests/test_internal_extension_exec_wrapper.py
+++ b/python/packages/aws-lambda-sdk/tests/test_internal_extension_exec_wrapper.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+import os
+
+
+def test_exec_wrapper_succeeds(monkeypatch):
+    # given
+    env = dict(os.environ)
+    monkeypatch.setattr(os, "environ", env)
+
+    os.environ["_TEST_INTERNAL_EXTENSION"] = "0"
+
+    monkeypatch.setenv("_HANDLER", "fixtures.lambdas.success.handler")
+    monkeypatch.setenv("LAMBDA_TASK_ROOT", str(Path(__file__).parent.resolve()))
+    monkeypatch.setenv("SLS_ORG_ID", "test-org")
+    monkeypatch.setenv("SLS_SDK_DEBUG", "1")
+    monkeypatch.setenv("LAMBDA_RUNTIME_DIR", "/var/runtime")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "/opt/sls-sdk-python/exec_wrapper.py",
+            "/var/lang/bin/python3",
+            str(Path(__file__).resolve()),
+        ],
+    )
+    sys.path.append(
+        str(
+            (
+                Path(__file__).parent.parent
+                / "serverless_aws_lambda_sdk/internal_extension"
+            ).resolve()
+        )
+    )
+    sys.path.append(str((Path(__file__).parent).resolve()))
+
+    # when
+    from serverless_aws_lambda_sdk.internal_extension.exec_wrapper import (
+        main as exec_wrapper_main,
+    )
+
+    exec_wrapper_main()
+
+    # then
+    assert os.environ["_TEST_INTERNAL_EXTENSION"] == "1"
+    del os.environ["_TEST_INTERNAL_EXTENSION"]
+
+
+def main():
+    os.environ["_TEST_INTERNAL_EXTENSION"] = "1"

--- a/python/packages/aws-lambda-sdk/tests/test_internal_extension_wrapper.py
+++ b/python/packages/aws-lambda-sdk/tests/test_internal_extension_wrapper.py
@@ -24,7 +24,6 @@ HANDLER_MODULE_DIR: Final[str] = str(Path(__file__).parent.resolve())
 def test_raises_exception_when_handler_is_not_set(reset_sdk):
     # given
     from serverless_aws_lambda_sdk.exceptions import HandlerNotFound
-    from serverless_aws_lambda_sdk.internal_extension.base import Env
 
     env = dict(os.environ)
     reset_sdk.setattr(os, "environ", env)


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-592/python-sdk-inaccurate-invocation-duration#comment-8f8627e6

### Description
1. The script set by `AWS_LAMBDA_EXEC_WRAPPER` is updated to make sure the AWS Lambda Runtime runs within the same process. This will ensure customer's lambda package is imported once.
2. The INIT duration is measured more precisely because the performance timer won't be reset as the same process is still executing.

### Testing done
Unit & integration tested
```
➜  node git:(improve-exec-wrapper) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-16T11:02:09.567Z ℹ test test uid: selcuk


  Python: integration
2023-03-16T11:02:09.669Z ℹ test Creating core resources test-python-sdk-selcuk
2023-03-16T11:02:46.918Z ℹ test Process function success-v3-8
2023-03-16T11:02:46.919Z ℹ test Process function success-v3-9
2023-03-16T11:02:46.919Z ℹ test Process function error-v3-8
2023-03-16T11:02:46.920Z ℹ test Process function error-v3-9
2023-03-16T11:02:46.920Z ℹ test Process function error_unhandled-v3-8
2023-03-16T11:02:46.920Z ℹ test Process function error_unhandled-v3-9
2023-03-16T11:02:46.921Z ℹ test Process function sdk-v3-8
2023-03-16T11:02:46.921Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (26198ms)
    ✔ success-v3-9 (4222ms)
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9 (577ms)
2023-03-16T11:03:17.948Z ℹ test Cleanup test-python-sdk-selcuk
2023-03-16T11:03:18.292Z ℹ test Deleted 6 version of the layer test-python-sdk-selcuk-internal
2023-03-16T11:03:19.217Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-selcuk from test-python-sdk-selcuk
2023-03-16T11:03:19.448Z ℹ test Deleted IAM role test-python-sdk-selcuk
2023-03-16T11:03:19.947Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-selcuk


  8 passing (1m)
```
