### PR TITLE
SDK: Do not fail on missing `layer.method`

### DIFF
--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -44,7 +44,9 @@ module.exports.install = (layerPrototype) => {
       const middlewareSpanName = (() => {
         if (routeSpan) {
           return `express.middleware.route.${[
-            generateMiddlewareName(this.method),
+            // TODO: Cover not set `this.method` case with integration test
+            // (at this point it's not clear how to reproduce it)
+            this.method && generateMiddlewareName(this.method),
             generateMiddlewareName(this.name) || 'unknown',
           ]
             .filter(Boolean)


### PR DESCRIPTION
Address issue reported with internal SDK error (on AWS Lambda SDK v0.14.15):

```
Cannot read property 'replace' of undefined
at generateMiddlewareName (/opt/nodejs/node_modules/@serverless/sdk/index.js:2925:49)
at /opt/nodejs/node_modules/@serverless/sdk/index.js:2961:17
at Layer.handle [as handle_request] (/opt/nodejs/node_modules/@serverless/sdk/index.js:2966:13)
at trim_prefix (/var/task/node_modules/express/lib/router/index.js:323:13)
at /var/task/node_modules/express/lib/router/index.js:284:7
at Function.process_params (/var/task/node_modules/express/lib/router/index.js:341:12)
at Function.process_params (/var/task/node_modules/@sentry/tracing/cjs/integrations/node/express.js:266:34)
at next (/var/task/node_modules/express/lib/router/index.js:275:10)
at /opt/nodejs/node_modules/@serverless/sdk/index.js:2995:20
at /var/task/node_modules/@sentry/tracing/cjs/integrations/node/express.js:98:16
```

At this point, it's not clear to me how to reproduce so I do not follow up with any regression test but added it to my backlog to look into it in more detail.