### PR TITLE
chore: Release python base sdk version 0.3.11

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.3.11 (2023-04-06)
+
+### Bug Fixes
+
+- Ensure thread-safety of public attributes/methods
+- Do not include `custom_tags` field when there are no custom tags set
+- Write structured logs as json serialized string
+
 ## 0.3.10 (2023-04-04)
 
 ### Maintenance Improvements

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.3.10"
+version = "0.3.11"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related to https://linear.app/serverless/issue/SC-768/python-sdk-not-capturing-events-in-devmode-in-some-cases