### PR TITLE
Emit span close event

### DIFF
--- a/python/packages/sdk/serverless_sdk/lib/trace.py
+++ b/python/packages/sdk/serverless_sdk/lib/trace.py
@@ -17,6 +17,7 @@ from ..exceptions import (
     PastSpanEndTime,
     FutureSpanEndTime,
 )
+from .emitter import event_emitter
 from .id import generate_id
 from .name import get_resource_name
 from .tags import Tags, convert_tags_to_protobuf
@@ -203,6 +204,7 @@ class TraceSpan:
                 if not found:
                     self._set_ctx(root_span)
 
+        event_emitter.emit("trace-span-close", self)
         return self
 
     def to_protobuf_dict(self):


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-563/python-sdk-support-dev-mode

### Description
Emit "trace-span-close" event when a span closes.

### Testing done
unit tested
