### PR TITLE
[Pyhthon] Base SDK flask instrumentation: Override http router tag

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -479,8 +479,11 @@ describe('Python: integration', function () {
               trace: { spans },
             },
           ] of invocationsData.entries()) {
-            spans.shift();
+            const lambdaSpan = spans.shift();
             if (!index) spans.shift();
+            const { tags: lambdaTags } = lambdaSpan;
+
+            expect(lambdaTags.aws.lambda.httpRouter.path.toString()).to.equal('/test');
 
             const [invocationSpan, flaskSpan, ...routeSpans] = spans;
             expect(flaskSpan.parentSpanId).to.deep.equal(invocationSpan.id);

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
@@ -80,6 +80,11 @@ class Instrumenter:
         if not self._flask.request.endpoint:
             return
         try:
+            if self._flask.request.path:
+                del serverlessSdk.trace_spans.root.tags["aws.lambda.http_router.path"]
+                serverlessSdk.trace_spans.root.tags[
+                    "aws.lambda.http_router.path"
+                ] = self._flask.request.path
             span_name = ".".join(
                 [
                     "flask",

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -50,6 +50,11 @@ class Tags(Dict[str, ValidTags]):
         except Exception as ex:
             report_error(ex)
 
+    def __delitem__(self, key: str):
+        with self._lock:
+            if key in self:
+                super().__delitem__(key)
+
     def __setitem__(self, key: str, value: ValidTags):
         self.set(key, value)
 

--- a/python/packages/sdk/tests/lib/instrumentation/test_flask.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_flask.py
@@ -116,6 +116,7 @@ def test_flask_post_500(app):
         "flask.error.customexception",
     ]
     assert events[0].tags["error.name"] == "CustomException"
+    assert root.tags["aws.lambda.http_router.path"] == "/internal-server-error"
 
 
 def test_flask_get_404(app):

--- a/python/packages/sdk/tests/lib/instrumentation/test_flask.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_flask.py
@@ -81,6 +81,7 @@ def test_flask_get_200(app):
     assert response.content == b"ok"
     root = serverlessSdk.trace_spans.root
     assert [s.name for s in root.spans] == ["flask", "flask.route.get.helloworld"]
+    assert root.tags["aws.lambda.http_router.path"] == "/"
 
 
 def test_flask_post_500(app):

--- a/python/packages/sdk/tests/lib/test_tags.py
+++ b/python/packages/sdk/tests/lib/test_tags.py
@@ -91,6 +91,23 @@ def test_tags_valid_names_and_values():
 
         for name in VALID_NAMES:
             tags[name] = value
+            assert tags[name] == ensure_tag_value(name, value)
+
+            tags[name] = "new-value"
+            assert tags[name] == ensure_tag_value(name, value)
+
+
+def test_tags_valid_names_and_values_replacement():
+    for value in VALID_VALUES:
+        tags = Tags()
+
+        for name in VALID_NAMES:
+            tags[name] = value
+            assert tags[name] == ensure_tag_value(name, value)
+
+            del tags[name]
+            tags[name] = "new-value"
+            assert tags[name] == ensure_tag_value(name, "new-value")
 
 
 def test_tags_valid_names_and_null_values():
@@ -111,6 +128,21 @@ def test_tags_update():
 
     # then
     assert tags == input
+
+
+def test_tags_delete():
+    # given
+    input = {"test": 0, "type": "unit"}
+    tags = Tags()
+    tags.update(input)
+
+    # when
+    del tags["test"]
+    del tags["type"]
+    del tags["non-existent"]
+
+    # then
+    assert tags == {}
 
 
 def test_tags_update_with_prefix():

--- a/python/packages/sdk/tests/test_thread_safety.py
+++ b/python/packages/sdk/tests/test_thread_safety.py
@@ -289,6 +289,22 @@ def test_set_tag_multithreaded(sdk):
     # then
     assert len(sdk._custom_tags) == parallelism * scale
 
+    # given
+    def _del_tag_and_sleep(thread_index):
+        sleep(0.05)
+        for i in range(scale):
+            unique_value = thread_index * scale * 10 + i
+            del sdk._custom_tags[f"tag{unique_value}"]
+
+    # when
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallelism) as executor:
+        futures = [executor.submit(_del_tag_and_sleep, i) for i in range(parallelism)]
+        for future in concurrent.futures.as_completed(futures):
+            assert future.exception() is None
+
+    # then
+    assert len(sdk._custom_tags) == 0
+
 
 @pytest.mark.parametrize(
     "request_body,response_body",


### PR DESCRIPTION
### Description
* Related issue https://github.com/serverless/console/pull/637#pullrequestreview-1383711466 & https://linear.app/serverless/issue/SC-691/python-sdk-instrument-flask
* Override `aws.lambda.http_router.path` with the current route from Flask.
* Provide thread-safe delete functionality for tags

### Testing done
Unit & integration tested
 