### PR TITLE
SDK: Fix resolution of url data from `options.path` in HTTP instrumentation

### DIFF
--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -164,9 +164,19 @@ const install = (protocol, httpModule) => {
 
     if (typeof options === 'function') {
       --cbIndex;
-      options = url || {};
+      options = { ...url };
     } else {
-      options = Object.assign(url || {}, options);
+      options = { ...url, ...options };
+    }
+    if (options.path) {
+      try {
+        const resolvedUrl = new URL(options.path, 'http://localhost');
+        options.pathname = resolvedUrl.pathname;
+        options.search = resolvedUrl.search;
+      } catch {
+        shouldIgnoreFollowingRequest = false;
+        return originalRequest.apply(this, args);
+      }
     }
 
     const originalCb = args[cbIndex];

--- a/node/packages/sdk/test/unit/instrumentation/express-app.test.js
+++ b/node/packages/sdk/test/unit/instrumentation/express-app.test.js
@@ -15,7 +15,7 @@ describe('instrumentation/expres-app.js', () => {
     delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
   });
 
-  it('should instrument `console.error`', () => {
+  it('should instrument express app', () => {
     const app = express();
     // Sanity check
     instrumentExpressApp.install(app)();

--- a/node/packages/sdk/test/unit/lib/instrumentation/http.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/http.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const http = require('http');
+const { expect } = require('chai');
+
+const requireUncached = require('ncjsm/require-uncached');
+
+const TEST_SERVER_PORT = 3177;
+
+describe('lib/instrumentation/http.js', () => {
+  let serverlessSdk;
+  let server;
+  let instrumentHttp;
+  before(() => {
+    requireUncached(() => {
+      serverlessSdk = require('../../../../');
+      instrumentHttp = require('../../../../lib/instrumentation/http');
+      instrumentHttp.install();
+      server = http
+        .createServer((request, response) => {
+          request.on('data', () => {});
+          request.on('end', () => {
+            response.writeHead(200, {});
+            response.end('"ok"');
+          });
+        })
+        .listen(TEST_SERVER_PORT);
+      serverlessSdk._createTraceSpan('root');
+    });
+  });
+  after(() => {
+    instrumentHttp.uninstall();
+    server.close();
+    serverlessSdk.traceSpans.root.close();
+    delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
+  });
+
+  it('should instrument HTTP', async () => {
+    let httpRequestSpan;
+    serverlessSdk._eventEmitter.once(
+      'trace-span-close',
+      (traceSpan) => (httpRequestSpan = traceSpan)
+    );
+    await new Promise((resolve, reject) => {
+      http
+        .request(
+          `http://localhost:${TEST_SERVER_PORT}/other?foo=bar`,
+          { headers: { someHeader: 'bar' } },
+          (response) => {
+            let body = '';
+            response.on('data', (data) => {
+              body += data;
+            });
+            response.on('end', () => {
+              resolve(JSON.parse(body));
+            });
+          }
+        )
+        .end()
+        .on('error', reject);
+    });
+    expect(httpRequestSpan.name).to.equal('node.http.request');
+    const { tags } = httpRequestSpan;
+    expect(tags.get('http.method')).to.equal('GET');
+    expect(tags.get('http.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('http.host')).to.equal('localhost:3177');
+    expect(tags.get('http.path')).to.equal('/other');
+    expect(tags.get('http.query_parameter_names')).to.deep.equal(['foo']);
+    expect(tags.get('http.request_header_names')).to.deep.equal(['someHeader']);
+    expect(tags.get('http.status_code')).to.equal(200);
+  });
+
+  it('should read url details from options', async () => {
+    let httpRequestSpan;
+    serverlessSdk._eventEmitter.once(
+      'trace-span-close',
+      (traceSpan) => (httpRequestSpan = traceSpan)
+    );
+    await new Promise((resolve, reject) => {
+      http
+        .request(
+          {
+            hostname: 'localhost',
+            pathname: '/other',
+            port: TEST_SERVER_PORT,
+            search: '?foo=bar',
+            headers: { someHeader: 'bar' },
+          },
+          (response) => {
+            let body = '';
+            response.on('data', (data) => {
+              body += data;
+            });
+            response.on('end', () => {
+              resolve(JSON.parse(body));
+            });
+          }
+        )
+        .end()
+        .on('error', reject);
+    });
+    expect(httpRequestSpan.name).to.equal('node.http.request');
+    const { tags } = httpRequestSpan;
+    expect(tags.get('http.method')).to.equal('GET');
+    expect(tags.get('http.protocol')).to.equal('HTTP/1.1');
+    expect(tags.get('http.host')).to.equal('localhost:3177');
+    expect(tags.get('http.path')).to.equal('/other');
+    expect(tags.get('http.query_parameter_names')).to.deep.equal(['foo']);
+    expect(tags.get('http.request_header_names')).to.deep.equal(['someHeader']);
+    expect(tags.get('http.status_code')).to.equal(200);
+  });
+});


### PR DESCRIPTION
Reported internally by @Danwakeem 

Apparently `options.path` was not read for tags resolution (just `options.pathname`) and in such case `path` resolved to `/`.

Additionally I've improved test coverage on SDK package side (so far better coverage was provided in AWS Lambda SDK package, but this is a dependent package)