### PR TITLE
Support python 3.10 in CI/CD

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9"]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
     outputs:
       pathChangedAwsLambdaSdk: ${{ steps.pathChanges.outputs.awsLambdaSdk }}
       pathChangedSdk: ${{ steps.pathChanges.outputs.sdk}}

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9"]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/node/test/benchmark/lib/resolve-use-cases-config/python.js
+++ b/node/test/benchmark/lib/resolve-use-cases-config/python.js
@@ -65,7 +65,7 @@ module.exports = async (coreConfig) => {
         config: {
           configuration: {
             Handler: 'success.handler',
-            Runtime: 'python3.9',
+            Runtime: 'python3.10',
             Code: {
               ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, 'success.py')),
             },

--- a/node/test/python/aws-lambda-sdk/benchmark/lib/run.js
+++ b/node/test/python/aws-lambda-sdk/benchmark/lib/run.js
@@ -20,7 +20,7 @@ module.exports = async (useCasesConfig, coreConfig) =>
       TracePayload,
       fixturesDirname,
       baseLambdaConfiguration: {
-        Runtime: 'python3.9',
+        Runtime: 'python3.10',
         Layers: [coreConfig.layerInternalArn],
         Environment: {
           Variables: {

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -1036,7 +1036,7 @@ describe('Python: integration', function () {
             'internal',
             {
               configuration: {
-                Runtime: 'python3.9',
+                Runtime: 'python3.10',
                 Code: {
                   ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, 'aws_sdk.py')),
                 },

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -593,6 +593,7 @@ describe('Python: integration', function () {
         variants: new Map([
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
           [
             'sampled',
             {
@@ -616,6 +617,7 @@ describe('Python: integration', function () {
         variants: new Map([
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
         ]),
         config: { expectedOutcome: 'error:handled' },
       },
@@ -626,6 +628,7 @@ describe('Python: integration', function () {
         variants: new Map([
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
         ]),
         config: { expectedOutcome: 'error:unhandled' },
       },
@@ -962,6 +965,7 @@ describe('Python: integration', function () {
         variants: new Map([
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
           ['dev-mode', devModeConfiguration],
         ]),
         config: sdkTestConfig,
@@ -973,6 +977,7 @@ describe('Python: integration', function () {
         variants: new Map([
           ['v3-8', { configuration: { Runtime: 'python3.8' } }],
           ['v3-9', { configuration: { Runtime: 'python3.9' } }],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
         ]),
       },
     ],


### PR DESCRIPTION
* Related to https://github.com/serverless/console/pull/674
* Add python v3.10 to unit test configuration in CI/CD
* Add python v3.10 config to integration tests
* Base configuration is now updated to be python v3.10
* To be merged after we publish a new version of the base SDK