### PR TITLE
fix: Updated warning type to user

### DIFF
--- a/node/packages/sdk/lib/trace-span.js
+++ b/node/packages/sdk/lib/trace-span.js
@@ -137,7 +137,7 @@ class TraceSpan {
         const message =
           "Serverless SDK Warning: Following trace spans didn't end before end of " +
           `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}\n`;
-        this._reportWarning(message, 'SDK_SPAN_NOT_CLOSED');
+        this._reportWarning(message, 'SDK_SPAN_NOT_CLOSED', { type: 'USER' });
       }
       asyncLocalStorage.enterWith(this);
     } else {


### PR DESCRIPTION
## Description
We should mark this warning as a user warning instead of an SDK warning