### PR TITLE
[Python SDK] Fix high level http instrumentation

### DIFF
--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "importlib_metadata>=5.2", # included in Python >=3.8
     "js-regex<1.1.0,>=1.0.1",
     "typing-extensions>=4.4", # included in Python 3.8 - 3.11
+    "wrapt~=1.15.0",
 ]
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-906/python-sdk-incorrect-http-span-duration
* We've noticed the http span duration when using either requests or urllib3 libraries are reported wrong, the reported duration is much shorter than the actual time it takes for the request to complete.
* Turns out the high-level library "urllib3" is extending the low-level http.client library and we are missing the extended portion's instrumentation.
* This change implements a separate instrumenter for urllib3 (which is consumed by requests as well) that disables low-level instrumentation for the current request and relies on urllib3's `urlopen` method, which is responsible for performing the request including opening a connection.

### Testing done
* Reproduced the issue in unit tests
* Increased test confidence for http spans by asserting on the number of spans created (to make sure we are both instrumenting at the high and low-level for a given request)
* Integration and performance tests are passing as well
