### PR TITLE
chore: Release python sdk-schema v0.2.0

### DIFF
--- a/python/packages/sdk-schema/CHANGELOG.md
+++ b/python/packages/sdk-schema/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.2.0 (2023-03-28)
+
+### ⚠ BREAKING CHANGES
+
+- Switch to protoc compiler instead of betterproto
+
 ### 0.1.1 (2023-03-17)
 
 ### Maintenance Improvements

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk-schema"
-version = "0.1.1"
+version = "0.2.0"
 description = "The protobuf generated Serverless SDK Schema"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Release protobuf changes introduced with https://github.com/serverless/console/pull/576