### PR TITLE
chore: Release python lambda sdk version 0.1.15

### DIFF
--- a/python/packages/aws-lambda-sdk/CHANGELOG.md
+++ b/python/packages/aws-lambda-sdk/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.1.15 (2023-04-27)
+
+### Bug Fixes
+
+- Fix handling of DynamoDB expression tags
+- Fix request response decoding
+- Fix span hierarchy in multithreaded usage
+- Fix duration resolution in HTTP instrumentation
+
+### Maintenance Improvements
+
+- Support Python v3.10
+
 ## 0.1.14 (2023-04-20)
 
 ### Features

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -7,14 +7,14 @@ requires = [
 
 [project]
 name = "serverless-aws-lambda-sdk"
-version = "0.1.14"
+version = "0.1.15"
 description = "Serverless AWS Lambda SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
 dependencies = [
     "aiohttp~=3.8",
-    "serverless-sdk~=0.4.2",
+    "serverless-sdk~=0.4.5",
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
     "wrapt~=1.15.0",


### PR DESCRIPTION
As per https://github.com/serverless/console/pull/697#pullrequestreview-1404334459