### PR TITLE
Add capture_warnings, origin and fingerprint

### DIFF
--- a/python/packages/sdk/README.md
+++ b/python/packages/sdk/README.md
@@ -46,7 +46,7 @@ Required setting. Id of your organization in Serverless Console.
 
 ##### `SLS_DISABLE_CAPTURED_EVENTS_STDOUT` (or `options.disableCapturedEventsStdout`)
 
-Disable writing captured events registered via `.capture_error` to stdout
+Disable writing captured events registered via `.capture_error` and `.capture_warning` to stdout
 
 ### Instrumentation
 

--- a/python/packages/sdk/docs/sdk.md
+++ b/python/packages/sdk/docs/sdk.md
@@ -25,6 +25,14 @@ Record captured error. Captured error is sent to Serverless Console backend and 
 - `error` - Captured error
 - `tags` _(object)_ - User tags object. Tag names can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters. Values can be _str_, _bool_, _int_, _float_, _datetime_ or _List_ containing any values of prior listed types
 
+### `.capture_warning(message[, options])`
+
+Record warning. Captured warning is sent to Serverless Console backend and printed to the stdout in structured format (writing to stdout can be disabled with `SLS_DISABLE_CAPTURED_EVENTS_STDOUT` env var)
+
+- `message` - Warning message
+- `tags` _(object)_ - User tags object. Tag names can contain alphanumeric (both lower and upper case), `-`, `_` and `.` characters. Values can be _str_, _bool_, _int_, _float_, _datetime_ or _List_ containing any values of prior listed types
+- `fingerprint` _(str)_ - Console UI groups common warnings by the _fingerprint_, which by default is derived from its message. This can be overriden by passing custom `fingerprint` value
+
 ### `.set_tag(name, value)`
 
 Set custom (user defined) trace tag

--- a/python/packages/sdk/serverless_sdk/__init__.py
+++ b/python/packages/sdk/serverless_sdk/__init__.py
@@ -10,7 +10,9 @@ from .lib import trace
 from .lib.emitter import event_emitter, EventEmitter
 from .lib.tags import Tags, ValidTags
 from .lib.error_captured_event import create as create_error_captured_event
+from .lib.warning_captured_event import create as create_warning_captured_event
 from .lib.error import report as report_error
+from .lib.warning import report as report_warning
 
 
 __all__: Final[List[str]] = [
@@ -51,6 +53,9 @@ class ServerlessSdk:
         self._settings = ServerlessSdkSettings()
         self._custom_tags = Tags()
 
+        self._report_error = report_error
+        self._report_warning = report_warning
+
     def _initialize(self, org_id: Optional[str] = None):
         self.org_id = environ.get(SLS_ORG_ID, default=org_id)
 
@@ -67,6 +72,12 @@ class ServerlessSdk:
     def capture_error(self, error, **kwargs):
         try:
             create_error_captured_event(error, **kwargs)
+        except Exception as ex:
+            report_error(ex)
+
+    def capture_warning(self, message: str, **kwargs):
+        try:
+            create_warning_captured_event(message, **kwargs)
         except Exception as ex:
             report_error(ex)
 

--- a/python/packages/sdk/serverless_sdk/lib/captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/captured_event.py
@@ -25,6 +25,7 @@ class CapturedEvent:
     custom_tags: Tags
     trace_span: Optional[TraceSpan]
     origin: Optional[str]
+    custom_fingerprint: Optional[str]
 
     def __init__(
         self,
@@ -34,6 +35,7 @@ class CapturedEvent:
         custom_tags: Optional[Tags] = None,
         trace_span: Optional[TraceSpan] = None,
         origin: Optional[str] = None,
+        custom_fingerprint: Optional[str] = None,
     ):
         trace_span = trace_span or TraceSpan.resolve_current_span()
         default_timestamp = time.perf_counter_ns()
@@ -46,6 +48,7 @@ class CapturedEvent:
                 "Cannot intialize captured event Start time cannot be set in the future"
             )
         self.timestamp = timestamp or default_timestamp
+        self.custom_fingerprint = custom_fingerprint
 
         self.tags = Tags()
         if tags:
@@ -71,4 +74,5 @@ class CapturedEvent:
             "eventName": self.name,
             "tags": convert_tags_to_protobuf(self.tags),
             "customTags": json.dumps(convert_tags_to_protobuf(self.custom_tags)),
+            "customFingerprint": self.custom_fingerprint,
         }

--- a/python/packages/sdk/serverless_sdk/lib/error.py
+++ b/python/packages/sdk/serverless_sdk/lib/error.py
@@ -36,11 +36,12 @@ def report(error, type: str = "INTERNAL"):
     logger.error(error_data)
 
     try:
