### PR TITLE
fix: Internal layer detection

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -56,8 +56,7 @@ type RuntimeDoneRecord struct {
 	Metrics   MetricsObject    `json:"metrics"`
 }
 
-var wrapper = os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
-var hasInternalExtension = wrapper == "/opt/sls-sdk-node/exec-wrapper.sh"
+var hasInternalExtension = lib.HasInternalExtension()
 
 func FindRequestId(logs []LogItem) string {
 	var requestId string = ""

--- a/go/packages/dev-mode/agent/http.go
+++ b/go/packages/dev-mode/agent/http.go
@@ -94,6 +94,8 @@ func (s *LogsApiHttpListener) Start() (bool, error) {
 // Logging or printing besides the error cases below is not recommended if you have subscribed to receive extension logs.
 // Otherwise, logging here will cause Logs API to send new logs for the printed lines which will create an infinite loop.
 func (h *LogsApiHttpListener) http_handler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Error("Error reading body", zap.Error(err))
@@ -109,6 +111,8 @@ func (h *LogsApiHttpListener) http_handler(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *LogsApiHttpListener) span_http_handler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Error("Error reading body", zap.Error(err))
@@ -130,6 +134,8 @@ func (h *LogsApiHttpListener) span_http_handler(w http.ResponseWriter, r *http.R
 }
 
 func (h *LogsApiHttpListener) req_res_http_handler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Error("Error reading body", zap.Error(err))

--- a/go/packages/dev-mode/lib/helper.go
+++ b/go/packages/dev-mode/lib/helper.go
@@ -1,0 +1,11 @@
+package lib
+
+import (
+	"os"
+	"strings"
+)
+
+func HasInternalExtension() bool {
+	wrapper := os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
+	return strings.HasPrefix(wrapper, "/opt/sls-sdk")
+}

--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -83,8 +83,7 @@ func (e *Extension) ExternalExtension() {
 
 	deferredLogs := []agent.LogItem{}
 
-	wrapper := os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
-	hasInternalExtension := wrapper == "/opt/sls-sdk-node/exec-wrapper.sh"
+	hasInternalExtension := lib.HasInternalExtension()
 
 	// Save the res payload from the SDK so we can send it out at runtime done so we can include the
 	// runtime_duration_ms & runtime_response_latency_ms that is included in the runtime done event


### PR DESCRIPTION
## Description
Fixing internal layer detection so it is generic enough to work for both node, python and any future internal SDKs we provide 😎 

I also updated the internal http handlers to write explicit responses at the top of the handler in the hopes to improve those response times we were seeing to the dev mode extension. Not sure if this will actually help but it definitely cannot hurt 🤷 