### PR TITLE
chore: Release python base sdk version 0.4.0

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.3.12 (2023-04-12)
+## 0.4.0 (2023-04-13)
 
 ### Features
 
 - Instrument http requests
+- Instrument flask
+
+### ⚠ BREAKING CHANGES
+
+- `_sls_ignore` is required to be set for dev-mode telemetry requests
 
 ## 0.3.11 (2023-04-06)
 

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.3.12"
+version = "0.4.0"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-847/python-sdk-internal-error-when-using-serverless-sdk-0312