### PR TITLE
Fix dev-mode trace reporting

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -220,6 +220,11 @@ class Instrumenter:
             f"SERVERLESS_TELEMETRY.T.{base64.b64encode(payload.SerializeToString()).decode('utf-8')}"
         )
 
+    def _flush_and_close_event_loop(self):
+        if self.event_loop:
+            self.event_loop.terminate()
+            self.event_loop = None
+
     def _close_trace(self, outcome: str, outcome_result: Optional[Any] = None):
         self.is_root_span_reset = False
         try:
@@ -254,7 +259,7 @@ class Instrumenter:
 
             if get_invocation_context():
                 self._report_trace(is_error_outcome)
-
+            self._flush_and_close_event_loop()
             self._clear_root_span()
 
             debug_log(
@@ -335,8 +340,6 @@ class Instrumenter:
                     user_handler = user_handler_generator()
                 return self._handler(user_handler, event, context)
             finally:
-                if self.event_loop:
-                    self.event_loop.terminate()
-                    self.event_loop = None
+                self._flush_and_close_event_loop()
 
         return stub

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 import json
 import importlib
 from .. import compare_handlers, context
-from .test_assertions import assert_trace_payload
+from .test_assertions import assert_trace_payload, assert_lambda_tags
 from serverless_sdk_schema import TracePayload, RequestResponse
 import base64
 from werkzeug.wrappers import Request, Response
@@ -479,6 +479,11 @@ def test_instrument_lambda_success_dev_mode_with_server(
         == capture_error_count
     )
 
+    dev_mode_trace_payload_lambda_span = [
+        span for t in trace_payloads for span in t.spans if span.name == "aws.lambda"
+    ][0]
+    assert_lambda_tags(dev_mode_trace_payload_lambda_span, 1)
+
     # when
     request_response_payloads = []
     trace_payloads = []
@@ -509,6 +514,11 @@ def test_instrument_lambda_success_dev_mode_with_server(
         "aws.lambda.invocation",
         "aws.lambda",
     ]
+
+    dev_mode_trace_payload_lambda_span = [
+        span for t in trace_payloads for span in t.spans if span.name == "aws.lambda"
+    ][0]
+    assert_lambda_tags(dev_mode_trace_payload_lambda_span, 1)
 
 
 def test_instrument_lambda_success_close_trace_failure(instrumenter):


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-768/python-sdk-not-capturing-events-in-devmode-in-some-cases
* We were clearing the root span tags for the next invocation, before waiting for the trace to be sent to the dev-mode extension. This was causing the sent trace to miss certain tags, depending on the race condition.

### Testing done
* Reproduced in a unit test and fixed.
* Integration tests are flaky, I've reproduced the flakiness in main as well so I don't think this PR is causing it. @medikoo could you take a look please. This is the error:

```
  10 passing (1m)
  2 failing

  1) Python: integration
       success-sampled:
     Error: Unexpected count of lambda instances: 2023/04/06/[$LATEST]f584b6cdad3145f49078efcbd30ebb0e,2023/04/06/[$LATEST]bbae55c1966b4a19b1460dbf194dd997
      at retrieveReports (test/lib/get-process-function.js:187:17)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async /Users/selcukcihan/serverless/console/node/test/lib/get-process-function.js:434:21

  2) Python: integration
       error-v3-9:
     Error: Unexpected count of lambda instances: 2023/04/06/[$LATEST]91cad5bff6c9441791e20ec5690d6e7c,2023/04/06/[$LATEST]c41ce977e116433789a0bd275d8c711c
      at retrieveReports (test/lib/get-process-function.js:187:17)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async /Users/selcukcihan/serverless/console/node/test/lib/get-process-function.js:434:21
```

When I check the CloudWatch log groups for these functions, I can see that the second invocation was also cold start:

![Screenshot 2023-04-06 at 13 57 15](https://user-images.githubusercontent.com/7043904/230357548-465bb5ff-3451-44b7-8882-4011e663cfcd.png)
![Screenshot 2023-04-06 at 13 57 05](https://user-images.githubusercontent.com/7043904/230357557-40e43b77-1378-41dd-9f5c-e731b6569a50.png)
