### PR TITLE
Exceptions during closing of trace should not be reported as user handler crash

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -211,13 +211,14 @@ class Instrumenter:
             # Invocation of customer code
             try:
                 result = user_handler(event, context)
-                self._close_trace("success", result)
-                return result
             except BaseException as ex:  # catches all exceptions, including SystemExit.
                 if isinstance(ex, Exception):
                     self._close_trace("error:handled", ex)
                 else:
                     self._close_trace("error:unhandled", ex)
                 raise
+
+            self._close_trace("success", result)
+            return result
 
         return stub


### PR DESCRIPTION
Related issue https://github.com/serverless/console/pull/556#discussion_r1146182266

### Description
Do not treat exceptions coming from `_close_trace` as user handler exceptions.

### Testing done
Unit tested