### PR TITLE
Upgrade dependencies and tests

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
-    "serverless-sdk~=0.3.0",
-    "serverless-sdk-schema~=0.1.0",
+    "serverless-sdk~=0.3.2",
+    "serverless-sdk-schema~=0.1.1",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
@@ -21,6 +21,11 @@ def handler(event, context):
         tags={"user.tag": "example", "invocationid": invocation_id},
     )
 
+    sdk.capture_warning(
+        "Captured warning",
+        tags={"user.tag": "example", "invocationid": invocation_id},
+    )
+
     sdk.set_tag("user.tag", f"example:{invocation_id}")
 
     return {


### PR DESCRIPTION
### Description
* Switch to latest version of sdk and sdk-schema
* Add tests covering `capture_warning` API

### Testing done
Integration tested:

```
➜  node git:(integration-tests-for-new-stuff) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-17T14:56:07.121Z ℹ test test uid: cihan


  Python: integration
2023-03-17T14:56:07.221Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-17T14:56:38.437Z ℹ test Process function success-v3-8
2023-03-17T14:56:38.439Z ℹ test Process function success-v3-9
2023-03-17T14:56:38.440Z ℹ test Process function error-v3-8
2023-03-17T14:56:38.440Z ℹ test Process function error-v3-9
2023-03-17T14:56:38.440Z ℹ test Process function error_unhandled-v3-8
2023-03-17T14:56:38.441Z ℹ test Process function error_unhandled-v3-9
2023-03-17T14:56:38.441Z ℹ test Process function sdk-v3-8
2023-03-17T14:56:38.441Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (30377ms)
    ✔ success-v3-9
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
2023-03-17T14:57:08.837Z ℹ test Cleanup test-python-sdk-cihan
2023-03-17T14:57:09.186Z ℹ test Deleted 5 version of the layer test-python-sdk-cihan-internal
2023-03-17T14:57:10.114Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-17T14:57:10.337Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-17T14:57:10.892Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  8 passing (1m)
```