### PR TITLE
Support only python 3.8+ and remove unnecessary dependencies

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9"]
+        python_version: ["3.8", "3.9"]
     outputs:
       pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
       pathChangedSdk: ${{ steps.pathChanges.outputs.sdk}}
@@ -172,10 +172,10 @@ jobs:
           # Hence we're passing 'serverless-ci' user authentication token
           token: ${{ secrets.USER_GITHUB_TOKEN }}
 
-      - name: Install Python 3.7
+      - name: Install Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: |
             **/pyproject.toml

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9"]
+        python_version: ["3.8", "3.9"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -11,13 +11,10 @@ version = "0.3.7"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "backports.cached-property", # included in Python >=3.8
     "blinker>=1.5",
-    "importlib_metadata>=5.2", # included in Python >=3.8
     "js-regex<1.1.0,>=1.0.1",
-    "typing-extensions>=4.4", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]
 tests = [

--- a/python/packages/sdk/serverless_sdk/base.py
+++ b/python/packages/sdk/serverless_sdk/base.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Union
-
-from importlib_metadata import packages_distributions, version
+from typing import List, Union
+from importlib.metadata import version
 from typing_extensions import Final
 
 
 FIRST: Final[int] = 0
 SLS_ORG_ID: Final[str] = "SLS_ORG_ID"
 
-_packages: Final[Dict[str, List[str]]] = packages_distributions()
-_pkg_name: str = __name__ or __package__
-_pkg_name, *_ = _pkg_name.split(".")
-_distribution: Final[List[str]] = _packages[_pkg_name]
-
 # module metadata
-__name__: Final[str] = _distribution[FIRST]
+__name__: Final[str] = "serverless-sdk"
 __version__: Final[str] = version(__name__)
 
 

--- a/python/packages/sdk/serverless_sdk/lib/captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/captured_event.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
+from functools import cached_property
 from typing import List, Optional
 import time
 import json
-from backports.cached_property import cached_property  # available in Python >=3.8
 from typing_extensions import Final
 from .timing import to_protobuf_epoch_timestamp
 from .id import generate_id

--- a/python/packages/sdk/serverless_sdk/lib/trace.py
+++ b/python/packages/sdk/serverless_sdk/lib/trace.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from collections.abc import Iterable
+from functools import cached_property
 import logging
 import time
 from typing import List, Optional
 from contextvars import ContextVar
-from backports.cached_property import cached_property  # available in Python >=3.8
 from typing_extensions import Final, Self
 import json
 from .timing import to_protobuf_epoch_timestamp


### PR DESCRIPTION
### Description
Related issue https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead

I've found out that a significant amount of time is spent when we import `importlib_metadata` just to extract the package version of our SDKs:

![Screenshot 2023-03-27 at 21 43 24](https://user-images.githubusercontent.com/7043904/228036730-32f4f43d-7ecd-44bf-9b40-9ebc5c735afd.png)

We can remove that dependency and improve both layer size and the init latency. I've also removed other dependencies that are only required for Python3.7, since we support 3.8+.

### Testing done
CI flows should cover testing.