### PR TITLE
[Python] Base SDK Store http span in context variable

### DIFF
--- a/python/packages/sdk/tests/conftest.py
+++ b/python/packages/sdk/tests/conftest.py
@@ -75,3 +75,17 @@ def _reset_sdk_reimport(
 @pytest.fixture(scope="session")
 def httpserver_listen_address():
     return ("127.0.0.1", 9800)
+
+
+@pytest.fixture(params=[False, True])
+def instrumented_sdk(reset_sdk, request, monkeypatch):
+    # if dev mode is enabled in the fixture
+    if request.param:
+        monkeypatch.setenv("SLS_DEV_MODE_ORG_ID", "test-org")
+    import sls_sdk
+
+    sls_sdk.serverlessSdk._initialize(
+        disable_request_response_monitoring=not request.param
+    )
+    yield sls_sdk.serverlessSdk
+    sls_sdk.lib.instrumentation.http.uninstall()

--- a/python/packages/sdk/tests/lib/instrumentation/test_http.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_http.py
@@ -15,20 +15,6 @@ LARGE_RESPONSE_PAYLOAD = b"r" * 1024 * 128
 SMALL_RESPONSE_PAYLOAD = b"r"
 
 
-@pytest.fixture(params=[False, True])
-def instrumented_sdk(reset_sdk, request, monkeypatch):
-    # if dev mode is enabled in the fixture
-    if request.param:
-        monkeypatch.setenv("SLS_DEV_MODE_ORG_ID", "test-org")
-    import sls_sdk
-
-    sls_sdk.serverlessSdk._initialize(
-        disable_request_response_monitoring=not request.param
-    )
-    yield sls_sdk.serverlessSdk
-    sls_sdk.lib.instrumentation.http.uninstall()
-
-
 def _assert_request_response_body(sdk, request_body, response_body):
     assert (
         not sdk._is_dev_mode

--- a/python/packages/sdk/tests/test_thread_safety.py
+++ b/python/packages/sdk/tests/test_thread_safety.py
@@ -4,6 +4,11 @@ import concurrent.futures
 import asyncio
 import random
 import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug.wrappers import Request, Response
+
+SMALL_REQUEST_PAYLOAD = b"a"
+SMALL_RESPONSE_PAYLOAD = b"r"
 
 
 def print_spans(root, length=100):
@@ -283,3 +288,56 @@ def test_set_tag_multithreaded(sdk):
 
     # then
     assert len(sdk._custom_tags) == parallelism * scale
+
+
+@pytest.mark.parametrize(
+    "request_body,response_body",
+    [
+        (SMALL_REQUEST_PAYLOAD, SMALL_RESPONSE_PAYLOAD),
+    ],
+)
+def test_instrument_requests_multithreaded(
+    instrumented_sdk, httpserver: HTTPServer, request_body, response_body
+):
+    # given
+    def handler(request: Request):
+        return Response(response_body)
+
+    httpserver.expect_request("/foo/bar").respond_with_handler(handler)
+
+    root = instrumented_sdk._create_trace_span("rootspan")
+    parallelism = 5
+
+    # when
+    import requests
+
+    def _run():
+        requests.get(
+            httpserver.url_for("/foo/bar?baz=qux"),
+            headers={"User-Agent": "foo"},
+            data=request_body,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallelism) as executor:
+        futures = [executor.submit(_run) for _i in range(parallelism)]
+        for future in concurrent.futures.as_completed(futures):
+            assert future.exception() is None
+
+    # then
+    assert len(root.spans) == parallelism + 1
+    for span in root.spans[1:]:
+        assert span.name == "python.http.request"
+        assert (
+            span.tags.items()
+            >= dict(
+                {
+                    "http.method": "GET",
+                    "http.protocol": "HTTP/1.1",
+                    "http.host": f"127.0.0.1:{httpserver.port}",
+                    "http.path": "/foo/bar",
+                    "http.query_parameter_names": ["baz"],
+                    "http.status_code": 200,
+                }
+            ).items()
+        )
+        assert "User-Agent" in span.tags["http.request_header_names"]


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-742/python-sdk-thread-safety
* I've identified another potential for a race-condition. This will make sure each http spans are stored as context variables and do not interfere with each other.

### Testing done
* Reproduced the problem in a unit test and fixed.
* Integration tested.

```
    ✔ success-v3-8 (46964ms)
    ✔ success-v3-9 (6081ms)
    ✔ success-sampled
    ✔ error-v3-8
    ✔ error-v3-9 (1810ms)
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ sdk-v3-8
    ✔ sdk-v3-9
    ✔ sdk-dev-mode
    ✔ dashboard-v3-8 (403ms)
    ✔ dashboard-v3-9
    ✔ http_requester-http
    ✔ http_requester-https
    ✔ aiohttp_requester-http
    ✔ aiohttp_requester-https (1195ms)
    ✔ flask_app
```
