### PR TITLE
Fix linter by specifying python classifiers

### DIFF
--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd python/packages
 
-          python3 -m pip install pyproject-fmt
+          python3 -m pip install tox pyproject-fmt
 
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -12,6 +12,14 @@ description = "Serverless AWS Lambda SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
 dependencies = [
     "aiohttp~=3.8",
     "serverless-sdk~=0.4.5",

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -12,6 +12,14 @@ description = "The protobuf generated Serverless SDK Schema"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
 dependencies = [
     "protobuf>=4.22",
     "typing-extensions>=4.4", # included in Python 3.8 - 3.11

--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -12,6 +12,14 @@ description = "Serverless SDK for Python"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]
 requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
 dependencies = [
     "backports.cached-property", # included in Python >=3.8
     "blinker>=1.5",


### PR DESCRIPTION
### Description
* Python validate actions https://github.com/serverless/console/actions/runs/4870227815/jobs/8685720884?pr=711 are failing with a linter error on project config file.
* The linter released a new version which tightens the check, so we are now adding the programming language classifiers for each project.
* This will allow clients on pypi to filter by programming language, such as https://pypi.org/search/?c=Programming+Language+%3A%3A+Python+%3A%3A+3+%3A%3A+Only

### Testing done
Ran the linter by running:

```
python -m pip install tox pyproject-fmt
python -m pyproject_fmt --indent 4 pyproject.toml
```