### PR TITLE
SDK: Trace spans black boxing

### DIFF
--- a/node/packages/sdk/index.js
+++ b/node/packages/sdk/index.js
@@ -127,7 +127,7 @@ if (serverlessSdk._isDebugMode) Error.stackTraceLimit = Infinity;
 
 serverlessSdk._eventEmitter = require('./lib/emitter');
 
-Object.defineProperties(
-  serverlessSdk,
-  lazy({ _customTags: d('cew', () => new Tags(), { flat: true }) })
-);
+Object.defineProperties(serverlessSdk, {
+  _isInTraceSpanBlackBox: d.gs(() => TraceSpan.isInBlackBox),
+  ...lazy({ _customTags: d('cew', () => new Tags(), { flat: true }) }),
+});

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -178,7 +178,8 @@ const install = (protocol, httpModule) => {
     if (
       shouldIgnoreFollowingRequest ||
       options._slsIgnore ||
-      (originalCb && typeof originalCb !== 'function')
+      (originalCb && typeof originalCb !== 'function') ||
+      serverlessSdk._isInTraceSpanBlackBox
     ) {
       shouldIgnoreFollowingRequest = false;
       return originalRequest.apply(this, args);

--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -144,15 +144,6 @@ const install = (protocol, httpModule) => {
 
   const request = function request(...args) {
     const startTime = process.hrtime.bigint();
-    if (serverlessSdk._isDebugMode) {
-      // Generate stack trace only if intend to write this log
-      // (stack trace generation can be expensive, esecially with source map generation on)
-      serverlessSdk._debugLog(
-        'HTTP request',
-        shouldIgnoreFollowingRequest,
-        !shouldIgnoreFollowingRequest && new Error().stack
-      );
-    }
     let [url, options] = args;
 
     let cbIndex = 2;
@@ -280,10 +271,8 @@ module.exports.install = () => {
 
 module.exports.ignoreFollowingRequest = () => {
   if (!isInstalled) return;
-  serverlessSdk._debugLog('ignore HTTP request', shouldIgnoreFollowingRequest);
   shouldIgnoreFollowingRequest = true;
   process.nextTick(() => {
-    serverlessSdk._debugLog('reset ignore HTTP request', shouldIgnoreFollowingRequest);
     shouldIgnoreFollowingRequest = false;
   });
 };


### PR DESCRIPTION
Internally we have a use case of not exposing sub spans when we're in context of specific trace span.

e.g. when in context of AWS SDK span we do not want to expose underlying HTTP request with extra span. So far we mitigated that with a primitive approach, where we were assuming that HTTP request is initialized in sequence synchronously and we were marking given HTTP request to not be instrumented.

This doesn't work for case where AWS SDK approaches temporary network issue and implies a retry, as then following HTTP request happens _async_ and appears as reported, which is not wanted. Very occasionally we observed integration test failures due to that (e.g. https://github.com/serverless/console/actions/runs/4810414588/jobs/8563030944)

This PR introduces an internal concept of black box trace spans. Where we can mark span as black box and that way ensure no child spans of it will be exposed. Even if some logic will add spans to such black box span (which is not prevented in any way), they will not be exposed in final trace report, or propagated to dev mode

--- 

Additionally removed debug logs, which were added to help investigate the issue of HTTP spans being exposed when run in context of AWS SDK request