### PR TITLE
Instrument Python logging module

### DIFF
--- a/python/packages/sdk/README.md
+++ b/python/packages/sdk/README.md
@@ -54,7 +54,7 @@ This package comes with instrumentation for following areas.
 
 _Note: instrumentation is enabled via environment specific SDK instance, relying just on `serverless-sdk` doesn't enable any instrumentation)_
 
-- N/A
+- [Python logging module](docs/instrumentation/python-logging.md)
 
 ### API
 

--- a/python/packages/sdk/docs/instrumentation/python-logging.md
+++ b/python/packages/sdk/docs/instrumentation/python-logging.md
@@ -1,0 +1,5 @@
+# Python [`logging module`](https://docs.python.org/3/library/logging.html) instrumentation
+
+_Disable with `SLS_DISABLE_PYTHON_LOG_MONITORING` environment variable_
+
+All `logging.error` invocations are monitored and propagated as [captured errors](../sdk.md#capture_errorerror-tags) to the Serverless Console

--- a/python/packages/sdk/docs/instrumentation/python-logging.md
+++ b/python/packages/sdk/docs/instrumentation/python-logging.md
@@ -2,4 +2,4 @@
 
 _Disable with `SLS_DISABLE_PYTHON_LOG_MONITORING` environment variable_
 
-All `logging.error` invocations are monitored and propagated as [captured errors](../sdk.md#capture_errorerror-tags) to the Serverless Console
+All `logging.error`, `logging.warning` & `logging.warn` invocations are monitored and propagated as [captured errors](../sdk.md#capture_errorerror-tags) to the Serverless Console

--- a/python/packages/sdk/serverless_sdk/__init__.py
+++ b/python/packages/sdk/serverless_sdk/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import sys
 from os import environ
 from typing import List, Optional
 from typing_extensions import Final
@@ -52,6 +52,7 @@ class ServerlessSdk:
     _settings: ServerlessSdkSettings
     _custom_tags: Tags
     _is_initialized: bool
+    _is_debug_mode: bool
 
     def __init__(self):
         self._is_initialized = False
@@ -67,6 +68,7 @@ class ServerlessSdk:
         if self._is_initialized:
             return
         self.org_id = environ.get(SLS_ORG_ID, default=org_id)
+        self._is_debug_mode = bool(environ.get("SLS_SDK_DEBUG"))
         if not self._settings.disable_python_log_monitoring:
             install_logging()
 
@@ -81,6 +83,10 @@ class ServerlessSdk:
         tags: Optional[Tags] = None,
     ) -> trace.TraceSpan:
         return trace.TraceSpan(name, input, output, start_time, tags)
+
+    def _debug_log(self, *args):
+        if self._is_debug_mode:
+            print("⚡ SDK:", *args, file=sys.stderr)
 
     def capture_error(self, error, **kwargs):
         try:

--- a/python/packages/sdk/serverless_sdk/lib/instrumentation/logging.py
+++ b/python/packages/sdk/serverless_sdk/lib/instrumentation/logging.py
@@ -1,0 +1,84 @@
+from logging import Logger
+
+from ..error import report as report_error
+from ..error_captured_event import create as create_error_captured_event
+from ..warning_captured_event import create as create_warning_captured_event
+
+
+_is_installed = False
+
+
+_original_error = None
+_original_warning = None
+_original_warn = None
+
+
+def _resolve_message(*args) -> str:
+    return args[0] % args[1:]
+
+
+def _error(self, *args, **kwargs):
+    _original_error(self, *args, **kwargs)
+    try:
+        if (
+            len(args) == 1
+            and type(args[0]) is dict
+            and args[0].get("source") == "serverlessSdk"
+        ):
+            return
+        if len(args) == 1 and isinstance(args[0], BaseException):
+            message = args[0]
+        else:
+            message = _resolve_message(*args)
+        create_error_captured_event(message, origin="pythonLogging")
+    except Exception as ex:
+        report_error(ex)
+
+
+def _warning(call_warn: bool = False):
+    def __warning(self, *args, **kwargs):
+        if call_warn:
+            _original_warn(self, *args, **kwargs)
+        else:
+            _original_warning(self, *args, **kwargs)
+
+        try:
+            if (
+                len(args) == 1
+                and type(args[0]) is dict
+                and args[0].get("source") == "serverlessSdk"
+            ):
+                return
+            create_warning_captured_event(
+                _resolve_message(*args), origin="pythonLogging"
+            )
+        except Exception as ex:
+            report_error(ex)
+
+    return __warning
+
+
+def install():
+    global _is_installed
+    if _is_installed:
+        return
+    _is_installed = True
+
+    global _original_error, _original_warning, _original_warn
+    _original_error = Logger.error
+    _original_warning = Logger.warning
+    _original_warn = Logger.warn
+
+    Logger.error = _error
+    Logger.warning = _warning()
+    Logger.warn = _warning(True)
+
+
+def uninstall():
+    global _is_installed
+    if not _is_installed:
+        return
+    Logger.error = _original_error
+    Logger.warning = _original_warning
+    Logger.warn = _original_warn
+    _is_installed = False

--- a/python/packages/sdk/tests/lib/instrumentation/test_logging.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_logging.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import MagicMock
+import serverless_sdk.lib.instrumentation.logging
+import logging
+from serverless_sdk import serverlessSdk
+
+
+@pytest.fixture(autouse=True)
+def instrumentation_setup():
+    serverless_sdk.lib.instrumentation.logging.install()
+    yield
+    serverless_sdk.lib.instrumentation.logging.uninstall()
+
+
+def test_instrument_error(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging, "create_error_captured_event", mock
+    )
+    error = Exception("My error")
+
+    # when
+    logging.error(error)
+
+    # then
+    mock.assert_called_once_with(error, origin="pythonLogging")
+
+
+def test_instrument_error_with_multiple_arguments(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging, "create_error_captured_event", mock
+    )
+    error = "%s %s went wrong"
+    args = ("logging", "test")
+
+    # when
+    logging.error(error, *args, exc_info=True)
+
+    # then
+    mock.assert_called_once_with(error % args, origin="pythonLogging")
+
+
+def test_instrument_warning(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging,
+        "create_warning_captured_event",
+        mock,
+    )
+    message = "My message: %s"
+
+    # when
+    logging.warning(message, "hello")
+
+    # then
+    mock.assert_called_once_with(message % "hello", origin="pythonLogging")
+
+
+def test_instrument_warn(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging,
+        "create_warning_captured_event",
+        mock,
+    )
+    message = "My message: %s"
+
+    # when
+    logging.warn(message, "hello")
+
+    # then
+    mock.assert_called_once_with(message % "hello", origin="pythonLogging")
+
+
+def test_instrument_warning_recognize_sdk_warning(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging,
+        "create_warning_captured_event",
+        mock,
+    )
+    message = "Something is wrong"
+
+    # when
+    logging.warning({"source": "serverlessSdk", "message": message})
+
+    # then
+    mock.assert_not_called()
+
+
+def test_instrument_warning_recognize_sdk_error(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        serverless_sdk.lib.instrumentation.logging,
+        "create_error_captured_event",
+        mock,
+    )
+    message = "Something is wrong"
+
+    # when
+    logging.error({"source": "serverlessSdk", "message": message})
+
+    # then
+    mock.assert_not_called()

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -76,6 +76,7 @@ def test_initialize_favors_env_var(sdk: ServerlessSdk):
 
     environ[SLS_ORG_ID] = env
 
+    sdk._is_initialized = False
     sdk._initialize(org_id=org_id)
     assert sdk.org_id != org_id
     assert sdk.org_id == env


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-623/python-sdk-instrument-pythons-native-logger

### Description
Instrument `.error` & `.warning` methods of Python's native `Logger` class.

### Testing done
Unit & integration tested

```
➜  node git:(main) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-20T09:37:58.284Z ℹ test test uid: cihan


  Python: integration
2023-03-20T09:37:58.392Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-20T09:38:09.316Z ℹ test Process function success-v3-8
2023-03-20T09:38:09.317Z ℹ test Process function success-v3-9
2023-03-20T09:38:09.318Z ℹ test Process function error-v3-8
2023-03-20T09:38:09.319Z ℹ test Process function error-v3-9
2023-03-20T09:38:09.319Z ℹ test Process function error_unhandled-v3-8
2023-03-20T09:38:09.320Z ℹ test Process function error_unhandled-v3-9
2023-03-20T09:38:09.320Z ℹ test Process function sdk-v3-8
2023-03-20T09:38:09.320Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (28456ms)
    ✔ success-v3-9 (2693ms)
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
2023-03-20T09:38:40.496Z ℹ test Cleanup test-python-sdk-cihan
2023-03-20T09:38:40.852Z ℹ test Deleted 8 version of the layer test-python-sdk-cihan-internal
2023-03-20T09:38:40.862Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-20T09:38:41.085Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-20T09:38:41.091Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  8 passing (43s)
```

