### PR TITLE
Test python logging module instrumentation

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -36,6 +36,8 @@ describe('Python: integration', function () {
     isCustomResponse: true,
     capturedEvents: [
       { name: 'telemetry.error.generated.v1', type: 'ERROR_TYPE_CAUGHT_USER' },
+      { name: 'telemetry.error.generated.v1', type: 'ERROR_TYPE_CAUGHT_USER' },
+      { name: 'telemetry.warning.generated.v1', type: 'WARNING_TYPE_USER' },
       { name: 'telemetry.warning.generated.v1', type: 'WARNING_TYPE_USER' },
     ],
     test: ({ invocationsData }) => {
@@ -99,11 +101,36 @@ describe('Python: integration', function () {
           {
             traceId: awsLambdaInvocationSpan.traceId,
             spanId: awsLambdaInvocationSpan.id,
+            eventName: 'telemetry.error.generated.v1',
+            customTags: JSON.stringify({}),
+            tags: {
+              error: {
+                name: 'str',
+                message: 'My error:',
+                type: 2,
+              },
+            },
+          },
+          {
+            traceId: awsLambdaInvocationSpan.traceId,
+            spanId: awsLambdaInvocationSpan.id,
             eventName: 'telemetry.warning.generated.v1',
             customTags: JSON.stringify({ 'user.tag': 'example', 'invocationid': index + 1 }),
             tags: {
               warning: {
                 message: 'Captured warning',
+                type: 1,
+              },
+            },
+          },
+          {
+            traceId: awsLambdaInvocationSpan.traceId,
+            spanId: awsLambdaInvocationSpan.id,
+            eventName: 'telemetry.warning.generated.v1',
+            customTags: JSON.stringify({}),
+            tags: {
+              warning: {
+                message: 'Consoled warning 12 True',
                 type: 1,
               },
             },

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk.py
@@ -1,4 +1,5 @@
 from serverless_sdk import serverlessSdk as sdk
+import logging
 
 
 counter = 0
@@ -21,12 +22,19 @@ def handler(event, context):
         tags={"user.tag": "example", "invocationid": invocation_id},
     )
 
+    try:
+        raise Exception("Consoled error")
+    except Exception:
+        logging.error("My error:", exc_info=True)
+
     sdk.capture_warning(
         "Captured warning",
         tags={"user.tag": "example", "invocationid": invocation_id},
     )
 
     sdk.set_tag("user.tag", f"example:{invocation_id}")
+
+    logging.warning("Consoled warning %s %s", 12, True)
 
     return {
         "name": sdk.name,


### PR DESCRIPTION
Related issue https://github.com/serverless/console/pull/547#issuecomment-1476046057

### Description
Add tests to validate python logging module instrumentation

### Testing done
Unit & integration tested:

```
➜  node git:(integration-test-logging-instrumentation) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-20T13:26:39.025Z ℹ test test uid: cihan


  Python: integration
2023-03-20T13:26:39.126Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-20T13:26:52.231Z ℹ test Process function success-v3-8
2023-03-20T13:26:52.232Z ℹ test Process function success-v3-9
2023-03-20T13:26:52.232Z ℹ test Process function success-sampled
2023-03-20T13:26:52.233Z ℹ test Process function error-v3-8
2023-03-20T13:26:52.233Z ℹ test Process function error-v3-9
2023-03-20T13:26:52.233Z ℹ test Process function error_unhandled-v3-8
2023-03-20T13:26:52.234Z ℹ test Process function error_unhandled-v3-9
2023-03-20T13:26:52.234Z ℹ test Process function sdk-v3-8
2023-03-20T13:26:52.234Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (26917ms)
    ✔ success-v3-9
    ✔ success-sampled (1297ms)
    ✔ error-v3-8 (3494ms)
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
2023-03-20T13:27:23.983Z ℹ test Cleanup test-python-sdk-cihan
2023-03-20T13:27:24.305Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-20T13:27:24.317Z ℹ test Deleted 13 version of the layer test-python-sdk-cihan-internal
2023-03-20T13:27:24.492Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-20T13:27:24.540Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  9 passing (45s)
```