### PR TITLE
chore: Release python base sdk version 0.4.1

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.4.1 (2023-04-17)
+
+### Bug Fixes
+
+- Fix race condition in HTTP trace spans
+- Fix setting of duplicate tags with same value
+
+### Maintenance Improvements
+
+- Improve internal configurability of HTTP instrumentation
+- Use context variables to selectively ignore instrumentation of HTTP requests
+
 ## 0.4.0 (2023-04-13)
 
 ### Features

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.4.0"
+version = "0.4.1"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-689/python-v4-auto-instrumentation-of-spans