### PR TITLE
Fix python logging source name

### DIFF
--- a/python/packages/sdk/serverless_sdk/lib/error.py
+++ b/python/packages/sdk/serverless_sdk/lib/error.py
@@ -41,7 +41,7 @@ def report(error, type: str = "INTERNAL"):
             name=error_data["name"],
             stack=error_data["stack"],
             type="handledSdkUser" if type == "USER" else "handledSdkInternal",
-            origin="pythonConsole",
+            origin="pythonLogging",
         )
     except:
         # ignore

--- a/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/error_captured_event.py
@@ -53,7 +53,7 @@ def create(
     from .. import serverlessSdk
 
     if (
-        origin == "pythonConsole"
+        origin == "pythonLogging"
         or type != "handledUser"
         or serverlessSdk._settings.disable_captured_events_stdout
     ):

--- a/python/packages/sdk/serverless_sdk/lib/warning.py
+++ b/python/packages/sdk/serverless_sdk/lib/warning.py
@@ -18,6 +18,6 @@ def report(message: str, code, type: str = "INTERNAL"):
     create_warning_captured_event(
         message,
         type=("sdkUser" if type == "USER" else "sdkInternal"),
-        origin="pythonConsole",
+        origin="pythonLogging",
         fingerprint=code,
     )

--- a/python/packages/sdk/serverless_sdk/lib/warning_captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/warning_captured_event.py
@@ -43,7 +43,7 @@ def create(
     from .. import serverlessSdk
 
     if (
-        origin == "pythonConsole"
+        origin == "pythonLogging"
         or type != "user"
         or serverlessSdk._settings.disable_captured_events_stdout
     ):

--- a/python/packages/sdk/tests/lib/test_error.py
+++ b/python/packages/sdk/tests/lib/test_error.py
@@ -34,7 +34,7 @@ def test_error_with_exception(monkeypatch):
         name="Exception",
         stack="Exception: Something went wrong\n",
         type="handledSdkInternal",
-        origin="pythonConsole",
+        origin="pythonLogging",
     )
 
 
@@ -67,7 +67,7 @@ def test_error_with_custom_object(monkeypatch):
     # then
     create_error_captured_event.assert_called_once()
     create_error_captured_event.assert_called_once_with(
-        str(error), name=ANY, stack=ANY, type="handledSdkUser", origin="pythonConsole"
+        str(error), name=ANY, stack=ANY, type="handledSdkUser", origin="pythonLogging"
     )
 
 

--- a/python/packages/sdk/tests/lib/test_error_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_error_captured_event.py
@@ -80,7 +80,7 @@ def test_create_error_captured_event_from_python_console():
     # given
     error = Exception("Captured error")
     tags = {"user.tag": "example"}
-    origin = "pythonConsole"
+    origin = "pythonLogging"
 
     # when
     with mock.patch.object(logger, "error") as mock_logger:

--- a/python/packages/sdk/tests/lib/test_warning.py
+++ b/python/packages/sdk/tests/lib/test_warning.py
@@ -33,5 +33,5 @@ def test_report_warning(monkeypatch):
         "Something went wrong",
         fingerprint=code,
         type="sdkInternal",
-        origin="pythonConsole",
+        origin="pythonLogging",
     )

--- a/python/packages/sdk/tests/lib/test_warning_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_warning_captured_event.py
@@ -77,7 +77,7 @@ def test_create_warning_captured_event_from_python_console():
     # given
     message = "Warning message"
     tags = {"user.tag": "example"}
-    origin = "pythonConsole"
+    origin = "pythonLogging"
 
     # when
     with mock.patch.object(logger, "warning") as mock_logger:


### PR DESCRIPTION
### Description
While trying out the latest officially published layer `arn:aws:lambda:eu-west-1:177335420605:layer:sls-sdk-python-v0-1-9:1` I've noticed my `logging.error` call resulted in two log lines instead of a single one:

```
[ERROR]	2023-03-20T13:59:55.936Z	e4511c1e-5c22-48d3-a93f-925d8763b334	Hello world!
[ERROR]	2023-03-20T13:59:55.937Z	e4511c1e-5c22-48d3-a93f-925d8763b334	{'source': 'serverlessSdk', 'type': 'ERROR_TYPE_CAUGHT_USER', 'name': 'str', 'message': 'Hello world!', 'stack': '  File "/opt/sls-sdk-python/exec_wrapper.py", line 25, in <module>\n    main()\n  File "/opt/sls-sdk-python/exec_wrapper.py", line 21, in main\n    bootstrap.main()\n  File "/var/runtime/bootstrap.py", line 57, in main\n    awslambdaricmain.main([os.environ["LAMBDA_TASK_ROOT"], os.environ["_HANDLER"]])\n  File "/var/runtime/awslambdaric/__main__.py", line 21, in main\n    bootstrap.run(app_root, handler, lambda_runtime_api_addr)\n  File "/var/runtime/awslambdaric/bootstrap.py", line 405, in run\n    handle_event_request(\n  File "/var/runtime/awslambdaric/bootstrap.py", line 149, in handle_event_request\n    response = request_handler(event, lambda_context)\n  File "/opt/python/serverless_aws_lambda_sdk/instrument/__init__.py", line 213, in stub\n    result = user_handler(event, context)\n  File "/var/task/mymodule/lambda_function.py", line 7, in lambda_handler\n    logging.error("Hello world!")\n  File "/var/lang/lib/python3.9/logging/__init__.py", line 2064, in error\n    root.error(msg, *args, **kwargs)\n'}
```

As you can see, the second line is from `create_error_captured_event`, but it should have skipped the logging part as this is already logged. The problem is that I was using `pythonConsole` as the source name in the base SDK, but the lambda SDK refers to the same source as `pythonLogging`.

I think it makes more sense to stick to `pythonLogging` as we are instrumenting the logging module in Python, so this fixes the base SDK to use the correct source for these logs.

### Testing done
Unit & integration tested.

```
➜  node git:(fix-python-logging-source-name) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-20T14:11:03.119Z ℹ test test uid: cihan


  Python: integration
2023-03-20T14:11:03.207Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-20T14:11:16.055Z ℹ test Process function success-v3-8
2023-03-20T14:11:16.057Z ℹ test Process function success-v3-9
2023-03-20T14:11:16.057Z ℹ test Process function success-sampled
2023-03-20T14:11:16.057Z ℹ test Process function error-v3-8
2023-03-20T14:11:16.058Z ℹ test Process function error-v3-9
2023-03-20T14:11:16.058Z ℹ test Process function error_unhandled-v3-8
2023-03-20T14:11:16.058Z ℹ test Process function error_unhandled-v3-9
2023-03-20T14:11:16.058Z ℹ test Process function sdk-v3-8
2023-03-20T14:11:16.059Z ℹ test Process function sdk-v3-9
    ✔ success-v3-8 (26429ms)
    ✔ success-v3-9
    ✔ success-sampled
    ✔ error-v3-8
    ✔ error-v3-9 (423ms)
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9 (3157ms)
2023-03-20T14:11:46.105Z ℹ test Cleanup test-python-sdk-cihan
2023-03-20T14:11:46.451Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-20T14:11:46.499Z ℹ test Deleted 15 version of the layer test-python-sdk-cihan-internal
2023-03-20T14:11:46.648Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-20T14:11:46.682Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  9 passing (43s)
```

### TODO
I'll try to validate the expected single log in a unit test, this test will belong to the lambda SDK package. Will be provided in a separate PR.