### PR TITLE
chore: Release python base sdk version 0.4.2

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.4.2 (2023-04-18)
+
+### Features
+
+- Override `aws.lambda.http_router.path` tag with Flask route
+
 ## 0.4.1 (2023-04-17)
 
 ### Bug Fixes

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.4.1"
+version = "0.4.2"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-691/python-sdk-instrument-flask