### PR TITLE
SDK: Write JSON strings as structured logs

### DIFF
--- a/node/packages/sdk/lib/create-error-captured-event.js
+++ b/node/packages/sdk/lib/create-error-captured-event.js
@@ -53,7 +53,7 @@ module.exports = (error, options = {}) => {
     stack: tags.stacktrace,
   };
   if (options.fingerprint) errorLogData.fingerprint = options.fingerprint;
-  console.error(errorLogData);
+  console.error(JSON.stringify(errorLogData));
 
   return capturedEvent;
 };

--- a/node/packages/sdk/lib/create-warning-captured-event.js
+++ b/node/packages/sdk/lib/create-warning-captured-event.js
@@ -45,7 +45,7 @@ module.exports = (message, options = {}) => {
     stack: stackTrace,
   };
   if (options.fingerprint) warnLogData.fingerprint = options.fingerprint;
-  console.warn(warnLogData);
+  console.warn(JSON.stringify(warnLogData));
 
   return capturedEvent;
 };

--- a/node/packages/sdk/lib/instrumentation/node-console.js
+++ b/node/packages/sdk/lib/instrumentation/node-console.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const isError = require('type/error/is');
-const isPlainObject = require('type/plain-object/is');
 const util = require('util');
 const createErrorCapturedEvent = require('../create-error-captured-event');
 const createWarningCapturedEvent = require('../create-warning-captured-event');
@@ -34,7 +33,13 @@ module.exports.install = () => {
     original.error.apply(this, args);
     try {
       const input = args[0];
-      if (args.length === 1 && isPlainObject(input) && input.source === 'serverlessSdk') return;
+      if (
+        args.length === 1 &&
+        typeof input === 'string' &&
+        input.startsWith('{"source":"serverlessSdk",')
+      ) {
+        return;
+      }
       createErrorCapturedEvent(args.length === 1 && isError(input) ? input : resolveMessage(args), {
         _origin: 'nodeConsole',
       });
@@ -46,7 +51,13 @@ module.exports.install = () => {
   nodeConsole.warn = function (...args) {
     original.warn.apply(this, args);
     try {
-      if (args.length === 1 && isPlainObject(args[0]) && args[0].source === 'serverlessSdk') return;
+      if (
+        args.length === 1 &&
+        typeof args[0] === 'string' &&
+        args[0].startsWith('{"source":"serverlessSdk",')
+      ) {
+        return;
+      }
       createWarningCapturedEvent(resolveMessage(args), { _origin: 'nodeConsole' });
     } catch (error) {
       reportError(error);

--- a/node/packages/sdk/lib/report-error.js
+++ b/node/packages/sdk/lib/report-error.js
@@ -28,7 +28,7 @@ module.exports = (error, options = {}) => {
   errorData.message = message;
   if (error.code) errorData.code = error.code;
   if (error.stack) errorData.stack = resolveStackTraceString(error);
-  console.error(errorData);
+  console.error(JSON.stringify(errorData));
   try {
     // Require on spot to avoid otherwise difficult to mitigate circular dependency
     require('./create-error-captured-event')(errorData.message, {

--- a/node/packages/sdk/lib/report-warning.js
+++ b/node/packages/sdk/lib/report-warning.js
@@ -4,12 +4,14 @@ const createWarningCapturedEvent = require('./create-warning-captured-event');
 
 module.exports = (message, code, options = {}) => {
   const type = options.type || 'INTERNAL';
-  console.warn({
-    source: 'serverlessSdk',
-    type: `WARNING_TYPE_SDK_${type}`,
-    message,
-    code,
-  });
+  console.warn(
+    JSON.stringify({
+      source: 'serverlessSdk',
+      type: `WARNING_TYPE_SDK_${type}`,
+      message,
+      code,
+    })
+  );
   createWarningCapturedEvent(message, {
     _origin: 'nodeConsole',
     _type: type === 'USER' ? 'sdkUser' : 'sdkInternal',

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
@@ -57,7 +57,7 @@ describe('lib/instrumentation/node-console.js', () => {
     let capturedEvent = null;
     serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
     // eslint-disable-next-line no-console
-    console.warn({ source: 'serverlessSdk', message: 'Something is wrong' });
+    console.warn(JSON.stringify({ source: 'serverlessSdk', message: 'Something is wrong' }));
 
     expect(capturedEvent).to.be.null;
   });
@@ -66,15 +66,17 @@ describe('lib/instrumentation/node-console.js', () => {
     let capturedEvent = null;
     serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
     // eslint-disable-next-line no-console
-    console.error({
-      source: 'serverlessSdk',
-      type: 'ERROR_TYPE_CAUGHT_SDK_INTERNAL',
-      description: 'Internal Serverless SDK Error',
-      name: 'Error',
-      message: 'Something failed',
-      code: 'ERROR_CODE',
-      stack: 'at /foo.js:12:1\nat /bar.js:13:1',
-    });
+    console.error(
+      JSON.stringify({
+        source: 'serverlessSdk',
+        type: 'ERROR_TYPE_CAUGHT_SDK_INTERNAL',
+        description: 'Internal Serverless SDK Error',
+        name: 'Error',
+        message: 'Something failed',
+        code: 'ERROR_CODE',
+        stack: 'at /foo.js:12:1\nat /bar.js:13:1',
+      })
+    );
     expect(capturedEvent).to.be.null;
   });
 });


### PR DESCRIPTION
While JS object input also works in CW for structured logging, to ensure consistency among runtimes and follow [AWS guidelines](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html) write structured logs as JSON string