### PR TITLE
SDK: Ensure to resolve stack trace only for exposed logs

### DIFF
--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -144,11 +144,15 @@ const install = (protocol, httpModule) => {
 
   const request = function request(...args) {
     const startTime = process.hrtime.bigint();
-    serverlessSdk._debugLog(
-      'HTTP request',
-      shouldIgnoreFollowingRequest,
-      !shouldIgnoreFollowingRequest && new Error().stack
-    );
+    if (serverlessSdk._isDebugMode) {
+      // Generate stack trace only if intend to write this log
+      // (stack trace generation can be expensive, esecially with source map generation on)
+      serverlessSdk._debugLog(
+        'HTTP request',
+        shouldIgnoreFollowingRequest,
+        !shouldIgnoreFollowingRequest && new Error().stack
+      );
+    }
     let [url, options] = args;
 
     let cbIndex = 2;


### PR DESCRIPTION
/cc @eahefnawy 

Addresses internally reported issue, where it was observed that for instrumented function duration is significantly worse.

It was caused by two things:
- Source maps being enabled  (set via `NODE_OPTIONS=--enable-source-maps`)
- Unconditionally resolved stack trace for debug log (which was to be written at start of each monitored HTTP request)

When source maps are enabled, resolution of stack traces is significantly more expensive, and as there was an attempt to resolve a stack trace with each monitored HTTP request, it put performance of the function down.

This patch ensures that we do not resolve the stack trace if debug mode is not explicitly turned on for the SDK, having that issue is not longer observed (unless `SLS_SDK_DEBUG` is set for the lambda)