### PR TITLE
Fix generated IDs

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -3,7 +3,22 @@ from google.protobuf import json_format
 
 
 def to_trace_payload(payload_dct: dict) -> TracePayload:
-    return json_format.ParseDict(payload_dct, TracePayload())
+    spans = payload_dct["spans"]
+    events = payload_dct["events"]
+    payload = json_format.ParseDict(payload_dct, TracePayload())
+    for index, span in enumerate(payload.spans):
+        span.id = bytes(spans[index]["id"], "utf-8")
+        span.trace_id = bytes(spans[index]["traceId"], "utf-8")
+        if spans[index]["parentSpanId"]:
+            span.parent_span_id = bytes(spans[index]["parentSpanId"], "utf-8")
+    for index, event in enumerate(payload.events):
+        event.id = bytes(events[index]["id"], "utf-8")
+        if events[index]["spanId"]:
+            event.span_id = bytes(events[index]["spanId"], "utf-8")
+        if events[index]["traceId"]:
+            event.trace_id = bytes(events[index]["traceId"], "utf-8")
+
+    return payload
 
 
 def to_request_response_payload(payload_dct: dict) -> RequestResponse:

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
@@ -45,3 +45,23 @@ def assert_trace_payload(trace_payload: TracePayload, spans: List[str], outcome:
 
     if outcome != 1:
         assert_error_event(trace_payload, aws_lambda_invocation, outcome)
+
+    [assert_hexadecimal(s.id) for s in trace_payload.spans]
+    [assert_hexadecimal(s.trace_id) for s in trace_payload.spans]
+    [
+        assert_hexadecimal(s.parent_span_id)
+        for s in trace_payload.spans
+        if s.parent_span_id
+    ]
+    [assert_hexadecimal(e.id) for e in trace_payload.events]
+    [assert_hexadecimal(e.trace_id) for e in trace_payload.events]
+    [assert_hexadecimal(e.span_id) for e in trace_payload.events]
+
+
+def assert_hexadecimal(id):
+    assert isinstance(id, bytes)
+    try:
+        assert int(id, 16)
+    except ValueError:
+        assert False
+    assert len(id) == 32


### PR DESCRIPTION
### Description
While working on https://linear.app/serverless/issue/SC-768/python-sdk-not-capturing-events-in-devmode-in-some-cases I've noticed that the IDs in reported by Python SDK are not formatted correctly

##### Bad Example:
```
spans {
  id: "\327\237{w\2768i\357\034sO9}\257^\345\307\236\355\327<u\266\274"
  trace_id: "\335\277}\343W\274\353\256\032i\276v\335\3556\345\335\265\365\376\232\345\276\375"
  name: "aws.lambda"
  start_time_unix_nano: 1680763654739145823
  end_time_unix_nano: 1680763655718071692
  tags {
    aws {
      lambda {
        arch: "x86_64"
        is_coldstart: true
        name: "test-dev-mode-python"
        request_id: "eb58a6f5-9f3d-4589-b772-21451d1fec4b"
        version: "1"
        outcome: OUTCOME_SUCCESS
      }
    }
  }
  custom_tags: "{}"
}
```

##### Good example:
```
spans {
  id: "7e62dff40b2765b59a6aa196e1e91327"
  trace_id: "6428e9c69f1210fdeb4e94f51ee514ba"
  name: "aws.lambda"
  start_time_unix_nano: 1680764313006769465
  end_time_unix_nano: 1680764313356544757
  tags {
    aws {
      lambda {
        arch: "x86_64"
        is_coldstart: true
        name: "test-new-node"
        request_id: "2f436986-4736-432d-ab1f-572d30ca7e16"
        version: "9"
        outcome: OUTCOME_SUCCESS
      }
    }
  }
}
```

This was encountered previously when we were using betterproto instead of the current protoc compiler and we had a fix. But when we switched to protoc we introduced a regression for these IDs. Protoc compiler is also not serializing the IDs as we need them, which should be a byte array representing 16 digit hex string. I've added a fix similar to the one we had before, which corrects the serialization of the IDs.

### Testing done
* I've reproduced the issue in the unit tests and provided a fix.
* Unit/Integration tested.