### PR TITLE
Handle import errors

### DIFF
--- a/python/packages/aws-lambda-sdk/tests/conftest.py
+++ b/python/packages/aws-lambda-sdk/tests/conftest.py
@@ -20,8 +20,17 @@ def reset_sdk_dev_mode(monkeypatch, request):
     yield _reset_sdk(monkeypatch, request, True, True)
 
 
+@pytest.fixture()
+def reset_sdk_no_import(monkeypatch, request):
+    yield _reset_sdk(monkeypatch, request, False, False, False)
+
+
 def _reset_sdk(
-    monkeypatch, request, is_dev_mode: bool = False, is_debug_mode: bool = False
+    monkeypatch,
+    request,
+    is_dev_mode: bool = False,
+    is_debug_mode: bool = False,
+    import_sdk: bool = True,
 ):
     for key in list(sys.modules.keys()):
         if [prefix for prefix in ["serverless_", "sls_"] if key.startswith(prefix)]:
@@ -45,7 +54,8 @@ def _reset_sdk(
             monkeypatch.setenv(key, request.param[key])
 
     # make sure the SDK is imported
-    importlib.import_module("serverless_aws_lambda_sdk")
+    if import_sdk:
+        importlib.import_module("serverless_aws_lambda_sdk")
     return monkeypatch
 
 

--- a/python/packages/aws-lambda-sdk/tests/internal_extension/test_internal_extension_wrapper.py
+++ b/python/packages/aws-lambda-sdk/tests/internal_extension/test_internal_extension_wrapper.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sys
 from unittest.mock import patch
 
 
@@ -87,3 +88,29 @@ def test_exec_wrapper_returns_uninstrumented_handler_if_initialization_error(
     assert os.environ["_HANDLER"] == lambda_handler
     assert os.environ.get("_ORIGIN_HANDLER") is None
     assert response == "ok"
+
+
+def test_exec_wrapper_returns_uninstrumented_handler_if_import_error(
+    reset_sdk_no_import, monkeypatch
+):
+    # given
+    env = dict(os.environ)
+    monkeypatch.setattr(os, "environ", env)
+
+    lambda_handler = "success.handler"
+    monkeypatch.setenv("_ORIGIN_HANDLER", lambda_handler)
+    monkeypatch.setitem(sys.modules, "google.protobuf", None)
+
+    # when
+    with patch("builtins.print") as mocked_print:
+        import serverless_aws_lambda_sdk.internal_extension.wrapper as wrapper
+
+        response = wrapper.handler({}, {})
+
+    # then
+    assert os.environ["_HANDLER"] == lambda_handler
+    assert os.environ.get("_ORIGIN_HANDLER") is None
+    assert response == "ok"
+
+    assert mocked_print.call_count == 1
+    assert mocked_print.call_args[0][0].startswith("Fatal Serverless SDK Error: ")


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-977/user-thetie-seeing-error-in-production-mode-with-python-sdk
* Handle import errors from the SDK (including 3rd party dependencies) by falling back to just executing the customer's handler function.

### Testing done
* Reproduced in a unit test
* Unit/integration tested