### PR TITLE
Fix transient dependency version and add more tests for aiohttp

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
     "wrapt~=1.15.0",
+    "yarl~=1.8.0",
 ]
 [project.optional-dependencies]
 tests = [

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiohttp_requester.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiohttp_requester.py
@@ -21,15 +21,14 @@ def run_http_server():
         httpd.serve_forever(0.1)
 
 
-def make_http_request(url, use_ssl=False):
+def make_http_request(url):
     sys.path.append(Path(__file__).parent / "test_dependencies")
     import aiohttp
 
     async def _request():
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers={"someHeader": "bar"}) as resp:
-                print(resp.status)
-                print(await resp.text())
+                await resp.text()
 
     asyncio.run(_request())
     sys.path.pop()
@@ -38,8 +37,6 @@ def make_http_request(url, use_ssl=False):
 def handler(event, context) -> str:
     url = event.get("url")
     if url:
-        from urllib.parse import urlparse
-
         make_http_request(url)
     else:
         from threading import Thread


### PR DESCRIPTION
### Description
While working on https://linear.app/serverless/issue/SC-905/python-sdk-incorrect-span-hierarchy I've noticed that the integration test `aiohttp_requester` was failing. I've noticed it fails against main as well. I could not trace it to a particular change we had. So I started looking at the dependencies.

I've traced the issue to a release in one of dependencies of `aiohttp`, named `yarl`. That repo has an issue that look similar to the problem we are facing: https://github.com/aio-libs/yarl/issues/854

The problem is, `url` reported in the tracing callbacks https://docs.aiohttp.org/en/stable/tracing_reference.html lack the query string parameter.

This PR adds a unit test that reproduces this problem ~, fix is yet to be provided.~ fix is provided as well.

For reference, if we install `yarl==1.8.2` the tests pass (previous version). If we use the latest version `yarl==1.9.1` the tests fail https://pypi.org/project/yarl/#history

### Testing done
Unit/integration tested