### PR TITLE
Import from layer base sdk

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -1053,6 +1053,12 @@ describe('Python: integration', function () {
     exec(
       `pip install aiohttp==3.8.4 serverless-wsgi==3.0.2 flask==2.2.3 --target="${fixturesDirname}/test_dependencies"`
     );
+    exec(
+      [
+        `mkdir ${fixturesDirname}/sls_sdk`,
+        `echo "raise Exception('This is a dummy module that should never get imported.')" > ${fixturesDirname}/sls_sdk/__init__.py`,
+      ].join('\n')
+    );
 
     pyProjectToml = toml.parse(
       await fsp.readFile(
@@ -1216,6 +1222,9 @@ describe('Python: integration', function () {
 
   after(async () => {
     cleanup({ mode: 'core' });
-    await fsp.rmdir(`${fixturesDirname}/test_dependencies`, { recursive: true, force: true });
+    await Promise.all([
+      fsp.rmdir(`${fixturesDirname}/test_dependencies`, { recursive: true, force: true }),
+      fsp.rmdir(`${fixturesDirname}/sls_sdk`, { recursive: true, force: true }),
+    ]);
   });
 });

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -14,7 +14,7 @@ authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
     "aiohttp~=3.8",
-    "serverless-sdk~=0.4.1",
+    "serverless-sdk~=0.4.2",
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
     "wrapt~=1.15.0",

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -4,11 +4,27 @@ import logging
 from typing import Optional
 from importlib_metadata import version
 from typing_extensions import Final
-from sls_sdk import serverlessSdk as baseSdk
-from .trace_spans.aws_lambda import aws_lambda_span
-from sls_sdk import ServerlessSdk, TraceSpans
-from sls_sdk.lib.trace import TraceSpan
-from .instrumentation import aws_sdk
+import sys
+import inspect
+
+# If the Lambda SDK is imported from the layer make sure
+# to import the base SDK also from the Lambda Layer.
+_is_loaded_from_layer = inspect.getfile(sys.modules[__name__]).startswith("/opt/python")
+_path_modified = False
+try:
+    if "sls_sdk" not in sys.modules and _is_loaded_from_layer:
+        sys.path.insert(0, "/opt/python")
+        _path_modified = True
+    from sls_sdk import serverlessSdk as baseSdk
+finally:
+    if _path_modified:
+        sys.path.pop(0)
+
+
+from .trace_spans.aws_lambda import aws_lambda_span  # noqa E402
+from sls_sdk import ServerlessSdk, TraceSpans  # noqa E402
+from sls_sdk.lib.trace import TraceSpan  # noqa E402
+from .instrumentation import aws_sdk  # noqa E402
 
 # module metadata
 __name__: Final[str] = "serverless-aws-lambda-sdk"

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
@@ -3,9 +3,7 @@ import importlib
 from os import environ
 from typing import List
 
-from typing_extensions import Final, TypeAlias, TYPE_CHECKING
-
-from ..instrument import Instrumenter
+from typing_extensions import Final
 
 __all__: Final[List[str]] = [
     "handler",

--- a/python/packages/aws-lambda-sdk/tests/internal_extension/test_internal_extension_exec_wrapper.py
+++ b/python/packages/aws-lambda-sdk/tests/internal_extension/test_internal_extension_exec_wrapper.py
@@ -8,10 +8,17 @@ import importlib
 
 @pytest.fixture()
 def exec_wrapper_main():
-    import serverless_aws_lambda_sdk.internal_extension.exec_wrapper
+    exec_wrapper_path = str(
+        Path(__file__).parent.parent.parent
+        / "serverless_aws_lambda_sdk/internal_extension"
+    )
+    sys.path.append(exec_wrapper_path)
+    import exec_wrapper
 
-    importlib.reload(serverless_aws_lambda_sdk.internal_extension.exec_wrapper)
-    yield serverless_aws_lambda_sdk.internal_extension.exec_wrapper.main
+    importlib.reload(exec_wrapper)
+    sys.path.remove(exec_wrapper_path)
+
+    yield exec_wrapper.main
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-847/python-sdk-internal-error-when-using-serverless-sdk-0312#comment-bb33e442
* If the Lambda SDK is imported from the layer, then the base SDK should also be imported from the layer
* Upgrade to latest base SDK
* Modify exec_wrapper test to mimic how AWS Lambda Runtime imports our SDK
* Integration test to inject a dummy module within lambda function package that fails, to make sure it's not the one that is imported.

### Testing done
Unit & integration tested.

#### Integration tests without the fix fails
This is from the CloudWatch logs:

```
[ERROR] Exception: This is a dummy module that should never get imported.
Traceback (most recent call last):
  File "/var/lang/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/opt/python/serverless_aws_lambda_sdk/__init__.py", line 20, in <module>
    from sls_sdk import serverlessSdk as baseSdk
  File "/var/task/sls_sdk/__init__.py", line 1, in <module>
    raise Exception('This is a dummy module that should never get imported.')
```

#### Integration tests with the fix succeeds
```
    ✔ success-v3-8 (47074ms)
    ✔ success-v3-9 (12242ms)
    ✔ success-sampled
    ✔ error-v3-8 (220ms)
    ✔ error-v3-9 (2412ms)
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ api_endpoint-rest-api
    ✔ api_endpoint-http-api-v1
    ✔ api_endpoint-http-api-v2
    ✔ api_endpoint-function-url
    ✔ sdk-v3-8
    ✔ sdk-v3-9
    ✔ sdk-dev-mode (830ms)
    ✔ dashboard-v3-8
    ✔ dashboard-v3-9
    ✔ http_requester-http
    ✔ http_requester-https
    ✔ aiohttp_requester-http
    ✔ aiohttp_requester-https (258ms)
    ✔ flask_app
    ✔ aws_sdk-internal
    ✔ aws_sdk-external (15379ms)
```
