### PR TITLE
Fix performance regression

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -23,7 +23,6 @@ _HTTP_SPAN = contextvars.ContextVar("http-span", default=None)
 
 class BaseInstrumenter:
     def __init__(self, target_module):
-        self._target_module = target_module
         self._import_hook = ImportHook(target_module)
         self._is_installed = False
         self._module = None

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -1,9 +1,9 @@
 import time
-import importlib
 import contextvars
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
 from ..error import report as report_error
+from .import_hook import ImportHook
 import sls_sdk
 
 SDK = sls_sdk.serverlessSdk
@@ -23,32 +23,33 @@ _HTTP_SPAN = contextvars.ContextVar("http-span", default=None)
 
 class BaseInstrumenter:
     def __init__(self, target_module):
-        self._is_installed = False
         self._target_module = target_module
+        self._import_hook = ImportHook(target_module)
+        self._is_installed = False
+        self._module = None
 
     def install(self, should_monitor_request_response):
         if self._is_installed:
             return
         self.should_monitor_request_response = should_monitor_request_response
-        try:
-            self._module = importlib.import_module(self._target_module)
-        except ImportError:
+
+        if self._import_hook.enabled:
             return
 
-        self._install()
+        self._import_hook.enable(self._install)
         self._is_installed = True
 
     def uninstall(self):
         if not self._is_installed:
             return
 
-        self._uninstall()
+        self._import_hook.disable(self._uninstall)
         self._is_installed = False
 
-    def _install(self):
+    def _install(self, module):
         raise NotImplementedError
 
-    def _uninstall(self):
+    def _uninstall(self, module):
         raise NotImplementedError
 
 
@@ -159,7 +160,8 @@ class NativeAIOHTTPInstrumenter(BaseInstrumenter):
 
         return _init
 
-    def _install(self):
+    def _install(self, module):
+        self._module = module
         if hasattr(self._module, "TraceConfig"):
             trace_config = self._module.TraceConfig()
             trace_config.on_request_start.append(self._on_request_start)
@@ -170,9 +172,10 @@ class NativeAIOHTTPInstrumenter(BaseInstrumenter):
             self._original_init = self._module.ClientSession.__init__
             self._module.ClientSession.__init__ = self._instrumented_init(trace_config)
 
-    def _uninstall(self):
+    def _uninstall(self, module):
         if self._original_init:
             self._module.ClientSession.__init__ = self._original_init
+        self._module = None
 
 
 class NativeHTTPInstrumenter(BaseInstrumenter):
@@ -282,7 +285,8 @@ class NativeHTTPInstrumenter(BaseInstrumenter):
         except Exception as ex:
             report_error(ex)
 
-    def _install(self):
+    def _install(self, module):
+        self._module = module
         self._original_request = self._module.client.HTTPConnection.request
         self._original_getresponse = self._module.client.HTTPConnection.getresponse
         self._module.client.HTTPConnection.request = self._instrumented_request()
@@ -290,9 +294,10 @@ class NativeHTTPInstrumenter(BaseInstrumenter):
             self._instrumented_getresponse()
         )
 
-    def _uninstall(self):
+    def _uninstall(self, module):
         self._module.client.HTTPConnection.request = self._original_request
         self._module.client.HTTPConnection.getresponse = self._original_getresponse
+        self._module = None
 
 
 _instrumenters = [NativeHTTPInstrumenter(), NativeAIOHTTPInstrumenter()]

--- a/python/packages/sdk/tests/conftest.py
+++ b/python/packages/sdk/tests/conftest.py
@@ -11,16 +11,27 @@ def sdk(monkeypatch, request):
 
     serverlessSdk._initialize()
     yield serverlessSdk
+    import sls_sdk
+
+    sls_sdk.lib.instrumentation.http.uninstall()
 
 
 @pytest.fixture()
 def reset_sdk(monkeypatch, request):
     _reset_sdk_reimport(monkeypatch, request)
+    yield
+    import sls_sdk
+
+    sls_sdk.lib.instrumentation.http.uninstall()
 
 
 @pytest.fixture()
 def reset_sdk_dev_mode(monkeypatch, request):
     _reset_sdk_reimport(monkeypatch, request, True, True)
