### PR TITLE
Fix serialization of custom tags on events

### DIFF
--- a/python/packages/sdk/serverless_sdk/lib/captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/captured_event.py
@@ -73,6 +73,6 @@ class CapturedEvent:
             "timestampUnixNano": to_protobuf_epoch_timestamp(self.timestamp),
             "eventName": self.name,
             "tags": convert_tags_to_protobuf(self.tags),
-            "customTags": json.dumps(convert_tags_to_protobuf(self.custom_tags)),
+            "customTags": json.dumps(self.custom_tags),
             "customFingerprint": self.custom_fingerprint,
         }

--- a/python/packages/sdk/tests/lib/test_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_captured_event.py
@@ -10,7 +10,7 @@ def test_captured_event():
     # given
     timestamp = time.perf_counter_ns()
     tags = Tags()
-    tags.update({"foo": "bar"})
+    tags.update({"foo.bar": "baz"})
     event_name = "foo.bar.event"
     fingerprint = "foo_bar"
     origin = "python-test"
@@ -35,7 +35,7 @@ def test_captured_event():
         "timestampUnixNano": to_protobuf_epoch_timestamp(timestamp),
         "eventName": event_name,
         "tags": convert_tags_to_protobuf(captured_event.tags),
-        "customTags": json.dumps(convert_tags_to_protobuf(tags)),
+        "customTags": json.dumps(tags),
         "customFingerprint": fingerprint,
     }
     assert captured_event.origin == origin

--- a/python/packages/sdk/tests/lib/test_error_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_error_captured_event.py
@@ -21,7 +21,7 @@ def assert_protobuf_dict(captured_event, tags, fingerprint=None):
         "eventName": "telemetry.error.generated.v1",
         "timestampUnixNano": to_protobuf_epoch_timestamp(captured_event.timestamp),
         "tags": convert_tags_to_protobuf(captured_event.tags),
-        "customTags": json.dumps(convert_tags_to_protobuf(tags)),
+        "customTags": json.dumps(tags),
         "customFingerprint": fingerprint,
     }
 

--- a/python/packages/sdk/tests/lib/test_warning_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_warning_captured_event.py
@@ -21,7 +21,7 @@ def assert_protobuf_dict(captured_event, tags, fingerprint=None):
         "eventName": "telemetry.warning.generated.v1",
         "timestampUnixNano": to_protobuf_epoch_timestamp(captured_event.timestamp),
         "tags": convert_tags_to_protobuf(captured_event.tags),
-        "customTags": json.dumps(convert_tags_to_protobuf(tags)),
+        "customTags": json.dumps(tags),
         "customFingerprint": fingerprint,
     }
 


### PR DESCRIPTION
### Description

Further fix similar to https://github.com/serverless/console/pull/542

Custom tag names should not be processed, should be used as is. Example: "user.tag" should not be converted to:
```
{
  "user": {
    "tag": ...
```

It should appear as is: `{ "user.tag": ... }`