### PR TITLE
chore: Release python base sdk v0.3.10

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.3.10 (2023-04-04)
+
+### Maintenance Improvements
+
+- Rename module as `sls_sdk` and alias public api as `serverless_sdk`
+
 ## 0.3.9 (2023-04-04)
 
 - Revert breaking rename of package module from `serverless_sdk` to `sls_sdk`

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.3.9"
+version = "0.3.10"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related to https://linear.app/serverless/issue/SC-708/urgent-python-sdk-breaking-customers-functions#comment-369500ac