### PR TITLE
Support python v3.10

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/stack_trace_string.py
+++ b/python/packages/sdk/sls_sdk/lib/stack_trace_string.py
@@ -7,11 +7,7 @@ from typing import Optional, Any
 def resolve(error: Optional[Any] = None) -> str:
     if isinstance(error, BaseException):
         # in case of an actual Exception, stack trace is already set up.
-        return "".join(
-            traceback.format_exception(
-                etype=type(error), value=error, tb=error.__traceback__
-            )
-        )
+        return "".join(traceback.format_exception(error, error, error.__traceback__))
     else:
         # in case of errors that are not exceptions, return the current stack trace
         # but exclude the most recent 3 frames to make sure stack trace ends at

--- a/python/packages/sdk/tests/lib/test_stack_trace_string.py
+++ b/python/packages/sdk/tests/lib/test_stack_trace_string.py
@@ -18,9 +18,7 @@ def test_resolve_stack_trace_string_from_error():
 
     # then
     assert stack_trace == "".join(
-        traceback.format_exception(
-            etype=type(error), value=error, tb=error.__traceback__
-        )
+        traceback.format_exception(error, error, error.__traceback__)
     )
 
 


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-900/support-aws-lambda-python-v310-runtime
* I've tried to run the unit tests with python3.10 and found a single piece of code that needed a change because they've changed the signature of `traceback.format_exception` (first argument is ignored since python 3.5+)

### Testing done
Unit and integration tested against python 3.10