### PR TITLE
Ensure logs are json

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/instrumentation/logging.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/logging.py
@@ -1,4 +1,5 @@
 from logging import Logger
+import json
 
 from ..error import report as report_error
 from ..error_captured_event import create as create_error_captured_event
@@ -18,13 +19,13 @@ def _resolve_message(*args) -> str:
 
 
 def _error(self, *args, **kwargs):
-    _original_error(self, *args, **kwargs)
     try:
         if (
             len(args) == 1
             and type(args[0]) is dict
             and args[0].get("source") == "serverlessSdk"
         ):
+            args = (json.dumps(args[0], indent=2),) + args[1:]
             return
         if len(args) == 1 and isinstance(args[0], BaseException):
             message = args[0]
@@ -33,27 +34,30 @@ def _error(self, *args, **kwargs):
         create_error_captured_event(message, origin="pythonLogging")
     except Exception as ex:
         report_error(ex)
+    finally:
+        _original_error(self, *args, **kwargs)
 
 
 def _warning(call_warn: bool = False):
     def __warning(self, *args, **kwargs):
-        if call_warn:
-            _original_warn(self, *args, **kwargs)
-        else:
-            _original_warning(self, *args, **kwargs)
-
         try:
             if (
                 len(args) == 1
                 and type(args[0]) is dict
                 and args[0].get("source") == "serverlessSdk"
             ):
+                args = (json.dumps(args[0], indent=2),) + args[1:]
                 return
             create_warning_captured_event(
                 _resolve_message(*args), origin="pythonLogging"
             )
         except Exception as ex:
             report_error(ex)
+        finally:
+            if call_warn:
+                _original_warn(self, *args, **kwargs)
+            else:
+                _original_warning(self, *args, **kwargs)
 
     return __warning
 

--- a/python/packages/sdk/tests/lib/instrumentation/test_logging.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_logging.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 import sls_sdk.lib.instrumentation.logging
 import logging
-from sls_sdk import serverlessSdk
+import json
 
 
 @pytest.fixture(autouse=True)
@@ -85,13 +85,17 @@ def test_instrument_warning_recognize_sdk_warning(monkeypatch):
         "create_warning_captured_event",
         mock,
     )
+    mock_json = MagicMock()
+    monkeypatch.setattr(json, "dumps", mock_json)
     message = "Something is wrong"
 
     # when
-    logging.warning({"source": "serverlessSdk", "message": message})
+    data = {"source": "serverlessSdk", "message": message}
+    logging.warning(data)
 
     # then
     mock.assert_not_called()
+    mock_json.assert_called_once_with(data, indent=2)
 
 
 def test_instrument_warning_recognize_sdk_error(monkeypatch):
@@ -102,10 +106,14 @@ def test_instrument_warning_recognize_sdk_error(monkeypatch):
         "create_error_captured_event",
         mock,
     )
+    mock_json = MagicMock()
+    monkeypatch.setattr(json, "dumps", mock_json)
     message = "Something is wrong"
 
     # when
-    logging.error({"source": "serverlessSdk", "message": message})
+    data = {"source": "serverlessSdk", "message": message}
+    logging.error(data)
 
     # then
     mock.assert_not_called()
+    mock_json.assert_called_once_with(data, indent=2)

--- a/python/packages/sdk/tests/test_thread_safety.py
+++ b/python/packages/sdk/tests/test_thread_safety.py
@@ -213,7 +213,7 @@ def test_overlapping_spans_async_with_multithreading_large_scale(sdk):
 def test_captured_events_async_with_multithreading(sdk, is_error):
     # given
     parallelism = 5
-    scale = 1000
+    scale = 100
     captured_events = []
 
     def _captured_event_handler(captured_event):


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-768/python-sdk-not-capturing-events-in-devmode-in-some-cases
* Ensure SDK internal logs are json serialized
* Reduce concurrency of multi-threaded test to make it faster to run

### Testing done
Unit/Integration tested.

From the sdk integration test, the logs are now json serialized:
![Screenshot 2023-04-06 at 15 29 30](https://user-images.githubusercontent.com/7043904/230379051-e1b59ebb-e5c7-41a9-9239-4fc1378d4e2f.png)
