### PR TITLE
SDK: Improve express middleware detection (fix compatibility with Serverless Dashboard)

### DIFF
--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -40,7 +40,7 @@ module.exports.install = (layerPrototype) => {
       }
       expressRouteData = expressSpansMap.get(req);
       const { routeSpan, openedSpans } = expressRouteData;
-      const isRouterMiddleware = !routeSpan && this.name === 'bound dispatch';
+      const isRouterMiddleware = Boolean(!routeSpan && this.route);
       const middlewareSpanName = (() => {
         if (routeSpan) {
           return `express.middleware.route.${[
@@ -77,7 +77,9 @@ module.exports.install = (layerPrototype) => {
           if (!middlewareSpan.endTime) {
             expressRouteData.openedSpans.delete(middlewareSpan);
             middlewareSpan.close();
-            if (this.name === 'bound dispatch') delete expressRouteData.routeSpan;
+            if (this.route) {
+              delete expressRouteData.routeSpan;
+            }
           }
         } catch (error) {
           reportError(error);


### PR DESCRIPTION
Express instrumentation fails when the function is also instrumented with the Dashboard.

It's due to the fact that:
1. Dashboard [overrides express's `route.dispatch` method](https://github.com/serverless/dashboard-plugin/blob/82822430d112a21cb96cb61de5205c251f488627/sdk-js/src/lib/frameworks/wrappers/express.js#L11) while this method is used as route middleware, and middlewares in our instrumentation are recognized by their names (which are derived in express from function names)
2. Dashboard bundles the SDK in minified form where internal function names are removed

This patch improves the route middleware detection so it's not achieved via name check, but by the `.route` property, where [dispatch router is assigned](https://github.com/expressjs/express/blob/0debedf4f31bb20203da0534719b9b10d6ac9a29/lib/router/index.js#L509-L511)

_Extensive integration test that confirms on general compatibility with Dashboard, and validity of this patch is ready and confirmed to pass locally, and will be added with the next PR (introduced in context of the `aws-lambda-sdk` package`)_