### PR TITLE
[Python] Add sdk runtime tag

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.7"
 dependencies = [
     "aiohttp~=3.8",
     "serverless-sdk~=0.3.11",
-    "serverless-sdk-schema~=0.2.0",
+    "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -120,6 +120,7 @@ class Instrumenter:
                 "sdk": {
                     "name": serverlessSdk.name,
                     "version": serverlessSdk.version,
+                    "runtime": "python",
                 },
             },
             "traceId": self.aws_lambda.trace_id,
@@ -148,6 +149,7 @@ class Instrumenter:
                 "sdk": {
                     "name": serverlessSdk.name,
                     "version": serverlessSdk.version,
+                    "runtime": "python",
                 },
             },
             "traceId": self.aws_lambda.trace_id,
@@ -205,6 +207,7 @@ class Instrumenter:
                 "sdk": {
                     "name": serverlessSdk.name,
                     "version": serverlessSdk.version,
+                    "runtime": "python",
                 },
             },
             "spans": [s for s in map(_map_span, self.aws_lambda.spans) if s],

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
@@ -122,6 +122,7 @@ class EventLoop(Thread):
                 "sdk": {
                     "name": serverlessSdk.name,
                     "version": serverlessSdk.version,
+                    "runtime": "python",
                 },
             },
             "spans": [_convert_span(s) for s in spans],

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_assertions.py
@@ -28,6 +28,9 @@ def assert_lambda_tags(aws_lambda: Span, outcome: int):
 
 
 def assert_trace_payload(trace_payload: TracePayload, spans: List[str], outcome: int):
+    assert trace_payload.sls_tags.sdk.name == "serverless-aws-lambda-sdk"
+    assert trace_payload.sls_tags.sdk.runtime == "python"
+
     assert [s.name for s in trace_payload.spans] == spans
     assert trace_payload.sls_tags.org_id == TEST_ORG
     assert trace_payload.sls_tags.service == TEST_FUNCTION


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-715/python-sdk-expose-the-slstagssdkruntime
* Upgrade to latest sdk-schema package
* Add runtime tag with value `python`

### Testing done
Unit/integration tested