### PR TITLE
chore: Release python base sdk version 0.4.5

### DIFF
--- a/python/packages/sdk/CHANGELOG.md
+++ b/python/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.4.5 (2023-04-26)
+
+### Bug Fixes
+
+- Fix request response decoding
+- Fix span hierarchy in multithreaded usage
+
 ## 0.4.4 (2023-04-20)
 
 ### Maintenance Improvements

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk"
-version = "0.4.4"
+version = "0.4.5"
 description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
To release
- Fix request response decoding
- Fix span hierarchy in multithreaded usage