### PR TITLE
fix: Ensure aws-lambda-sdk types match aws-sdk

### DIFF
--- a/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
+++ b/node/packages/aws-lambda-sdk/.ts-types/index.d.ts
@@ -18,4 +18,5 @@ interface AwsLambdaSdk extends Sdk {
   instrumentation: AwsLambdaInstrumentation;
 }
 
-export default AwsLambdaSdk;
+declare const sdk: AwsLambdaSdk;
+export default sdk;


### PR DESCRIPTION
When we fixed the [types for serverless-sdk](https://github.com/serverless/console/pull/371). We never applied this fix to the `serverless-lambda-sdk`. 