### PR TITLE
Draft: Add other vendors to benchmark

### DIFF
--- a/node/test/benchmark/lib/resolve-use-cases-config/python.js
+++ b/node/test/benchmark/lib/resolve-use-cases-config/python.js
@@ -29,6 +29,21 @@ module.exports = async (coreConfig) => {
       },
     ],
     [
+      'lumigo',
+      {
+        configuration: {
+          Handler: 'lumigo_tracer._handler',
+          Layers: ['arn:aws:lambda:us-east-1:114300393969:layer:lumigo-python-tracer:250'],
+          Environment: {
+            Variables: {
+              LUMIGO_ORIGINAL_HANDLER: 'success.handler',
+              LUMIGO_TRACER_TOKEN: 'dummy',
+            },
+          },
+        },
+      },
+    ],
+    [
       'external',
       {
         configuration: {


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead#comment-c563f986