### PR TITLE
chore: Release python lambda sdk v0.1.13

### DIFF
--- a/python/packages/aws-lambda-sdk/CHANGELOG.md
+++ b/python/packages/aws-lambda-sdk/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.1.13 (2023-04-06)
+
+### Bug Fixes
+
+- Fix dev-mode trace reporting
+- Fix generated span IDs to be hexadecimal strings
+
+### Maintenance Improvements
+
+- Improve and clean up wrapper logic
+
 ## 0.1.12 (2023-04-05)
 
 ### Bug Fixes

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-aws-lambda-sdk"
-version = "0.1.12"
+version = "0.1.13"
 description = "Serverless AWS Lambda SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-768#comment-7be7634e