### PR TITLE
[Python] Emit types from sdk-schema

### DIFF
--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -36,5 +36,8 @@ documentation = "https://github.com/serverless/console/tree/main/python/packages
 homepage = "https://www.serverless.com/console"
 repository = "https://github.com/serverless/console"
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [tool.ruff]
 ignore = ["F401"]


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-628/python-sdk-type-checking
* Package the "py.typed" file so we can use the types from the sdk-schema package when running static type checking.

### Testing done
I've tested by removing the ignore type line from https://github.com/serverless/console/pull/714/files#diff-f65297473acc7c577d9b389639983b6fbaa366723b8a1f072c2e2715dfeece10