### PR TITLE
fix: SC-799 Added capture warning when spans are not closed

### DIFF
--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -110,7 +110,13 @@ serverlessSdk._initialize = (options = {}) => {
   return serverlessSdk;
 };
 
-serverlessSdk._createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
+serverlessSdk._createTraceSpan = (name, options = {}) =>
+  new TraceSpan(
+    name,
+    Object.assign(options, {
+      _reportWarning: reportWarning,
+    })
+  );
 serverlessSdk._reportError = reportError;
 serverlessSdk._reportWarning = reportWarning;
 serverlessSdk._reportNotice = reportNotice;

--- a/node/packages/sdk/lib/trace-span.js
+++ b/node/packages/sdk/lib/trace-span.js
@@ -43,6 +43,7 @@ class TraceSpan {
         );
       }
     }
+    this._reportWarning = options._reportWarning;
     this.startTime = startTime || defaultStartTime;
     this.name = ensureSpanName(name);
 
@@ -85,6 +86,7 @@ class TraceSpan {
       new TraceSpan(immediateDescendants.shift(), {
         startTime: this.startTime,
         immediateDescendants,
+        _reportWarning: this._reportWarning,
       });
     }
   }
@@ -132,10 +134,10 @@ class TraceSpan {
         leftoverSpans.push(subSpan.close({ endTime: this.endTime }));
       }
       if (leftoverSpans.length) {
-        process.stderr.write(
+        const message =
           "Serverless SDK Warning: Following trace spans didn't end before end of " +
-            `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}\n`
-        );
+          `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}\n`;
+        this._reportWarning(message, 'SDK_SPAN_NOT_CLOSED');
       }
       asyncLocalStorage.enterWith(this);
     } else {


### PR DESCRIPTION
## Description
Updated the span not closed warning to produce a warning event

> I will create an integration test for this after I create a new version of the sdk and create the `aws-lambda-sdk` PR to use the new sdk version 👍 