### PR TITLE
[sdk-schema] Support only python 3.8+ and remove unnecessary dependencies

### DIFF
--- a/.github/workflows/python-sdk-schema-publish.yaml
+++ b/.github/workflows/python-sdk-schema-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python and Pip
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
           # ensure project dependencies are cached
           # When using only `pyproject.toml` for dependencies, see:

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -11,10 +11,9 @@ version = "0.1.1"
 description = "The protobuf generated Serverless SDK Schema"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "betterproto<3.0.0,>=2.0.0b5", # This version supports proto3 optional fields
-    "typing-extensions>=4.4", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
Please see https://github.com/serverless/console/pull/570 for context

This PR depends on the merge of https://github.com/serverless/console/pull/570 as that removes Python3.7 from the CI flows.