### PR TITLE
chore: Release python sdk schema v 0.2.2

### DIFF
--- a/python/packages/sdk-schema/CHANGELOG.md
+++ b/python/packages/sdk-schema/CHANGELOG.md
@@ -2,19 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.2.2 (2023-05-08)
+
+### Maintenance Improvements
+
+- Support static type checking
+
 ## 0.2.1 (2023-04-07)
 
 ### Features
 
 - AWS Lambda runtime related tags
 
-### 0.2.0 (2023-03-28)
+## 0.2.0 (2023-03-28)
 
 ### ⚠ BREAKING CHANGES
 
 - Switch to protoc compiler instead of betterproto
 
-### 0.1.1 (2023-03-17)
+## 0.1.1 (2023-03-17)
 
 ### Maintenance Improvements
 
@@ -22,6 +28,6 @@ All notable changes to this project will be documented in this file. See [standa
 - Remove alternative install method
 - Remove tests from distributed package
 
-### 0.1.0 (2023-02-22)
+## 0.1.0 (2023-02-22)
 
 - Initial Release of Schema ([c359118](https://github.com/serverless/console/commit/c3591187e854af1bad6fcac28d612e73c4daecc0))

--- a/python/packages/sdk-schema/pyproject.toml
+++ b/python/packages/sdk-schema/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "serverless-sdk-schema"
-version = "0.2.1"
+version = "0.2.2"
 description = "The protobuf generated Serverless SDK Schema"
 readme = "README.md"
 authors = [{ name = "serverlessinc" }]


### PR DESCRIPTION
Related issue https://linear.app/serverless/issue/SC-628/python-sdk-type-checking