### PR TITLE
[Python] SLS SDK Handle existing tags

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -39,10 +39,8 @@ class Tags(Dict[str, ValidTags]):
                 return
 
             current: ValidTags = self[name]
-
-            if isinstance(current, list):
-                if value != current:
-                    return
+            if value == current:
+                return
 
         raise DuplicateTraceSpanName(f"Cannot set tag: Tag {name} is already set")
 

--- a/python/packages/sdk/tests/lib/test_tags.py
+++ b/python/packages/sdk/tests/lib/test_tags.py
@@ -171,7 +171,20 @@ def test_tags_duplicate(tags: Tags, monkeypatch):
         for value in VALID_VALUES:
             tags[name] = value
 
-    mock.assert_called()
+    assert mock.call_count == len(VALID_NAMES) * len(VALID_VALUES)
+
+
+def test_tags_duplicate_same_value(tags: Tags, monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(sls_sdk.lib.tags, "report_error", mock)
+
+    tags["foo"] = "bar"
+    tags["foo"] = "bar"
+
+    tags["baz"] = ["list", "of", "values"]
+    tags["baz"] = ["list", "of", "values"]
+
+    mock.assert_not_called()
 
 
 def test_tags_duplicate_internal_method_raises_exception(tags: Tags):


### PR DESCRIPTION
### Description
While working on https://linear.app/serverless/issue/SC-690/python-sdk-instrument-aws-sdk-requests I've noticed a bug in how we handle duplicate tags.

### Testing done
Reproduced the problem in a unit test and fixed.