### PR TITLE
fix: Do not send SDK errors for unsupported log levels

### DIFF
--- a/node/packages/sdk/lib/structured-log-to-event.js
+++ b/node/packages/sdk/lib/structured-log-to-event.js
@@ -132,6 +132,11 @@ module.exports.attemptParseStructuredLogAndCapture = (logLine) => {
       case 'WARN':
         handleWarningLog(logLineParsed);
         return;
+      case 'INFO':
+      case null:
+        // We don't capture info logs but we don't want to throw an error either.
+        // If a value is null, it means it is not a valid log line
+        return;
       default:
         throw new Error(`Unsupported log level: ${logLevel}`);
     }

--- a/node/packages/sdk/lib/structured-log-to-event.js
+++ b/node/packages/sdk/lib/structured-log-to-event.js
@@ -132,10 +132,8 @@ module.exports.attemptParseStructuredLogAndCapture = (logLine) => {
       case 'WARN':
         handleWarningLog(logLineParsed);
         return;
-      case 'INFO':
       case null:
-        // We don't capture info logs but we don't want to throw an error either.
-        // If a value is null, it means it is not a valid log line
+        // If a value is null, it means it is not a valid log line for capturing
         return;
       default:
         throw new Error(`Unsupported log level: ${logLevel}`);


### PR DESCRIPTION
When I pushed out the newest SDK version to dev I noticed quite a few more SDK Caught Errors coming in and it appears to be sending an error for every info log. 