### PR TITLE
Fix serialization of IDs within request-response payload

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -22,4 +22,7 @@ def to_trace_payload(payload_dct: dict) -> TracePayload:
 
 
 def to_request_response_payload(payload_dct: dict) -> RequestResponse:
-    return json_format.ParseDict(payload_dct, RequestResponse())
+    payload = json_format.ParseDict(payload_dct, RequestResponse())
+    payload.span_id = bytes(payload_dct["spanId"], "utf-8")
+    payload.trace_id = bytes(payload_dct["traceId"], "utf-8")
+    return payload

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
@@ -4,7 +4,11 @@ from unittest.mock import patch, MagicMock
 import json
 import importlib
 from .. import compare_handlers, context
-from .test_assertions import assert_trace_payload, assert_lambda_tags
+from .test_assertions import (
+    assert_trace_payload,
+    assert_lambda_tags,
+    assert_hexadecimal,
+)
 from serverless_sdk_schema import TracePayload, RequestResponse
 import base64
 from werkzeug.wrappers import Request, Response
@@ -468,6 +472,9 @@ def test_instrument_lambda_success_dev_mode_with_server(
         (1, event),
         (2, "ok"),
     ]
+    [assert_hexadecimal(r.trace_id) for r in request_response_payloads]
+    [assert_hexadecimal(r.span_id) for r in request_response_payloads]
+
     assert [s.name for t in trace_payloads for s in t.spans] == [
         "aws.lambda.initialization",
         "aws.lambda.invocation",


### PR DESCRIPTION
### Description
While investigating https://linear.app/serverless/issue/SC-768/python-sdk-capture-events-not-structured-logs-in-devmode I've noticed the trace & span IDs are not serialized properly when sending request to dev-mode, this is a similar issue to https://github.com/serverless/console/pull/612 but this time the fix is on the `RequestResponse` type.

### Testing done
* Reproduced the ID problem in a unit test and resolved
* Integration tests are passing as well
