### PR TITLE
[Python base SDK] Remove wrapt dependency

### DIFF
--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "blinker>=1.5",
     "js-regex<1.1.0,>=1.0.1",
     "typing-extensions>=4.4", # included in Python 3.8 - 3.11
-    "wrapt~=1.15.0",
 ]
 [project.optional-dependencies]
 tests = [
@@ -68,10 +67,6 @@ disable_error_code = "override,assignment,arg-type"
 exclude = [
     '^tests/',
 ]
-
-[[tool.mypy.overrides]]
-module = "wrapt"
-ignore_missing_imports = true
 
 [tool.ruff]
 ignore = ["F401", "E722"]

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs
 from ..error import report as report_error
 from .import_hook import ImportHook
 import sls_sdk
-from wrapt import wrap_function_wrapper, ObjectProxy
+from .wrapper import replace_method
 import io
 from typing import Iterable
 
@@ -415,7 +415,7 @@ class URLLib3Instrumenter(BaseInstrumenter):
 
     def _install(self, module):
         self._module = module
-        wrap_function_wrapper(
+        replace_method(
             module.connectionpool.HTTPConnectionPool,
             self._target_method,
             self._patched_call,
@@ -425,11 +425,7 @@ class URLLib3Instrumenter(BaseInstrumenter):
         _wrapping_method = getattr(
             module.connectionpool.HTTPConnectionPool, self._target_method, None
         )
-        if (
-            _wrapping_method
-            and isinstance(_wrapping_method, ObjectProxy)
-            and hasattr(_wrapping_method, "__wrapped__")
-        ):
+        if hasattr(_wrapping_method, "__wrapped__"):
             setattr(
                 module.connectionpool.HTTPConnectionPool,
                 self._target_method,

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/wrapper.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/wrapper.py
@@ -1,0 +1,28 @@
+from functools import partial
+
+
+class ReplacementMethod(object):
+    def __init__(self, class_, method_name, target_method) -> None:
+        self.class_ = class_
+        self.method_name = method_name
+        self.target_method = target_method
+        self.original_method = getattr(class_, method_name)
+
+    def get_target_method(self):
+        def _target_method(instance, *args, **kwargs):
+            return self.target_method(
+                partial(self.original_method, instance), instance, args, kwargs
+            )
+
+        _target_method.__wrapped__ = self.original_method
+        return _target_method
+
+
+def replace_method(class_, method_name, target_method):
+    # replace class_.method_name with replacement_method
+    # keep reference to original
+    # pass the original instance as argument
+    # pass the original method as argument, but it should be bounded to the instance
+
+    proxy = ReplacementMethod(class_, method_name, target_method)
+    setattr(class_, method_name, proxy.get_target_method())

--- a/python/packages/sdk/sls_sdk/lib/trace.py
+++ b/python/packages/sdk/sls_sdk/lib/trace.py
@@ -23,7 +23,7 @@ from .emitter import event_emitter
 from .id import generate_id
 from .name import get_resource_name
 from .tags import Tags, convert_tags_to_protobuf
-from wrapt import wrap_function_wrapper
+from .instrumentation.wrapper import replace_method
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def _install_thread_hook(threading_module):
         result = actual_start(*args, **kwargs)
         return result
 
-    wrap_function_wrapper(threading_module.Thread, "start", _thread_ctor_wrapper)
+    replace_method(threading_module.Thread, "start", _thread_ctor_wrapper)
 
 
 _import_hook = ImportHook("threading")

--- a/python/packages/sdk/tests/conftest.py
+++ b/python/packages/sdk/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import sys
 import importlib
-from wrapt import ObjectProxy
 from . import TEST_ORG, TEST_DEV_MODE_ORG_ID
 
 
@@ -17,11 +16,7 @@ def _uninstall():
 
     def _uninstall_threading_hook(threading):
         _wrapping_method = getattr(threading.Thread, "start", None)
-        if (
-            _wrapping_method
-            and isinstance(_wrapping_method, ObjectProxy)
-            and hasattr(_wrapping_method, "__wrapped__")
-        ):
+        if hasattr(_wrapping_method, "__wrapped__"):
             setattr(
                 threading.Thread,
                 "start",

--- a/python/packages/sdk/tests/lib/instrumentation/test_wrapper.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_wrapper.py
@@ -1,0 +1,34 @@
+from sls_sdk.lib.instrumentation.wrapper import replace_method
+
+
+def test_replace_method():
+    # given
+    class Foo(object):
+        def __init__(self):
+            self.foo = "foo"
+
+        def bar(self):
+            return "bar"
+
+    class Target(object):
+        def method(self, original_method, instance, args, kwargs):
+            original_result = original_method(*args, **kwargs)
+            return (original_result, "baz", instance.foo)
+
+    # when
+    original = Foo.bar
+    foo = Foo()
+    result = foo.bar()
+
+    # then
+    assert result == "bar"
+
+    # when
+    target = Target()
+    replace_method(Foo, "bar", target.method)
+    result = foo.bar()
+
+    # then
+    assert result == ("bar", "baz", "foo")
+    target_method = getattr(foo, "bar")
+    assert target_method.__wrapped__ == original


### PR DESCRIPTION
### Description
* Related issues https://linear.app/serverless/issue/SC-606/python-sdk-very-large-extension-layer-size & https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead
* We were using wrapt when instrumenting 3rd party libraries, we only use a small functionality which is easy to implement and save some space and performance by not importing wrapt.

### Testing done
Unit/integration tested.