### PR TITLE
feat: Capture Structured Logs as Errors & Warnings

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -15,6 +15,7 @@
     ]
   },
   "devDependencies": {
+    "@aws-lambda-powertools/logger": "^1.8.0",
     "@aws-sdk/client-api-gateway": "^3.306.0",
     "@aws-sdk/client-apigatewayv2": "^3.306.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.306.0",
@@ -37,6 +38,7 @@
     "@serverless/utils": "^6.11.1",
     "@tsconfig/node16": "^1.0.3",
     "adm-zip": "^0.5.10",
+    "bunyan": "^1.8.15",
     "chai": "^4.3.7",
     "chalk": "^4.1.2",
     "child-process-ext": "^2.1.1",
@@ -63,6 +65,7 @@
     "ncjsm": "^4.3.2",
     "node-fetch": "^2.6.9",
     "node-machine-id": "^1.1.12",
+    "pino": "^8.11.0",
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
@@ -77,6 +80,7 @@
     "typescript": "^4.9.5",
     "uni-global": "^1.0.0",
     "uuid": "^9.0.0",
+    "winston": "^3.8.2",
     "yargs-parser": "^21.1.1"
   },
   "scripts": {

--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -103,6 +103,8 @@ serverlessSdk._initialize = (options = {}) => {
   if (!settings.disableNodeConsoleMonitoring) {
     // Auto capture `console.error` and `console.warning` invocations
     require('./lib/instrumentation/node-console').install();
+    // Auto capture structured logs as errors and warnings from stdout & stderr stream
+    require('./lib/instrumentation/node-process-stdout-stderr').install();
   }
 
   if (serverlessSdk._initializeExtension) serverlessSdk._initializeExtension(options);

--- a/node/packages/sdk/lib/instrumentation/node-process-stdout-stderr.js
+++ b/node/packages/sdk/lib/instrumentation/node-process-stdout-stderr.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { attemptParseStructuredLogAndCapture } = require('../structured-log-to-event');
+
+const nodeStdout = process.stdout;
+const nodeStderr = process.stderr;
+
+let isInstalled = false;
+let uninstall;
+
+module.exports.install = () => {
+  if (isInstalled) return;
+  isInstalled = true;
+
+  const original = {
+    stdout: { write: nodeStdout.write },
+    stderr: { write: nodeStderr.write },
+  };
+
+  nodeStdout.write = function (...args) {
+    original.stdout.write.apply(this, args);
+    attemptParseStructuredLogAndCapture(args[0]);
+  };
+
+  nodeStderr.write = function (...args) {
+    original.stderr.write.apply(this, args);
+    attemptParseStructuredLogAndCapture(args[0]);
+  };
+
+  uninstall = () => {
+    nodeStdout.write = original.stdout.write;
+    nodeStderr.write = original.stderr.write;
+  };
+};
+
+module.exports.uninstall = () => {
+  if (!isInstalled) return;
+  isInstalled = false;
+  uninstall();
+};

--- a/node/packages/sdk/lib/structured-log-to-event.js
+++ b/node/packages/sdk/lib/structured-log-to-event.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const isObject = require('type/object/is');
+const { debuglog } = require('util');
+const createErrorCapturedEvent = require('./create-error-captured-event');
+const createWarningCapturedEvent = require('./create-warning-captured-event');
+
+const parseLogLevel = (level) => {
+  if (typeof level === 'string') {
+    const levelUpperCase = level.toUpperCase();
+    if (levelUpperCase !== 'ERROR' && levelUpperCase !== 'WARN') {
+      throw new Error('Unsupported level');
+    }
+    return levelUpperCase;
+  } else if (typeof level === 'number') {
+    if (level <= 30) {
+      throw new Error('Unsupported level');
+    }
+
+    if (level <= 40) {
+      return 'WARN';
+    }
+    return 'ERROR';
+  }
+  throw new Error('Unsupported level');
+};
+
+const highCardinalityAttributes = [
+  'timestamp',
+  'xray_trace_id',
+  'level',
+  'message',
+  'msg',
+  'time',
+  'v',
+  'hostname',
+  'pid',
+];
+const pinoKeys = ['time', 'pid', 'hostname'];
+const errorObjectKeys = ['message', 'stack'];
+
+const handleErrorLog = (logLineParsed) => {
+  // Winston error logs will parse the error into `message` and `stack` keys at the root of the log object.
+  const hasWinstonError = errorObjectKeys.every((key) => key in logLineParsed);
+  // Pino error logs will parse the error into `err` key at the root of the log object.
+  const hasPinoError = 'err' in logLineParsed && pinoKeys.every((key) => key in logLineParsed);
+
+  if (hasWinstonError) {
+    const tags = Object.fromEntries(
+      Object.entries(logLineParsed)
+        .filter(([key]) => ![...highCardinalityAttributes, ...errorObjectKeys].includes(key))
+        .filter(([, value]) => !Array.isArray(value) && typeof value !== 'object')
+    );
+
+    const err = new Error(logLineParsed.message);
+    err.stack = logLineParsed.stack;
+
+    if (logLineParsed.name) {
+      err.name = logLineParsed.name;
+    }
+
+    createErrorCapturedEvent(err, { tags, _origin: 'nodeConsole' });
+  } else if (hasPinoError) {
+    const tags = Object.fromEntries(
+      Object.entries(logLineParsed)
+        .filter(([key]) => ![...highCardinalityAttributes, 'err'].includes(key))
+        .filter(([, value]) => !Array.isArray(value) && typeof value !== 'object')
+    );
+
+    const err = new Error(logLineParsed.err.message);
+    err.stack = logLineParsed.err.stack;
+
+    if (logLineParsed.err.name) {
+      err.name = logLineParsed.err.name;
+    }
+
+    createErrorCapturedEvent(err, { tags, _origin: 'nodeConsole' });
+  } else {
+    // In this case we do best attempt at parsing.
+    // AWS Lambda Powertools will fall in this category.
+    const [errKey, errObj] = Object.entries(logLineParsed).find(
+      ([, value]) => isObject(value) && 'message' in value && 'stack' in value
+    );
+
+    if (!errKey || !errObj) {
+      return;
+    }
+    const tags = Object.fromEntries(
+      Object.entries(logLineParsed)
+        .filter(([key]) => ![...highCardinalityAttributes, errKey].includes(key))
+        .filter(([, value]) => !Array.isArray(value) && typeof value !== 'object')
+    );
+
+    const err = new Error(errObj.message);
+    err.stack = errObj.stack;
+
+    if (errObj.name) {
+      err.name = errObj.name;
+    }
+
+    createErrorCapturedEvent(err, { tags, _origin: 'nodeConsole' });
+  }
+};
+
+const handleWarningLog = (logLineParsed) => {
+  const msg = logLineParsed.msg || logLineParsed.message;
+
+  const tags = Object.fromEntries(
+    Object.entries(logLineParsed)
+      .filter(([key]) => !highCardinalityAttributes.includes(key))
+      .filter(([, value]) => !Array.isArray(value) && typeof value !== 'object')
+  );
+
+  if (msg) {
+    createWarningCapturedEvent(msg, { tags, _origin: 'nodeConsole' });
+  }
+};
+
+module.exports.attemptParseStructuredLogAndCapture = (logLine) => {
+  try {
+    const logLineParsed = JSON.parse(logLine.toString());
+    // console.log(logLineParsed);
+    if ('level' in logLineParsed) {
+      debuglog('LOG LEVEL', logLineParsed.level);
+      const logLevel = parseLogLevel(logLineParsed.level);
+      if (logLevel === 'ERROR') {
+        handleErrorLog(logLineParsed);
+      } else if (logLevel === 'WARN') {
+        handleWarningLog(logLineParsed);
+      }
+    }
+  } catch (err) {
+    // Not a structured logline
+  }
+};

--- a/node/packages/sdk/lib/structured-log-to-event.js
+++ b/node/packages/sdk/lib/structured-log-to-event.js
@@ -119,7 +119,6 @@ const handleWarningLog = (logLineParsed) => {
 module.exports.attemptParseStructuredLogAndCapture = (logLine) => {
   try {
     const logLineParsed = JSON.parse(logLine.toString());
-    // console.log(logLineParsed);
     if ('level' in logLineParsed) {
       debuglog('LOG LEVEL', logLineParsed.level);
       const logLevel = parseLogLevel(logLineParsed.level);

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const { expect } = require('chai');
+const { Logger: PowertoolsLogger } = require('@aws-lambda-powertools/logger');
+const pino = require('pino');
+const winston = require('winston');
+const bunyan = require('bunyan');
+
+const requireUncached = require('ncjsm/require-uncached');
+
+describe('lib/instrumentation/node-console.js', () => {
+  let serverlessSdk;
+  let instrumentNodeConsole;
+  before(() => {
+    requireUncached(() => {
+      serverlessSdk = require('../../../../');
+      instrumentNodeConsole = require('../../../../lib/instrumentation/node-process-stdout-stderr');
+      instrumentNodeConsole.install();
+    });
+  });
+  after(() => {
+    instrumentNodeConsole.uninstall();
+    delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
+  });
+
+  it('should instrument `process.stderr.write` with powertools logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const logger = new PowertoolsLogger({
+      serviceName: 'test-app',
+      persistentLogAttributes: { testtag: 'test tag' },
+    });
+
+    logger.error('Test Error', new Error('My error'));
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+    expect(capturedEvent.customTags.get('service')).to.equal('test-app');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stderr.write` with pino logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = pino();
+
+    const logger = parent.child({ testtag: 'test tag' });
+
+    logger.error(new Error('My error'));
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stderr.write` with winston logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = winston.createLogger({
+      format: winston.format.json(),
+      transports: [new winston.transports.Console()],
+    });
+
+    const logger = parent.child({ testtag: 'test tag' });
+
+    const error = new Error('My error');
+    error.name = 'WinstonError';
+    logger.error('winston error', error);
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('winston error My error');
+    expect(capturedEvent.tags.get('error.name')).to.equal('WinstonError');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stderr.write` with bunyan logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = bunyan.createLogger({ name: 'bunyan-test' });
+    const logger = parent.child({ testtag: 'test tag' });
+
+    const error = new Error('My error');
+    error.name = 'BunyanError';
+    logger.error(error, 'bunyan error');
+    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+    expect(capturedEvent.tags.get('error.name')).to.equal('BunyanError');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stdout.write` with powertools logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const logger = new PowertoolsLogger({
+      serviceName: 'test-app',
+      persistentLogAttributes: { testtag: 'test tag' },
+    });
+
+    logger.warn('Test Warning');
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+    expect(capturedEvent.customTags.get('service')).to.equal('test-app');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stdout.write` with pino logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = pino();
+
+    const logger = parent.child({ testtag: 'test tag' });
+
+    logger.warn('Test Warning');
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stdout.write` with winston logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = winston.createLogger({
+      format: winston.format.json(),
+      transports: [new winston.transports.Console()],
+    });
+
+    const logger = parent.child({ testtag: 'test tag' });
+
+    logger.warn('Test Warning');
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+
+  it('should instrument `process.stdout.write` with bunyan logger', () => {
+    let capturedEvent;
+    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+    const parent = bunyan.createLogger({ name: 'bunyan-test' });
+    const logger = parent.child({ testtag: 'test tag' });
+
+    logger.warn('Test Warning');
+    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+    expect(capturedEvent._origin).to.equal('nodeConsole');
+  });
+});


### PR DESCRIPTION
Introduces instrumentation of `process.stdout.write` and `process.stderr.write` so that we can attempt to capture errors & warning events from popular structured logging libraries. 

It has been tested against,
1. pino
2. winston
3. bunyan
4. AWS Powertools Logger

We are guaranteeing support of those 4 but the logic is in place to attempt parsing of any.

<img width="819" alt="Screen Shot 2023-04-13 at 10 42 32 AM" src="https://user-images.githubusercontent.com/41359/231796128-faa867b4-4a71-4f16-9311-5faf69e77f75.png">
