### PR TITLE
Add extension initialization hook

### DIFF
--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -93,13 +93,13 @@ class ServerlessSdk:
 
     def _initialize(
         self,
+        *args,
         org_id: Optional[str] = None,
         disable_captured_events_stdout: Optional[bool] = False,
         disable_python_log_monitoring: Optional[bool] = False,
         disable_request_response_monitoring: Optional[bool] = False,
         disable_http_monitoring: Optional[bool] = False,
         disable_flask_monitoring: Optional[bool] = False,
-        *args,
         **kwargs,
     ):
         if self._is_initialized:

--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -70,7 +70,7 @@ class ServerlessSdk:
     _event_emitter: EventEmitter
 
     trace_spans: TraceSpans
-    instrumentation: Final = ...
+    instrumentation: Final = SimpleNamespace()
 
     org_id: Optional[str] = None
     _settings: ServerlessSdkSettings
@@ -99,6 +99,8 @@ class ServerlessSdk:
         disable_request_response_monitoring: Optional[bool] = False,
         disable_http_monitoring: Optional[bool] = False,
         disable_flask_monitoring: Optional[bool] = False,
+        *args,
+        **kwargs,
     ):
         if self._is_initialized:
             return
@@ -125,6 +127,9 @@ class ServerlessSdk:
             from .lib.instrumentation.flask import install as install_flask
 
             install_flask()
+
+        if hasattr(self, "_initialize_extension"):
+            self._initialize_extension(*args, **kwargs)
 
         self._is_initialized = True
 

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -214,3 +214,24 @@ def test_initialize_all_options(sdk: ServerlessSdk, monkeypatch):
     assert sdk._is_debug_mode
 
     sdk._settings = _settings
+
+
+def test_initialize_extension(sdk: ServerlessSdk):
+    # given
+    sdk._initialize_extension = MagicMock()
+
+    # when
+    sdk._is_initialized = False
+    sdk._initialize(
+        "foo",
+        org_id="test",
+        disable_captured_events_stdout=True,
+        disable_python_log_monitoring=True,
+        disable_request_response_monitoring=True,
+        disable_http_monitoring=True,
+        disable_flask_monitoring=True,
+        bar="baz",
+    )
+
+    # then
+    sdk._initialize_extension.assert_called_once_with("foo", bar="baz")


### PR DESCRIPTION
### Description
* Prep for implementing AWS SDK instrumentation https://linear.app/serverless/issue/SC-690/python-sdk-instrument-aws-sdk-requests
* This provides a way for the lambda SDK to perform initialization logic specific to the lambda runtime

### Testing done
Unit tested