+    yield
+    import sls_sdk
+
+    sls_sdk.lib.instrumentation.http.uninstall()
 
 
 def _reset_sdk_reimport(

--- a/python/packages/sdk/tests/lib/instrumentation/test_http.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_http.py
@@ -422,8 +422,10 @@ def test_instrument_aiohttp_unsupported_version(instrumented_sdk):
 
     with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
         # given
+        import sls_sdk.lib.instrumentation.http
         from sls_sdk.lib.instrumentation.http import NativeAIOHTTPInstrumenter
 
+        sls_sdk.lib.instrumentation.http.uninstall()
         instrumenter = NativeAIOHTTPInstrumenter()
 
         assert not instrumenter._import_hook.enabled

--- a/python/packages/sdk/tests/lib/instrumentation/test_http.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_http.py
@@ -426,10 +426,14 @@ def test_instrument_aiohttp_unsupported_version(instrumented_sdk):
 
         instrumenter = NativeAIOHTTPInstrumenter()
 
+        assert not instrumenter._import_hook.enabled
+
         # when
         instrumenter.install(True)
 
         # then
+        assert instrumenter._import_hook.enabled
+        assert instrumenter._module is not None
         assert instrumenter._original_init is None
 
 
@@ -437,6 +441,7 @@ def test_instrument_aiohttp_noops_if_aiohttp_is_not_installed():
     with patch.dict(sys.modules, {"aiohttp": None}):
         # given
         import sls_sdk
+        from sls_sdk.lib.instrumentation.http import NativeAIOHTTPInstrumenter
 
         # when
         sls_sdk.serverlessSdk._initialize()
@@ -445,7 +450,7 @@ def test_instrument_aiohttp_noops_if_aiohttp_is_not_installed():
         instrumenter = [
             x
             for x in sls_sdk.lib.instrumentation.http._instrumenters
-            if x._target_module == "aiohttp"
+            if isinstance(x, NativeAIOHTTPInstrumenter)
         ][0]
         assert not instrumenter._is_installed
 


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead#comment-448411f1
* Instrument http on the go, without importing the target modules first

### Testing done
Unit, integration & performance tested

#### Integration tests
```
    ✔ success-v3-8 (45192ms)
    ✔ success-v3-9 (8878ms)
    ✔ success-sampled (9453ms)
    ✔ error-v3-8
    ✔ error-v3-9
    ✔ error_unhandled-v3-8
    ✔ error_unhandled-v3-9
    ✔ api_endpoint-rest-api
    ✔ api_endpoint-http-api-v1
    ✔ api_endpoint-http-api-v2
    ✔ api_endpoint-function-url
    ✔ sdk-v3-8
    ✔ sdk-v3-9
    ✔ sdk-dev-mode (3462ms)
    ✔ dashboard-v3-8
    ✔ dashboard-v3-9
    ✔ http_requester-http
    ✔ http_requester-https
    ✔ aiohttp_requester-http
    ✔ aiohttp_requester-https
    ✔ flask_app (421ms)
    ✔ aws_sdk-internal
    ✔ aws_sdk-external (15594ms)
```

#### Performance tests
```
➜  node git:(fix-performance-regression) ✗ npx mocha test/python/aws-lambda-sdk/benchmark/performance.test.js
2023-04-19T13:08:08.749Z ℹ test test uid: omar


  performance
2023-04-19T13:08:08.909Z ℹ test Creating core resources test-python-sdk-omar
2023-04-19T13:08:51.621Z ℹ test Process function success-internal-1
2023-04-19T13:08:51.622Z ℹ test Process function success-internal-2
2023-04-19T13:08:51.623Z ℹ test Process function success-internal-3
2023-04-19T13:08:51.623Z ℹ test Process function success-internal-4
2023-04-19T13:08:51.623Z ℹ test Process function success-internal-5
2023-04-19T13:09:23.033Z ℹ test Cleanup test-python-sdk-omar
2023-04-19T13:09:23.393Z ℹ test Deleted 54 version of the layer test-python-sdk-omar-external
2023-04-19T13:09:23.408Z ℹ test Deleted 54 version of the layer test-python-sdk-omar-internal
2023-04-19T13:09:24.279Z ℹ test Detached IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-omar from test-python-sdk-omar
2023-04-19T13:09:24.512Z ℹ test Deleted IAM role test-python-sdk-omar
2023-04-19T13:09:24.948Z ℹ test Deleted IAM policy arn:aws:iam::692593327170:policy/test-python-sdk-omar
    ✔ should introduce reasonable initialization overhead
    ✔ should introduce reasonable first invocation overhead
    ✔ should introduce reasonable following invocation overhead


  3 passing (1m)
```