### PR TITLE
SDK: Resolve parametrized paths with nested routers

### DIFF
--- a/node/packages/sdk/instrumentation/express-app.js
+++ b/node/packages/sdk/instrumentation/express-app.js
@@ -2,7 +2,7 @@
 
 const ensureObject = require('type/object/ensure');
 const ensurePlainFunction = require('type/plain-function/ensure');
-const instrumentLayerPrototype = require('../lib/instrumentation/express/instrument-layer-prototype');
+const instrumentRouter = require('../lib/instrumentation/express/instrument-router');
 
 const instrumentedApps = new WeakMap();
 
@@ -13,7 +13,7 @@ module.exports.install = (app) => {
     errorMessage: 'Passed argument is not an instance of express app',
   });
   app.lazyrouter();
-  const uninstall = instrumentLayerPrototype.install(Object.getPrototypeOf(app._router.stack[0]));
+  const uninstall = instrumentRouter.install(Object.getPrototypeOf(app._router));
   instrumentedApps.set(app, uninstall);
   return uninstall;
 };

--- a/node/packages/sdk/lib/instrumentation/express/index.js
+++ b/node/packages/sdk/lib/instrumentation/express/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const cjsHook = require('../utils/cjs-hook');
-const instrumentLayerPrototype = require('./instrument-layer-prototype');
+const instrumentRouter = require('./instrument-router');
 
 module.exports.install = () =>
-  cjsHook.register('/express/lib/router/layer.js', ({ prototype }) =>
-    instrumentLayerPrototype.install(prototype)
-  );
+  cjsHook.register('/express/lib/router/index.js', (router) => instrumentRouter.install(router));
 
-module.exports.uninstall = () => cjsHook.unregister('/express/lib/router/layer.js');
+module.exports.uninstall = () => cjsHook.unregister('/express/lib/router/index.js');

--- a/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-layer-prototype.js
@@ -56,7 +56,9 @@ module.exports.install = (layerPrototype) => {
         }
         if (isRouterMiddleware) return 'express.middleware.router';
         if (this.name === 'router' && this.path) {
-          return `express.middleware.router.${generateMiddlewareName(this.path) || 'unknown'}`;
+          return `express.middleware.router.${
+            generateMiddlewareName(this.$slsRoutePath || '') || 'unknown'
+          }`;
         }
         return `express.middleware.${generateMiddlewareName(this.name) || 'unknown'}`;
       })();
@@ -64,9 +66,10 @@ module.exports.install = (layerPrototype) => {
       openedSpans.add(middlewareSpan);
       if (this.path) {
         if (isRouterMiddleware) {
-          expressRouteData.path = (expressRouteData.nestedPath || '') + this.route.path;
+          expressRouteData.path = (expressRouteData.nestedPath || '') + (this.$slsRoutePath || '');
         } else {
-          expressRouteData.nestedPath = (expressRouteData.nestedPath || '') + this.path;
+          expressRouteData.nestedPath =
+            (expressRouteData.nestedPath || '') + (this.$slsRoutePath || '');
         }
       }
       if (this.method) expressRouteData.method = this.method;

--- a/node/packages/sdk/lib/instrumentation/express/instrument-router.js
+++ b/node/packages/sdk/lib/instrumentation/express/instrument-router.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const reportError = require('../../report-error');
+const instrumentLayerPrototype = require('./instrument-layer-prototype');
+
+const instrumentedRouters = new WeakMap();
+
+module.exports.install = (routerPrototype) => {
+  if (instrumentedRouters.has(routerPrototype)) return instrumentedRouters.get(routerPrototype);
+
+  const originalUse = routerPrototype.use;
+  const originalRoute = routerPrototype.route;
+
+  routerPrototype.use = function use(fn) {
+    const initLength = this.stack.length;
+    try {
+      // eslint-disable-next-line prefer-rest-params
+      return originalUse.apply(this, arguments);
+    } finally {
+      if (this.stack[0]) instrumentLayerPrototype.install(Object.getPrototypeOf(this.stack[0]));
+      if (typeof fn === 'string') {
+        try {
+          for (let i = initLength; i < this.stack.length; i++) {
+            const layer = this.stack[i];
+            layer.$slsRoutePath = fn;
+          }
+        } catch (error) {
+          reportError(error);
+        }
+      }
+    }
+  };
+
+  routerPrototype.route = function route(path) {
+    const initLength = this.stack.length;
+    try {
+      // eslint-disable-next-line prefer-rest-params
+      return originalRoute.apply(this, arguments);
+    } finally {
+      if (this.stack[0]) instrumentLayerPrototype.install(Object.getPrototypeOf(this.stack[0]));
+      try {
+        for (let i = initLength; i < this.stack.length; i++) {
+          const layer = this.stack[i];
+          layer.$slsRoutePath = path;
+        }
+      } catch (error) {
+        reportError(error);
+      }
+    }
+  };
+
+  const uninstall = () => {
+    if (!instrumentedRouters.has(routerPrototype)) return;
+    routerPrototype.use = originalUse;
+    routerPrototype.route = originalRoute;
+    instrumentedRouters.delete(routerPrototype);
+  };
+  instrumentedRouters.set(routerPrototype, uninstall);
+  return uninstall;
+};
+
+module.exports.uninstall = (routerPrototype) => {
+  if (!instrumentedRouters.has(routerPrototype)) return;
+  instrumentedRouters.get(routerPrototype)();
+};

--- a/node/packages/sdk/test/unit/instrumentation/express-app.test.js
+++ b/node/packages/sdk/test/unit/instrumentation/express-app.test.js
@@ -325,4 +325,227 @@ describe('instrumentation/express-app.js', () => {
       );
     });
   });
