### PR TITLE
Release python base sdk v0.3.6

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.3.6 (2023-03-23)
+
+### Features
+
+- Add `_report_notice` method
+- Emit `trace-span-close` event when a span is closed 
+
 ## 0.3.5 (2023-03-22)
 
 ### Features

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.3.5"
+version = "0.3.6"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Releasing
- Add `_report_notice` method
- Emit `trace-span-close` event when a span is closed 