### PR TITLE
Install optional dependencies for tests

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -57,7 +57,7 @@ jobs:
           cd python/packages/sdk
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 -m pip install . pytest strenum
+          python3 -m pip install '.[tests]'
 
       - name: Run SDK unit tests
         if: steps.pathChanges.outputs.sdk == 'true'
@@ -100,14 +100,13 @@ jobs:
         run: |
           cd python/packages/sdk-schema
           source .venv/bin/activate
-          python3 -m pip install .
+          python3 -m pip install '.[tests]'
 
       - name: Run SDK Schema unit tests
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
           source .venv/bin/activate
-          python3 -m pip install pytest
           python3 -m pytest
 
       - name: Install AWS Lambda SDK project and dependencies
@@ -116,7 +115,7 @@ jobs:
           cd python/packages/aws-lambda-sdk
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 -m pip install . pytest strenum
+          python3 -m pip install '.[tests]'
 
       - name: Run AWS Lambda SDK unit tests
         if: steps.pathChanges.outputs.awsLambdaSdk == 'true'

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -90,7 +90,7 @@ jobs:
           cd python/packages/sdk
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 -m pip install . pytest strenum
+          python3 -m pip install '.[tests]'
 
       - name: Run SDK unit tests
         if: steps.pathChanges.outputs.sdk == 'true'
@@ -133,14 +133,13 @@ jobs:
         run: |
           cd python/packages/sdk-schema
           source .venv/bin/activate
-          python3 -m pip install .
+          python3 -m pip install '.[tests]'
 
       - name: Run SDK Schema unit tests
         if: steps.pathChanges.outputs.sdkSchema == 'true' || steps.pathChanges.outputs.proto == 'true'
         run: |
           cd python/packages/sdk-schema
           source .venv/bin/activate
-          python3 -m pip install pytest
           python3 -m pytest
 
       - name: Install AWS Lambda SDK project and dependencies
@@ -149,7 +148,7 @@ jobs:
           cd python/packages/aws-lambda-sdk
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 -m pip install . pytest strenum
+          python3 -m pip install '.[tests]'
 
       - name: Run AWS Lambda SDK unit tests
         if: steps.pathChanges.outputs.awsLambdaSdk == 'true'

--- a/python/packages/aws-lambda-sdk/tests/README.md
+++ b/python/packages/aws-lambda-sdk/tests/README.md
@@ -9,8 +9,7 @@ cd python/packages/aws-lambda-sdk
 python3 -m venv .venv
 source .venv/bin/activate
 
-python3 -m pip install --editable .
-python3 -m pip install pytest strenum
+python3 -m pip install --editable '.[tests]'
 python3 -m pytest
 ```
 

--- a/python/packages/sdk-schema/README.md
+++ b/python/packages/sdk-schema/README.md
@@ -25,6 +25,6 @@ python -m build --wheel --sdist .
 To run the unit tests, replace the last two steps of the `Build` step with these:
 
 ```bash
-pip install . pytest
+pip install '.[tests]'
 python3 -m pytest
 ```


### PR DESCRIPTION
### Description
I've noticed when I added new test dependencies while working on https://github.com/serverless/console/pull/556 they were not installed in the CI/CD. I've fixed the CI flows so that the test dependencies are installed before the tests.

### Testing done
We'll see it in the CI 🤞 