### PR TITLE
Fix error handling in tags

### DIFF
--- a/python/packages/sdk/serverless_sdk/__init__.py
+++ b/python/packages/sdk/serverless_sdk/__init__.py
@@ -129,7 +129,7 @@ class ServerlessSdk:
 
     def set_tag(self, name: str, value: ValidTags):
         try:
-            self._custom_tags[name] = value
+            self._custom_tags._set(name, value)
         except Exception as ex:
             report_error(ex, type="USER")
 

--- a/python/packages/sdk/serverless_sdk/lib/captured_event.py
+++ b/python/packages/sdk/serverless_sdk/lib/captured_event.py
@@ -11,7 +11,7 @@ from .tags import Tags, convert_tags_to_protobuf
 from .trace import TraceSpan
 from ..exceptions import FutureEventTimestamp
 from .emitter import event_emitter
-
+from .error import report as report_error
 
 __all__: Final[List[str]] = [
     "CapturedEvent",
@@ -55,8 +55,11 @@ class CapturedEvent:
             self.tags.update(tags)
 
         self.custom_tags = Tags()
-        if custom_tags:
-            self.custom_tags.update(custom_tags)
+        try:
+            if custom_tags:
+                self.custom_tags._update(custom_tags)
+        except Exception as ex:
+            report_error(ex, type="USER")
 
         self.trace_span = trace_span
         event_emitter.emit("captured-event", self)

--- a/python/packages/sdk/serverless_sdk/lib/error.py
+++ b/python/packages/sdk/serverless_sdk/lib/error.py
@@ -2,7 +2,6 @@ import os
 from builtins import type as builtins_type
 from .stack_trace_string import resolve as resolve_stack_trace_string
 
-from .error_captured_event import create as create_error_captured_event
 import logging
 
 
@@ -36,6 +35,9 @@ def report(error, type: str = "INTERNAL"):
     logger.error(error_data)
 
     try:
+        # Require on spot to avoid otherwise difficult to mitigate circular dependency
+        from .error_captured_event import create as create_error_captured_event
+
         create_error_captured_event(
             error_data["message"],
             name=error_data["name"],

--- a/python/packages/sdk/tests/lib/test_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_captured_event.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 import time
 import json
+from unittest.mock import MagicMock
 from serverless_sdk.lib.captured_event import CapturedEvent
 from serverless_sdk.lib.tags import Tags, convert_tags_to_protobuf
 from serverless_sdk.lib.timing import to_protobuf_epoch_timestamp
+import serverless_sdk.lib.captured_event
 
 
 def test_captured_event():
@@ -39,3 +41,40 @@ def test_captured_event():
         "customFingerprint": fingerprint,
     }
     assert captured_event.origin == origin
+
+
+def test_captured_event_invalid_custom_tags(monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(serverless_sdk.lib.captured_event, "report_error", mock)
+    timestamp = time.perf_counter_ns()
+    tags = {"foo- !": "bar"}
+    event_name = "foo.bar.event"
+    fingerprint = "foo_bar"
+    origin = "python-test"
+    captured_event = CapturedEvent(
+        event_name,
+        timestamp=timestamp,
+        custom_tags=tags,
+        custom_fingerprint=fingerprint,
+        origin=origin,
+    )
+
+    # when
+    protobuf_dict = captured_event.to_protobuf_dict()
+
+    # then
+    assert protobuf_dict == {
+        "id": captured_event.id,
+        "traceId": captured_event.trace_span.trace_id
+        if captured_event.trace_span
+        else None,
+        "spanId": captured_event.trace_span.id if captured_event.trace_span else None,
+        "timestampUnixNano": to_protobuf_epoch_timestamp(timestamp),
+        "eventName": event_name,
+        "tags": convert_tags_to_protobuf(captured_event.tags),
+        "customTags": json.dumps({}),
+        "customFingerprint": fingerprint,
+    }
+    assert captured_event.origin == origin
+    mock.assert_called_once()

--- a/python/packages/sdk/tests/lib/test_error.py
+++ b/python/packages/sdk/tests/lib/test_error.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock, patch, ANY
 from serverless_sdk.lib.error import report as report_error, logger
-import serverless_sdk.lib.error
+import serverless_sdk.lib.error_captured_event
 
 
 def test_error_with_exception(monkeypatch):
@@ -10,8 +10,8 @@ def test_error_with_exception(monkeypatch):
     error = Exception("Something went wrong")
     create_error_captured_event = MagicMock()
     monkeypatch.setattr(
-        serverless_sdk.lib.error,
-        "create_error_captured_event",
+        serverless_sdk.lib.error_captured_event,
+        "create",
         create_error_captured_event,
     )
 
@@ -46,8 +46,8 @@ def test_error_with_custom_object(monkeypatch):
     }
     create_error_captured_event = MagicMock()
     monkeypatch.setattr(
-        serverless_sdk.lib.error,
-        "create_error_captured_event",
+        serverless_sdk.lib.error_captured_event,
+        "create",
         create_error_captured_event,
     )
 

--- a/python/packages/sdk/tests/lib/test_warning_captured_event.py
+++ b/python/packages/sdk/tests/lib/test_warning_captured_event.py
@@ -55,6 +55,7 @@ def test_create_warning_captured_event():
 
 def test_create_warning_captured_event_disabled(monkeypatch):
     # given
+    serverlessSdk._initialize()
     message = "Warning message"
     tags = {"user.tag": "example"}
     settings = MagicMock()

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from types import MethodType
-
+from unittest.mock import MagicMock
 import pytest
 
 from . import get_params
+import serverless_sdk
 from serverless_sdk import ServerlessSdk
 from serverless_sdk.base import SLS_ORG_ID
 from serverless_sdk.lib.error_captured_event import TYPE_MAP as ERROR_TYPE_MAP
@@ -170,8 +171,10 @@ def test_sdk_exposes_set_tag(sdk: ServerlessSdk):
     assert sdk._custom_tags[tag_name] == tag_value
 
 
-def test_sdk_set_tag_does_not_crash_on_invalid_input(sdk: ServerlessSdk):
+def test_sdk_set_tag_does_not_crash_on_invalid_input(sdk: ServerlessSdk, monkeypatch):
     # given
+    mock = MagicMock()
+    monkeypatch.setattr(serverless_sdk, "report_error", mock)
     tag_name = ""
     tag_value = "value"
 
@@ -184,6 +187,7 @@ def test_sdk_set_tag_does_not_crash_on_invalid_input(sdk: ServerlessSdk):
 
     # then
     assert not failed
+    mock.assert_called_once()
 
 
 def test_initialize_all_options(sdk: ServerlessSdk, monkeypatch):

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -120,6 +120,25 @@ def test_sdk_exposes_capture_error(sdk: ServerlessSdk):
     assert captured.tags["error.type"] == ERROR_TYPE_MAP["handledUser"]
 
 
+def test_sdk_capture_unhandled_error(sdk: ServerlessSdk):
+    # given
+    error = Exception("My error")
+    captured = None
+
+    def _captured_event_handler(event):
+        nonlocal captured
+        captured = event
+
+    # when
+    sdk._event_emitter.on("captured-event", _captured_event_handler)
+    sdk.capture_error(error, type="unhandled", tags={"user.tag": "somevalue"})
+
+    # then
+    assert captured.tags["error.message"] == "My error"
+    assert captured.custom_tags["user.tag"] == "somevalue"
+    assert captured.tags["error.type"] == ERROR_TYPE_MAP["unhandled"]
+
+
 def test_sdk_exposes_capture_warning(sdk: ServerlessSdk):
     # given
     warning = "My warning"


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-693/tag-validation-error-on-capture-error-is-wrong-type

### Description
We had a bug where we treat a user error as internal SDK error. This was in the `Tags` implementation. Public methods for setting tags will now report a user error. Private methods will raise an exception and we handle them accordingly.

### Testing done
Unit & integration tested