### PR TITLE
Use importlib.metadata if available

### DIFF
--- a/python/packages/sdk/serverless_sdk/base.py
+++ b/python/packages/sdk/serverless_sdk/base.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
-
 from datetime import datetime
-from typing import Dict, List, Union
-
-from importlib_metadata import packages_distributions, version
+from typing import List, Union
+import sys
 from typing_extensions import Final
 
+if sys.version_info[1] < 8:
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
 
-FIRST: Final[int] = 0
+
 SLS_ORG_ID: Final[str] = "SLS_ORG_ID"
 
-_packages: Final[Dict[str, List[str]]] = packages_distributions()
-_pkg_name: str = __name__ or __package__
-_pkg_name, *_ = _pkg_name.split(".")
-_distribution: Final[List[str]] = _packages[_pkg_name]
-
 # module metadata
-__name__: Final[str] = _distribution[FIRST]
+__name__: Final[str] = "serverless-sdk"
 __version__: Final[str] = version(__name__)
 
 


### PR DESCRIPTION
Related https://github.com/serverless/console/pull/570

### Description
If minor version is 8+, use builtin version function.