-        return create_error_captured_event(
+        create_error_captured_event(
             error_data["message"],
             name=error_data["name"],
             stack=error_data["stack"],
             type="handledSdkUser" if type == "USER" else "handledSdkInternal",
+            origin="pythonConsole",
         )
     except:
         # ignore

--- a/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
@@ -26,6 +26,7 @@ def create(
     name=None,
     stack=None,
     origin: Optional[str] = None,
+    fingerprint: Optional[str] = None,
 ):
     timestamp = timestamp or time.perf_counter_ns()
     tags = tags or Tags()
@@ -34,6 +35,7 @@ def create(
         timestamp=timestamp,
         custom_tags=tags,
         origin=origin,
+        custom_fingerprint=fingerprint,
     )
     _tags = {
         "type": TYPE_MAP[type],
@@ -51,19 +53,20 @@ def create(
     from .. import serverlessSdk
 
     if (
-        origin == "nodeConsole"
+        origin == "pythonConsole"
         or type != "handledUser"
         or serverlessSdk._settings.disable_captured_events_stdout
     ):
         return captured_event
 
-    logger.error(
-        {
-            "source": "serverlessSdk",
-            "type": "ERROR_TYPE_CAUGHT_USER",
-            "name": _tags["name"],
-            "message": _tags["message"],
-            "stack": _tags["stacktrace"],
-        }
-    )
+    error_log_data = {
+        "source": "serverlessSdk",
+        "type": "ERROR_TYPE_CAUGHT_USER",
+        "name": _tags["name"],
+        "message": _tags["message"],
+        "stack": _tags["stacktrace"],
+    }
+    if fingerprint:
+        error_log_data["fingerprint"] = fingerprint
+    logger.error(error_log_data)
     return captured_event

--- a/python/packages/sdk/serverless_sdk/lib/warning.py
+++ b/python/packages/sdk/serverless_sdk/lib/warning.py
@@ -1,0 +1,23 @@
+from .warning_captured_event import create as create_warning_captured_event
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def report(message: str, code, type: str = "INTERNAL"):
+    logger.warning(
+        {
+            "source": "serverlessSdk",
+            "type": f"WARNING_TYPE_SDK_{type}",
+            "message": message,
+            "code": code,
+        }
+    )
+
+    create_warning_captured_event(
+        message,
+        type=("sdkUser" if type == "USER" else "sdkInternal"),
+        origin="pythonConsole",
+        fingerprint=code,
+    )

--- a/python/packages/sdk/serverless_sdk/lib/warning_captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/warning_captured_event.py
@@ -1,0 +1,61 @@
+import logging
+import time
+from typing import Optional
+from .tags import Tags
+from .captured_event import CapturedEvent
+from .stack_trace_string import resolve as resolve_stack_trace_string
+
+
+logger = logging.getLogger(__name__)
+
+
+TYPE_MAP = {
+    "user": 1,
+    "sdkUser": 2,
+    "sdkInternal": 3,
+}
+
+
+def create(
+    message: str,
+    tags: Optional[Tags] = None,
+    type: str = "user",
+    origin: Optional[str] = None,
+    fingerprint: Optional[str] = None,
+):
+    timestamp = time.perf_counter_ns()
+    stack_trace = resolve_stack_trace_string()
+
+    tags = tags or Tags()
+    captured_event = CapturedEvent(
+        "telemetry.warning.generated.v1",
+        timestamp=timestamp,
+        custom_tags=tags,
+        custom_fingerprint=fingerprint,
+        tags={
+            "warning.message": message,
+            "warning.type": TYPE_MAP[type],
+            "warning.stacktrace": stack_trace,
+        },
+        origin=origin,
+    )
+    # to avoid circular dependency, require inline
+    from .. import serverlessSdk
+
+    if (
+        origin == "pythonConsole"
+        or type != "user"
+        or serverlessSdk._settings.disable_captured_events_stdout
+    ):
+        return captured_event
+
+    warn_log_data = {
+        "source": "serverlessSdk",
+        "type": "WARNING_TYPE_USER",
+        "message": message,
+        "stack": stack_trace,
+    }
+    if fingerprint:
+        warn_log_data["fingerprint"] = fingerprint
+    logger.warning(warn_log_data)
+    return captured_event

--- a/python/packages/sdk/tests/lib/test_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_captured_event.py
@@ -12,7 +12,15 @@ def test_captured_event():
     tags = Tags()
     tags.update({"foo": "bar"})
     event_name = "foo.bar.event"
-    captured_event = CapturedEvent(event_name, timestamp=timestamp, custom_tags=tags)
+    fingerprint = "foo_bar"
+    origin = "python-test"
+    captured_event = CapturedEvent(
+        event_name,
+        timestamp=timestamp,
+        custom_tags=tags,
+        custom_fingerprint=fingerprint,
+        origin=origin,
+    )
 
     # when
     protobuf_dict = captured_event.to_protobuf_dict()
@@ -20,10 +28,14 @@ def test_captured_event():
     # then
     assert protobuf_dict == {
         "id": captured_event.id,
-        "traceId": captured_event.trace_span.trace_id,
-        "spanId": captured_event.trace_span.id,
+        "traceId": captured_event.trace_span.trace_id
+        if captured_event.trace_span
+        else None,
+        "spanId": captured_event.trace_span.id if captured_event.trace_span else None,
         "timestampUnixNano": to_protobuf_epoch_timestamp(timestamp),
         "eventName": event_name,
         "tags": convert_tags_to_protobuf(captured_event.tags),
         "customTags": json.dumps(convert_tags_to_protobuf(tags)),
+        "customFingerprint": fingerprint,
     }
+    assert captured_event.origin == origin

--- a/python/packages/sdk/tests/lib/test_error.py
+++ b/python/packages/sdk/tests/lib/test_error.py
@@ -17,7 +17,7 @@ def test_error_with_exception(monkeypatch):
 
     # when
     with patch.object(logger, "error") as mock_logger:
-        reported_error = report_error(error)
+        report_error(error)
         mock_logger.call_args[0][0].items() <= dict(
             {
                 "source": "serverlessSdk",
@@ -29,12 +29,12 @@ def test_error_with_exception(monkeypatch):
         mock_logger.assert_called_once()
 
     # then
-    assert create_error_captured_event.return_value == reported_error
     create_error_captured_event.assert_called_once_with(
         "Something went wrong",
         name="Exception",
         stack="Exception: Something went wrong\n",
         type="handledSdkInternal",
+        origin="pythonConsole",
     )
 
 
@@ -53,7 +53,7 @@ def test_error_with_custom_object(monkeypatch):
 
     # when
     with patch.object(logger, "error") as mock_logger:
-        reported_error = report_error(error, "USER")
+        report_error(error, "USER")
         mock_logger.call_args[0][0].items() <= dict(
             {
                 "source": "serverlessSdk",
@@ -65,10 +65,9 @@ def test_error_with_custom_object(monkeypatch):
         mock_logger.assert_called_once()
 
     # then
-    assert create_error_captured_event.return_value == reported_error
     create_error_captured_event.assert_called_once()
     create_error_captured_event.assert_called_once_with(
-        str(error), name=ANY, stack=ANY, type="handledSdkUser"
+        str(error), name=ANY, stack=ANY, type="handledSdkUser", origin="pythonConsole"
     )
 
 

--- a/python/packages/sdk/tests/lib/test_warning.py
+++ b/python/packages/sdk/tests/lib/test_warning.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from unittest.mock import MagicMock, patch
+from serverless_sdk.lib.warning import report as report_warning, logger
+import serverless_sdk.lib.error
+
+
+def test_report_warning(monkeypatch):
+    # given
+    warning = "Something went wrong"
+    code = "WARN_CODE"
+    create_warning_captured_event = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.warning,
+        "create_warning_captured_event",
+        create_warning_captured_event,
+    )
+
+    # when
+    with patch.object(logger, "warning") as mock_logger:
+        report_warning(warning, code)
+        mock_logger.call_args[0][0].items() <= dict(
+            {
+                "source": "serverlessSdk",
+                "type": "ERROR_TYPE_CAUGHT_SDK_INTERNAL",
+                "name": "Exception",
+                "message": "Something went wrong",
+            }
+        ).items()
+        mock_logger.assert_called_once()
+
+    # then
+    create_warning_captured_event.assert_called_once_with(
+        "Something went wrong",
+        fingerprint=code,
+        type="sdkInternal",
+        origin="pythonConsole",
+    )

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -6,7 +6,8 @@ import pytest
 from . import get_params
 from serverless_sdk import ServerlessSdk
 from serverless_sdk.base import SLS_ORG_ID
-from serverless_sdk.lib.error_captured_event import TYPE_MAP
+from serverless_sdk.lib.error_captured_event import TYPE_MAP as ERROR_TYPE_MAP
+from serverless_sdk.lib.warning_captured_event import TYPE_MAP as WARNING_TYPE_MAP
 from serverless_sdk.lib.emitter import event_emitter
 
 
@@ -115,7 +116,26 @@ def test_sdk_exposes_capture_error(sdk: ServerlessSdk):
     # then
     assert captured.tags["error.message"] == "My error"
     assert captured.custom_tags["user.tag"] == "somevalue"
-    assert captured.tags["error.type"] == TYPE_MAP["handledUser"]
+    assert captured.tags["error.type"] == ERROR_TYPE_MAP["handledUser"]
+
+
+def test_sdk_exposes_capture_warning(sdk: ServerlessSdk):
+    # given
+    warning = "My warning"
+    captured = None
+
+    def _captured_event_handler(event):
+        nonlocal captured
+        captured = event
+
+    # when
+    sdk._event_emitter.on("captured-event", _captured_event_handler)
+    sdk.capture_warning(warning, tags={"user.tag": "somevalue"})
+
+    # then
+    assert captured.tags["warning.message"] == warning
+    assert captured.custom_tags["user.tag"] == "somevalue"
+    assert captured.tags["warning.type"] == WARNING_TYPE_MAP["user"]
 
 
 def test_sdk_exposes_set_tag(sdk: ServerlessSdk):


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-311/python-sdk-captured-errors-and-warnings-api

### Description
* Add `capture_warning` API.
* Add `fingerprint` parameter.
* Add `origin` parameter
* Fix `nodeConsole` as `pythonConsole`

### Testing done
Unit tested