### PR TITLE
Schema: AWS Lambda runtime related tags

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -131,6 +131,8 @@ message AwsLambdaTags {
   optional AwsLambdaInitializationTags initialization = 104;
   // The AWS Lambda Invocation tags.
   optional AwsLambdaInvocationTags invocation = 105;
+  // The AWS Lambda Runtime tags.
+  optional AwsLambdaRuntimeTags runtime = 107;
 }
 
 // Describe routing of incoming HTTP requests.
@@ -153,6 +155,16 @@ message AwsSnsEventTags {
   string topic_name = 1;
   // Introspected from the events records
   repeated string message_ids = 2;
+}
+
+// Describes the AWS Lambda runtime details
+message AwsLambdaRuntimeTags {
+  // Runtime identifier
+  string identifier = 1;
+  // Runtime version
+  string version = 2;
+  // Runtime ARN
+  string arn = 3;
 }
 
 message AwsLambdaInitializationTags {

--- a/proto/serverless/instrumentation/tags/v1/tags.proto
+++ b/proto/serverless/instrumentation/tags/v1/tags.proto
@@ -78,4 +78,6 @@ message SdkTags {
   string name = 1;
   // The version of the Serverless SDK used to instrument.
   string version = 2;
+  // SDK runtime (e.g. nodejs)
+  optional string runtime = 3;
 }


### PR DESCRIPTION
Runtime dedicated schema

@Mmarzex instead of `sdk.language` I've proposed `sdk.runtime` tag. I think it's a better fit, as _language_ may get confused with spoken language (.e.g English). Additionally in case of Node.js we want to set it to `nodejs` and not `javascript`