### PR TITLE
Remove pydantic dependency

### DIFF
--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -17,8 +17,6 @@ dependencies = [
     "blinker>=1.5",
     "importlib_metadata>=5.2", # included in Python >=3.8
     "js-regex<1.1.0,>=1.0.1",
-    "pydantic>=1.10.4",
-    "pyhumps>=3.8",
     "typing-extensions>=4.4", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
I've noticed two dependencies we list but we don't use. Removal of these (pydantic is huge and pulls other transitive dependencies as well) reduces the layer size from 5.6M down to 1.2M.

### Testing done
Integration tested.
