### PR TITLE
Use static name for sdk package

### DIFF
--- a/python/packages/sdk/serverless_sdk/base.py
+++ b/python/packages/sdk/serverless_sdk/base.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import List, Union
 
-from importlib_metadata import packages_distributions, version
+from importlib_metadata import version
 from typing_extensions import Final
 
-
-FIRST: Final[int] = 0
 SLS_ORG_ID: Final[str] = "SLS_ORG_ID"
 
-_packages: Final[Dict[str, List[str]]] = packages_distributions()
-_pkg_name: str = __name__ or __package__
-_pkg_name, *_ = _pkg_name.split(".")
-_distribution: Final[List[str]] = _packages[_pkg_name]
-
 # module metadata
-__name__: Final[str] = _distribution[FIRST]
+__name__: Final[str] = "serverless-sdk"
 __version__: Final[str] = version(__name__)
 
 


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead

### Description
`packages_distributions` call is causing some latency which we don't need, we can use the package name as a constant.

### Testing done
Unit & Integration tested