### PR TITLE
Fix init phase logging and error reporting

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
-    "serverless-sdk~=0.3.2",
+    "serverless-sdk~=0.3.3",
     "serverless-sdk-schema~=0.1.1",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -33,7 +33,6 @@ TraceSpans.aws_lambda_initialization = next(
 
 
 baseSdk._is_dev_mode = bool(os.environ.get("SLS_DEV_MODE_ORG_ID"))
-baseSdk._is_debug_mode = bool(os.environ.get("SLS_SDK_DEBUG"))
 
 
 class AwsLambdaTraceSpans(TraceSpans):
@@ -45,7 +44,6 @@ class AwsLambdaTraceSpans(TraceSpans):
 class AwsLambdaSdk(ServerlessSdk):
     trace_spans: AwsLambdaTraceSpans
     _is_dev_mode: bool
-    _is_debug_mode: bool
 
 
 serverlessSdk: AwsLambdaSdk = baseSdk

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -204,8 +204,8 @@ class Instrumenter:
                 diff = int((time.perf_counter_ns() - request_start_time) / 1000_000)
                 debug_log("Overhead duration: Internal request:" + f"{diff}ms")
 
-            except Exception:
-                logger.exception("Unhandled exception during instrumentation.")
+            except Exception as ex:
+                serverlessSdk._report_error(ex)
                 return user_handler(event, context)
 
             # Invocation of customer code

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
@@ -69,10 +69,11 @@ def initialize(handler: Optional[str] = HANDLER):
         handler = handler.replace("/", ".")
 
         if not SLS_ORG_ID:
-            logger.error(
+            print(
                 "Serverless SDK Warning: "
                 "Cannot instrument function: "
                 'Missing "SLS_ORG_ID" environment variable',
+                file=sys.stderr,
             )
             return
 
@@ -137,8 +138,9 @@ def initialize(handler: Optional[str] = HANDLER):
 
         debug_log(f"Overhead duration: Internal initialization: {ms}ms")
     except Exception:
-        logger.exception(
+        print(
             "Fatal Serverless SDK Error: "
             "Please report at https://github.com/serverless/console/issues: "
-            "Internal extension setup failed."
+            "Internal extension setup failed.",
+            file=sys.stderr,
         )

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/base.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from os import environ
 from pathlib import Path
 from typing import Optional, Tuple
@@ -42,19 +41,14 @@ LAMBDA_TASK_ROOT: Final[Optional[str]] = environ.get(Env.LAMBDA_TASK_ROOT)
 
 # Serverless env vars
 SLS_ORG_ID: Final[Optional[str]] = environ.get(Env.SLS_ORG_ID)
-SLS_SDK_DEBUG: Final[Optional[str]] = environ.get(Env.SLS_SDK_DEBUG)
+_is_debug_mode: Final[bool] = bool(environ.get(Env.SLS_SDK_DEBUG))
 
 DEFAULT_TASK_ROOT: Final[str] = "/var/task"
 
 
-logger = logging.getLogger(__name__)
-
-if SLS_SDK_DEBUG:
-    logger.setLevel(logging.DEBUG)
-
-
 def debug_log(msg):
-    return logger.debug(f"⚡ SDK: {msg}")
+    if _is_debug_mode:
+        print(f"⚡ SDK: {msg}", file=sys.stderr)
 
 
 def initialize(handler: Optional[str] = HANDLER):

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
@@ -60,8 +60,7 @@ def _get_sdk() -> ServerlessSdk:
     try:
         sdk._initialize()
     except Exception as ex:
-        # TODO: call _reportError on sdk
-        logging.error(ex)
+        sdk._report_error(ex)
 
     return sdk
 
@@ -83,14 +82,13 @@ def _get_instrumented_handler() -> Handler:
     _check_original_handler_and_reset_vars()
 
     handler = _get_handler_function()
-    _get_sdk()
+    sdk = _get_sdk()
 
     try:
         instrumenter = Instrumenter()
         return instrumenter.instrument(handler)
     except Exception as ex:
-        # TODO: call _reportError on sdk
-        logging.error(ex)
+        sdk._report_error(ex)
         return handler
 
 

--- a/python/packages/aws-lambda-sdk/tests/test_internal_extension.py
+++ b/python/packages/aws-lambda-sdk/tests/test_internal_extension.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import pytest
 import os
 
 from typing_extensions import Final


### PR DESCRIPTION
### Description
* Upgrade base sdk to newest version
* Use base sdk's `_is_debug_mode `
* Use "print" for debug logging in init phase and output to `stderr` like in NodeJS SDK.
* Report errors around wrapping and instrumentation with `_report_error` SDK call.

### Testing done
Unit & integration tested:

```
➜  node git:(fix-init-logging) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-20T10:35:32.684Z ℹ test test uid: cihan


  Python: integration
2023-03-20T10:35:32.788Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-20T10:35:45.237Z ℹ test Process function success-v3-8
2023-03-20T10:35:45.238Z ℹ test Process function success-v3-9
2023-03-20T10:35:45.239Z ℹ test Process function success-sampled
2023-03-20T10:35:45.239Z ℹ test Process function error-v3-8
2023-03-20T10:35:45.239Z ℹ test Process function error-v3-9
2023-03-20T10:35:45.240Z ℹ test Process function error_unhandled-v3-8
2023-03-20T10:35:45.240Z ℹ test Process function error_unhandled-v3-9
2023-03-20T10:35:45.240Z ℹ test Process function sdk-v3-8
2023-03-20T10:35:45.241Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (23338ms)
    ✔ success-v3-9
    ✔ success-sampled (5915ms)
    ✔ error-v3-8 (2490ms)
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
2023-03-20T10:36:17.016Z ℹ test Cleanup test-python-sdk-cihan
2023-03-20T10:36:17.359Z ℹ test Deleted 9 version of the layer test-python-sdk-cihan-internal
2023-03-20T10:36:17.359Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-20T10:36:17.591Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-20T10:36:17.606Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  9 passing (45s)
```