### PR TITLE
AWS Lambda SDK: Ensure our `--require` option is first

### DIFF
--- a/node/packages/aws-lambda-sdk/internal-extension/exec-wrapper.sh
+++ b/node/packages/aws-lambda-sdk/internal-extension/exec-wrapper.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/sls-sdk-node"
+# Ensure our --require first in the list of pre-required modules
+export NODE_OPTIONS="--require /opt/sls-sdk-node ${NODE_OPTIONS}"
 
 exec "$@"


### PR DESCRIPTION
Some instrumentations (as Baselime: https://baselime.io/docs/sending-data/otel/) inject their instrumentation via `NODE_OPTIONS=--require...` instead of `AWS_LAMBDA_EXEC_WRAPPER`

Our instrumentation applies same method yet it's done via module pointed in `AWS_LAMBDA_EXEC_WRAPPER` env variable: https://github.com/serverless/console/blob/795bb111be87a6aa728a9b947f7b8de3c09f5581/node/packages/aws-lambda-sdk/internal-extension/exec-wrapper.sh#L3

We respect all other eventually set `NODE_OPTIONS`, so in case of Baselime it'll result with setting as `--require <baseline module> --require <console module>`.

As I tested Node.js respects input for all `--require` calls, and loads them in provided order, so that is not breaking for Baselime. Yet to ensure most correct instrumentation outcome it'll be better if our instrumentation is loaded first. This PR ensures that