### PR TITLE
Match nodejs sdk behaviour for empty custom tags

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/trace.py
+++ b/python/packages/sdk/sls_sdk/lib/trace.py
@@ -208,7 +208,7 @@ class TraceSpan:
         return self
 
     def to_protobuf_dict(self):
-        return {
+        result = {
             "id": self.id,
             "traceId": self.trace_id,
             "parentSpanId": self.parent_span.id if self.parent_span else None,
@@ -218,8 +218,10 @@ class TraceSpan:
             "input": self.input,
             "output": self.output,
             "tags": convert_tags_to_protobuf(self.tags),
-            "customTags": json.dumps(self.custom_tags),
         }
+        if self.custom_tags:
+            result["customTags"] = json.dumps(self.custom_tags)
+        return result
 
 
 def _flatten(xs):

--- a/python/packages/sdk/tests/lib/test_trace_span.py
+++ b/python/packages/sdk/tests/lib/test_trace_span.py
@@ -145,6 +145,35 @@ def test_span_protobuf(sdk):
     }, "should stringify to JSON"
 
 
+def test_span_protobuf_no_custom_tags(sdk):
+    # given
+    from sls_sdk.lib.trace import TraceSpan
+    from sls_sdk.lib.timing import to_protobuf_epoch_timestamp
+
+    parent_span = TraceSpan("parent")
+    child_span = TraceSpan("child")
+    child_span.input = "some input"
+    child_span.output = "some output"
+
+    child_span.close()
+
+    # when
+    proto_dict = child_span.to_protobuf_dict()
+
+    # then
+    assert proto_dict == {
+        "traceId": child_span.trace_id,
+        "parentSpanId": parent_span.id,
+        "id": child_span.id,
+        "name": child_span.name,
+        "startTimeUnixNano": to_protobuf_epoch_timestamp(child_span.start_time),
+        "endTimeUnixNano": to_protobuf_epoch_timestamp(child_span.end_time),
+        "input": child_span.input,
+        "output": child_span.output,
+        "tags": {},
+    }, "should stringify to JSON"
+
+
 def test_creation_of_immediate_descendant_spans(sdk):
     # given
     from sls_sdk.lib.trace import TraceSpan


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-768/python-sdk-not-capturing-events-in-devmode-in-some-cases
* While doing investigation, I've noticed a slight difference in how we report traces. For spans without any custom tags, we were reporting a json string that represents the empty object `{}`. This is now removed and we do not include `custom_tags` field if there are no custom tags, like in NodeJS SDK.

### Testing done
Reproduced in a unit test.

