### PR TITLE
chore: Release python lambda sdk version 0.1.16

### DIFF
--- a/python/packages/aws-lambda-sdk/CHANGELOG.md
+++ b/python/packages/aws-lambda-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.1.16 (2023-05-03)
+
+### Bug Fixes
+
+- Sanitize service/operation names when instrumenting AWS SDK
+
 ## 0.1.15 (2023-04-27)
 
 ### Bug Fixes

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-aws-lambda-sdk"
-version = "0.1.15"
+version = "0.1.16"
 description = "Serverless AWS Lambda SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
To release AWS SDK instrumentation fix https://github.com/serverless/console/pull/705