### PR TITLE
SDK: Improve `serverlessSdk._reportWarning` resolution

### DIFF
--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -112,13 +112,7 @@ serverlessSdk._initialize = (options = {}) => {
   return serverlessSdk;
 };
 
-serverlessSdk._createTraceSpan = (name, options = {}) =>
-  new TraceSpan(
-    name,
-    Object.assign(options, {
-      _reportWarning: reportWarning,
-    })
-  );
+serverlessSdk._createTraceSpan = (name, options = {}) => new TraceSpan(name, options);
 serverlessSdk._reportError = reportError;
 serverlessSdk._reportWarning = reportWarning;
 serverlessSdk._reportNotice = reportNotice;

--- a/node/packages/sdk/lib/trace-span.js
+++ b/node/packages/sdk/lib/trace-span.js
@@ -43,7 +43,6 @@ class TraceSpan {
         );
       }
     }
-    this._reportWarning = options._reportWarning;
     this.startTime = startTime || defaultStartTime;
     this.name = ensureSpanName(name);
 
@@ -86,7 +85,6 @@ class TraceSpan {
       new TraceSpan(immediateDescendants.shift(), {
         startTime: this.startTime,
         immediateDescendants,
-        _reportWarning: this._reportWarning,
       });
     }
   }
@@ -137,7 +135,8 @@ class TraceSpan {
         const message =
           "Serverless SDK Warning: Following trace spans didn't end before end of " +
           `lambda invocation: ${leftoverSpans.map(({ name }) => name).join(', ')}\n`;
-        this._reportWarning(message, 'SDK_SPAN_NOT_CLOSED', { type: 'USER' });
+        // Require on spot to avoid otherwise difficult to mitigate circular dependency
+        require('..')._reportWarning(message, 'SDK_SPAN_NOT_CLOSED', { type: 'USER' });
       }
       asyncLocalStorage.enterWith(this);
     } else {


### PR DESCRIPTION
`_reportWarning` ideally should always be accessed directly from the SDK instance.