### PR TITLE
feat: Adjust default log parsing

### DIFF
--- a/go/packages/dev-mode/lib/helper.go
+++ b/go/packages/dev-mode/lib/helper.go
@@ -9,3 +9,13 @@ func HasInternalExtension() bool {
 	wrapper := os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
 	return strings.HasPrefix(wrapper, "/opt/sls-sdk")
 }
+
+func InternalExtensionRuntime() string {
+	wrapper := os.Getenv("AWS_LAMBDA_EXEC_WRAPPER")
+	if strings.HasPrefix(wrapper, "/opt/sls-sdk-node") {
+		return "node"
+	} else if strings.HasPrefix(wrapper, "/opt/sls-sdk-python") {
+		return "python"
+	}
+	return "unknown"
+}


### PR DESCRIPTION
## Description
We need to adjust the way we detect the default logs because the format in Cloudwatch is different between python and nodejs. I am not sure if I should mark this as a feat or a fix because it is a bug but only because of a new feature 🤔 So I guess I will just mark it as feat 🤷 