### PR TITLE
Upgrade sdk schema

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.7"
 dependencies = [
     "aiohttp~=3.8",
     "serverless-sdk~=0.3.6",
-    "serverless-sdk-schema~=0.1.1",
+    "serverless-sdk-schema~=0.2.0",
     "strenum~=0.4",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -137,7 +137,7 @@ class Instrumenter:
         ) = to_request_response_payload(payload_dct)
         return self.event_loop.send_telemetry(
             "request-response",
-            bytes(payload_buffer),
+            payload_buffer.SerializeToString(),
         )
 
     def _report_response(self, response, context, end_time):
@@ -161,7 +161,9 @@ class Instrumenter:
         payload_buffer = (
             serverlessSdk._last_response_buffer
         ) = to_request_response_payload(payload_dct)
-        self.event_loop.send_telemetry("request-response", bytes(payload_buffer))
+        self.event_loop.send_telemetry(
+            "request-response", payload_buffer.SerializeToString()
+        )
 
     def _report_trace(self, is_error_outcome: bool):
         is_sampled_out = (

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
@@ -133,7 +133,7 @@ class EventLoop(Thread):
                 s for s in payload["spans"] if s["name"] != "aws.lambda"
             ]
 
-        self.send_telemetry("trace", bytes(to_trace_payload(payload)))
+        self.send_telemetry("trace", to_trace_payload(payload).SerializeToString())
 
     def _schedule_eventually(self):
         """

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -3,14 +3,8 @@ from google.protobuf import json_format
 
 
 def to_trace_payload(payload_dct: dict) -> TracePayload:
-    payload = json_format.ParseDict(payload_dct, TracePayload())
-    return payload
+    return json_format.ParseDict(payload_dct, TracePayload())
 
 
 def to_request_response_payload(payload_dct: dict) -> RequestResponse:
-    payload = json_format.ParseDict(payload_dct, RequestResponse())
-    if payload_dct["spanId"]:
-        payload.span_id = str.encode(payload_dct["spanId"])
-    if payload_dct["traceId"]:
-        payload.trace_id = str.encode(payload_dct["traceId"])
-    return payload
+    return json_format.ParseDict(payload_dct, RequestResponse())

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -1,33 +1,14 @@
 from serverless_sdk_schema import TracePayload, RequestResponse
+from google.protobuf import json_format
 
 
 def to_trace_payload(payload_dct: dict) -> TracePayload:
-    payload = TracePayload()
-    payload.from_dict(payload_dct)
-    spans = payload_dct["spans"]
-    events = payload_dct["events"]
-    for index, span in enumerate(payload.spans):
-        span.id = str.encode(spans[index]["id"])
-        span.trace_id = str.encode(spans[index]["traceId"])
-        span.parent_span_id = (
-            str.encode(spans[index]["parentSpanId"])
-            if spans[index]["parentSpanId"]
-            else None
-        )
-    for index, event in enumerate(payload.events):
-        event.id = str.encode(events[index]["id"])
-        event.span_id = (
-            str.encode(events[index]["spanId"]) if events[index]["spanId"] else None
-        )
-        event.trace_id = (
-            str.encode(events[index]["traceId"]) if events[index]["traceId"] else None
-        )
+    payload = json_format.ParseDict(payload_dct, TracePayload())
     return payload
 
 
 def to_request_response_payload(payload_dct: dict) -> RequestResponse:
-    payload = RequestResponse()
-    payload.from_dict(payload_dct)
+    payload = json_format.ParseDict(payload_dct, RequestResponse())
     if payload_dct["spanId"]:
         payload.span_id = str.encode(payload_dct["spanId"])
     if payload_dct["traceId"]:

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
@@ -1,6 +1,6 @@
 from typing import List
 from serverless_sdk_schema import TracePayload
-from serverless_sdk_schema.schema.serverless.instrumentation.v1 import Span
+from serverless_sdk_schema.schema.serverless.instrumentation.v1.trace_pb2 import Span
 from ..conftest import TEST_FUNCTION, TEST_ORG
 from .. import context
 
@@ -20,8 +20,11 @@ def assert_trace_payload(trace_payload: TracePayload, spans: List[str], outcome:
     assert trace_payload.sls_tags.org_id == TEST_ORG
     assert trace_payload.sls_tags.service == TEST_FUNCTION
     aws_lambda = [x for x in trace_payload.spans if x.name == "aws.lambda"][0]
-    assert aws_lambda.tags.aws.lambda_.outcome == outcome
-    assert aws_lambda.tags.aws.lambda_.request_id == context.aws_request_id
+    lambda_tag = [
+        val for x, val in aws_lambda.tags.aws.ListFields() if x.name == "lambda"
+    ][0]
+    assert lambda_tag.outcome == outcome
+    assert lambda_tag.request_id == context.aws_request_id
 
     aws_lambda_initialization = [
         x for x in trace_payload.spans if x.name == "aws.lambda.initialization"

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
@@ -204,7 +204,7 @@ def _assert_event(
 ):
     assert event.timestamp_unix_nano < timestamp
     assert event.event_name == event_name
-    if event.tags.error:
+    if event.tags.HasField("error"):
         assert event.tags.error.type == type
         assert event.tags.error.name == error_name
         assert event.tags.error.message == message
@@ -341,8 +341,9 @@ def test_instrument_sdk_sampled_out(
         + (["user.span"] if not sampled_out else []),
         1,
     )
-    assert (sampled_out and trace_payload.custom_tags is None) or (
-        not sampled_out and trace_payload.custom_tags is not None
+
+    assert (sampled_out and not trace_payload.HasField("custom_tags")) or (
+        not sampled_out and trace_payload.HasField("custom_tags")
     )
 
 
@@ -393,9 +394,9 @@ def test_instrument_lambda_success_dev_mode_with_server(
     def handler(request: Request):
         payload_type = request.url.split("/")[-1]
         if payload_type == "request-response":
-            request_response_payloads.append(RequestResponse().parse(request.data))
+            request_response_payloads.append(RequestResponse.FromString(request.data))
         elif payload_type == "trace":
-            trace_payloads.append(TracePayload().parse(request.data))
+            trace_payloads.append(TracePayload.FromString(request.data))
         else:
             raise Exception(f"Unexpected payload type: {payload_type}")
         return Response(str("OK"))


### PR DESCRIPTION
Follow up for https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead

### Description
Upgrade to latest version of sdk schema to benefit from the speed up.

### Testing done
Unit & integration tested

```
➜  node git:(release-python-sdk-schema-v0.2.0) ✗ npx mocha test/python/aws-lambda-sdk/integration.test.js
2023-03-29T07:26:15.440Z ℹ test test uid: cihan


  Python: integration
2023-03-29T07:26:15.541Z ℹ test Creating core resources test-python-sdk-cihan
2023-03-29T07:27:02.198Z ℹ test Process function success-v3-8
2023-03-29T07:27:02.199Z ℹ test Process function success-v3-9
2023-03-29T07:27:02.199Z ℹ test Process function success-sampled
2023-03-29T07:27:02.200Z ℹ test Process function error-v3-8
2023-03-29T07:27:02.200Z ℹ test Process function error-v3-9
2023-03-29T07:27:02.200Z ℹ test Process function error_unhandled-v3-8
2023-03-29T07:27:02.201Z ℹ test Process function error_unhandled-v3-9
2023-03-29T07:27:02.201Z ℹ test Process function sdk-v3-8
2023-03-29T07:27:02.202Z ℹ test Process function sdk-v3-9
2023-03-29T07:27:02.202Z ℹ test Process function sdk-dev-mode
    ✔ success-v3-8 (25557ms)
    ✔ success-v3-9 (547ms)
    ✔ success-sampled
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
    ✔ sdk-dev-mode (442ms)
2023-03-29T07:27:28.775Z ℹ test Cleanup test-python-sdk-cihan
2023-03-29T07:27:29.106Z ℹ test Deleted 51 version of the layer test-python-sdk-cihan-internal
2023-03-29T07:27:29.118Z ℹ test Deleted 32 version of the layer test-python-sdk-cihan-external
2023-03-29T07:27:29.999Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan from test-python-sdk-cihan
2023-03-29T07:27:30.196Z ℹ test Deleted IAM role test-python-sdk-cihan
2023-03-29T07:27:30.717Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-cihan


  10 passing (1m)
```