### PR TITLE
[Python AWS Lambda SDK] Use importlib.metadata if available

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/base.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/base.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
-
-from typing import Callable, Dict, List, TypeVar
-
-from importlib_metadata import packages_distributions, version
+from typing import Callable, TypeVar
 from typing_extensions import Concatenate, Final, ParamSpec
+import sys
 
-
-FIRST: Final[int] = 0
-
-_packages: Final[Dict[str, List[str]]] = packages_distributions()
-_pkg_name: str = __name__ or __package__
-_pkg_name, *_ = _pkg_name.split(".")
-_distribution: Final[List[str]] = _packages[_pkg_name]
+if sys.version_info[1] < 8:
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
 
 # module metadata
-__name__: Final[str] = _distribution[FIRST]
+__name__: Final[str] = "serverless-aws-lambda-sdk"
 __version__: Final[str] = version(__name__)
 
 NAME: Final[str] = __name__


### PR DESCRIPTION
Related https://github.com/serverless/console/pull/570

### Description
If minor version is 8+, use builtin version function.