+
+  describe('Nested parametrized path', () => {
+    let instrumentExpressApp;
+    let serverless;
+    let express;
+    let serverlessSdk;
+    let uninstall;
+    before(() => {
+      requireUncached(() => {
+        serverlessSdk = require('../../../');
+        instrumentExpressApp = require('../../../instrumentation/express-app');
+        serverless = require('serverless-http');
+        express = require('express');
+      });
+    });
+    after(() => {
+      if (uninstall) uninstall();
+      delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
+    });
+
+    it('should instrument parametrized paths ', async () => {
+      const spans = [];
+      serverlessSdk._eventEmitter.on('trace-span-close', (traceSpan) => spans.push(traceSpan));
+      const app = express();
+      uninstall = instrumentExpressApp.install(app);
+
+      app.use(express.json());
+
+      const paramRouter = new express.Router();
+      paramRouter.get('/ipsum/:cat', (req, res) => {
+        res.send('"ok"');
+      });
+
+      app.use('/lorem/:dog', paramRouter);
+
+      app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+      const handler = serverless(app);
+      await handler({
+        version: '2.0',
+        routeKey: 'GET /lorem/123/ipsum/456',
+        rawPath: '/lorem/123/ipsum/456',
+        rawQueryString: 'lone=value&multi=one,stillone&multi=two',
+        headers: {
+          'content-length': '385',
+          'content-type':
+            'multipart/form-data; boundary=--------------------------419073009317249310175915',
+          'multi': 'one,stillone,two',
+        },
+        queryStringParameters: {
+          lone: 'value',
+          multi: 'one,stillone,two',
+        },
+        requestContext: {
+          accountId: '205994128558',
+          apiId: 'xxx',
+          domainName: 'xxx.execute-api.us-east-1.amazonaws.com',
+          domainPrefix: 'xx',
+          http: {
+            method: 'GET',
+            path: '/lorem/123/ipsum/456',
+            protocol: 'HTTP/1.1',
+            sourceIp: '80.55.87.22',
+            userAgent: 'PostmanRuntime/7.29.0',
+          },
+          requestId: 'XyGnwhe0oAMEJJw=',
+          routeKey: 'GET /lorem/{dog}/ipsum/{cat}',
+          stage: '$default',
+          time: '01/Sep/2022:13:46:51 +0000',
+          timeEpoch: 1662040011065,
+        },
+        body:
+          'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNw' +
+          'b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJMb25lIg0KDQpvbmUNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t' +
+          'LS00MTkwNzMwMDkzMTcyNDkzMTAxNzU5MTUNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0i' +
+          'bXVsdGkiDQoNCm9uZSxzdGlsbG9uZQ0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0' +
+          'OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJtdWx0aSINCg0KdHdvDQot' +
+          'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tNDE5MDczMDA5MzE3MjQ5MzEwMTc1OTE1LS0NCg==',
+        isBase64Encoded: true,
+      });
+
+      const expressSpan = spans.pop();
+      const routeSpan = spans.pop();
+      const routerSpan = spans.pop();
+      const topRouterSpan = spans[spans.length - 1];
+
+      expect(expressSpan.name).to.equal('express');
+
+      expect(spans.map(({ name }) => name)).to.deep.equal([
+        'express.middleware.query',
+        'express.middleware.expressinit',
+        'express.middleware.jsonparser',
+        'express.middleware.router.loremdog',
+      ]);
+      for (const middlewareSpan of spans) {
+        expect(String(middlewareSpan.parentSpan.id)).to.equal(String(expressSpan.id));
+      }
+      expect(routerSpan.name).to.equal('express.middleware.router');
+      expect(String(routerSpan.parentSpan.id)).to.equal(String(topRouterSpan.id));
+      expect(routeSpan.name).to.equal('express.middleware.route.get.anonymous');
+      expect(String(routeSpan.parentSpan.id)).to.equal(String(routerSpan.id));
+
+      expect(serverlessSdk.traceSpans.root.tags.get('aws.lambda.http_router.path')).to.equal(
+        '/lorem/:dog/ipsum/:cat'
+      );
+    });
+  });
+
+  describe('Deeply nested parametrized path', () => {
+    let instrumentExpressApp;
+    let serverless;
+    let express;
+    let serverlessSdk;
+    let uninstall;
+    before(() => {
+      requireUncached(() => {
+        serverlessSdk = require('../../../');
+        instrumentExpressApp = require('../../../instrumentation/express-app');
+        serverless = require('serverless-http');
+        express = require('express');
+      });
+    });
+    after(() => {
+      if (uninstall) uninstall();
+      delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
+    });
+
+    it('should instrument parametrized paths ', async () => {
+      const spans = [];
+      serverlessSdk._eventEmitter.on('trace-span-close', (traceSpan) => spans.push(traceSpan));
+      const app = express();
+      uninstall = instrumentExpressApp.install(app);
+
+      app.use(express.json());
+
+      const nestedChildRouter = new express.Router({ mergeParams: true });
+
+      nestedChildRouter.get('/dolor', (req, res) => {
+        res.send('"ok"');
+      });
+
+      const paramRouter = new express.Router();
+      paramRouter.use('/ipsum/:cat', nestedChildRouter);
+
+      app.use('/lorem/:dog', paramRouter);
+
+      app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+      const handler = serverless(app);
+      await handler({
+        version: '2.0',
+        routeKey: 'GET /lorem/123/ipsum/456/dolor',
+        rawPath: '/lorem/123/ipsum/456/dolor',
+        rawQueryString: 'lone=value&multi=one,stillone&multi=two',
+        headers: {
+          'content-length': '385',
+          'content-type':
+            'multipart/form-data; boundary=--------------------------419073009317249310175915',
+          'multi': 'one,stillone,two',
+        },
+        queryStringParameters: {
+          lone: 'value',
+          multi: 'one,stillone,two',
+        },
+        requestContext: {
+          accountId: '205994128558',
+          apiId: 'xxx',
+          domainName: 'xxx.execute-api.us-east-1.amazonaws.com',
+          domainPrefix: 'xx',
+          http: {
+            method: 'GET',
+            path: '/lorem/123/ipsum/456/dolor',
+            protocol: 'HTTP/1.1',
+            sourceIp: '80.55.87.22',
+            userAgent: 'PostmanRuntime/7.29.0',
+          },
+          requestId: 'XyGnwhe0oAMEJJw=',
+          routeKey: 'GET /lorem/{dog}/ipsum/{cat}/dolor',
+          stage: '$default',
+          time: '01/Sep/2022:13:46:51 +0000',
+          timeEpoch: 1662040011065,
+        },
+        body:
+          'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNw' +
+          'b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJMb25lIg0KDQpvbmUNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t' +
+          'LS00MTkwNzMwMDkzMTcyNDkzMTAxNzU5MTUNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0i' +
+          'bXVsdGkiDQoNCm9uZSxzdGlsbG9uZQ0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLTQxOTA3MzAwOTMxNzI0' +
+          'OTMxMDE3NTkxNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJtdWx0aSINCg0KdHdvDQot' +
+          'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tNDE5MDczMDA5MzE3MjQ5MzEwMTc1OTE1LS0NCg==',
+        isBase64Encoded: true,
+      });
+
+      const expressSpan = spans.pop();
+      const routeSpan = spans.pop();
+      const routerSpan = spans.pop();
+      const midRouterSpan = spans.pop();
+      const topRouterSpan = spans[spans.length - 1];
+
+      expect(expressSpan.name).to.equal('express');
+
+      expect(spans.map(({ name }) => name)).to.deep.equal([
+        'express.middleware.query',
+        'express.middleware.expressinit',
+        'express.middleware.jsonparser',
+        'express.middleware.router.loremdog',
+      ]);
+      for (const middlewareSpan of spans) {
+        expect(String(middlewareSpan.parentSpan.id)).to.equal(String(expressSpan.id));
+      }
+      expect(midRouterSpan.name).to.equal('express.middleware.router.ipsumcat');
+      expect(String(midRouterSpan.parentSpan.id)).to.equal(String(topRouterSpan.id));
+
+      expect(routerSpan.name).to.equal('express.middleware.router');
+      expect(String(routerSpan.parentSpan.id)).to.equal(String(midRouterSpan.id));
+
+      expect(routeSpan.name).to.equal('express.middleware.route.get.anonymous');
+      expect(String(routeSpan.parentSpan.id)).to.equal(String(routerSpan.id));
+
+      expect(serverlessSdk.traceSpans.root.tags.get('aws.lambda.http_router.path')).to.equal(
+        '/lorem/:dog/ipsum/:cat/dolor'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Resolve properly paramterized paths as passed to `app.use()` routing method.

It was observed that with nested working constructed as follows, the first part of the path is assigned as resolved to 
`aws.lambda.http_router.path` tag

```javascript
 const paramRouter = new express.Router();
 paramRouter.get('/ipsum/:cat', (req, res) => { res.send('"ok"');  });

app.use('/lorem/:dog', paramRouter);
```