### PR TITLE
Upgrade & test behind the scenes logging

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
-    "serverless-sdk~=0.3.3",
+    "serverless-sdk~=0.3.4",
     "serverless-sdk-schema~=0.1.1",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11


### PR DESCRIPTION
Related issue https://github.com/serverless/console/pull/552

### Description
Upgrade to use the latest base sdk version to have the logging fix

### Testing done
Reproduced the issue with a unit test and now asserting on the number of actual logging calls made to make sure we are not logging instrumented calls which are already logged by the platform logger.