### PR TITLE
Fix custom tags serialization

### DIFF
--- a/python/packages/sdk/serverless_sdk/lib/trace.py
+++ b/python/packages/sdk/serverless_sdk/lib/trace.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from contextvars import ContextVar
 from backports.cached_property import cached_property  # available in Python >=3.8
 from typing_extensions import Final, Self
+import json
 from .timing import to_protobuf_epoch_timestamp
 from ..base import Nanoseconds, TraceId
 from ..exceptions import (
@@ -215,7 +216,7 @@ class TraceSpan:
             "input": self.input,
             "output": self.output,
             "tags": convert_tags_to_protobuf(self.tags),
-            "customTags": convert_tags_to_protobuf(self.custom_tags),
+            "customTags": json.dumps(self.custom_tags),
         }
 
 

--- a/python/packages/sdk/tests/lib/test_trace_span.py
+++ b/python/packages/sdk/tests/lib/test_trace_span.py
@@ -1,5 +1,6 @@
 import pytest
 import time
+import json
 from serverless_sdk.lib.timing import to_protobuf_epoch_timestamp
 from serverless_sdk.lib.trace import TraceSpan
 
@@ -128,7 +129,7 @@ def test_span_protobuf():
                 "numbers": [12, 23],
             },
         },
-        "customTags": {"elo": "marko"},
+        "customTags": json.dumps({"elo": "marko"}),
     }, "should stringify to JSON"
 
 


### PR DESCRIPTION
### Description
While trying to extend the integration tests, I've realized a difference in how `customTags` are serialized. This fixes the issue, by not converting custom tags and using them as is.

### Testing done
Unit tested
