### PR TITLE
feat: SC-846 Ignore logger library warning and errors

### DIFF
--- a/go/packages/dev-mode/agent/forwarder_test.go
+++ b/go/packages/dev-mode/agent/forwarder_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import "testing"
+
+func TestProcessLoggerLevelWarning(t *testing.T) {
+	fakeLevel1 := interface{}("WARNING")
+	levelOutput1 := ProcessLoggerLevel(fakeLevel1)
+	if levelOutput1 != "WARNING" {
+		t.Errorf("Expected levelOutput to be 'WARNING', got %s", levelOutput1)
+	}
+
+	fakeLevel2 := interface{}("WARN")
+	levelOutput2 := ProcessLoggerLevel(fakeLevel2)
+	if levelOutput2 != "WARN" {
+		t.Errorf("Expected levelOutput to be 'WARN', got %s", levelOutput2)
+	}
+
+	fakeLevel3 := interface{}(35)
+	levelOutput3 := ProcessLoggerLevel(fakeLevel3)
+	if levelOutput3 != "WARN" {
+		t.Errorf("Expected levelOutput to be 'WARN', got %s", levelOutput3)
+	}
+}
+
+func TestProcessLoggerLevelError(t *testing.T) {
+	fakeLevel1 := interface{}("ERROR")
+	levelOutput1 := ProcessLoggerLevel(fakeLevel1)
+	if levelOutput1 != "ERROR" {
+		t.Errorf("Expected levelOutput to be 'ERROR', got %s", levelOutput1)
+	}
+
+	fakeLevel2 := interface{}(41)
+	levelOutput2 := ProcessLoggerLevel(fakeLevel2)
+	if levelOutput2 != "ERROR" {
+		t.Errorf("Expected levelOutput to be 'ERROR', got %s", levelOutput2)
+	}
+}

--- a/go/packages/dev-mode/main_test.go
+++ b/go/packages/dev-mode/main_test.go
@@ -325,7 +325,7 @@ func TestStartInvokeDone(t *testing.T) {
 	extensionPlatformStart(requestId)
 	extensionInvoke(requestId)
 
-	messages := []string{"1 invocation", "2 invocation"}
+	messages := []string{"1 invocation", "2 invocation", "{\"level\": \"WARN\"}"}
 	postLogs(fmt.Sprintf(`[
 		{
 			"type": "function",
@@ -353,6 +353,9 @@ func TestStartInvokeDone(t *testing.T) {
 		}
 		if protoPayload.SlsTags.Service != functionName {
 			t.Errorf("Expected function name %s Received %s", functionName, protoPayload.SlsTags.Service)
+		}
+		if len(protoPayload.LogEvents) != 2 {
+			t.Errorf("Expected log message count %d Received %d", 2, len(protoPayload.LogEvents))
 		}
 		for index, event := range protoPayload.LogEvents {
 			if event.Body != messages[index] {


### PR DESCRIPTION
## Description
I will wait for the `aws-lambda-sdk` release first but this should be all we need to do to ignore library warning/error messages.