### PR TITLE
[Python Lambda SDK] Remove wrapt dependency

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -34,7 +34,6 @@ tests = [
     "boto3>=1.16.112",
     "flask>=2.2.3",
     "importlib_metadata>=5.2", # included in Python >=3.8
-    "moto>=4.1.7",
     "mypy>=1.2",
     "pynamodb>=5.5",
     "pytest>=7.2",

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -23,10 +23,9 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "serverless-sdk~=0.4.6",
+    "serverless-sdk~=0.4.7",
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
-    "wrapt~=1.15.0",
     "yarl~=1.8.0",
 ]
 [project.optional-dependencies]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
@@ -10,7 +10,7 @@ from sls_sdk.lib.instrumentation.wrapper import replace_method
 import re
 
 _instrumenter = None
-_import_hook = ImportHook("botocore.client")
+_import_hook = ImportHook("botocore")
 
 
 def _sanitize_span_name(name):
@@ -20,8 +20,10 @@ def _sanitize_span_name(name):
 class Instrumenter:
     target_method = "_make_api_call"
 
-    def __init__(self, botocore_client):
-        self._botocore_client = botocore_client
+    def __init__(self, botocore):
+        import botocore.client
+
+        self._botocore_client = botocore.client
 
     def install(self, should_monitor_request_response):
         self._should_monitor_request_response = should_monitor_request_response
@@ -104,16 +106,16 @@ class Instrumenter:
             reset_ignore_following_request()
 
 
-def _hook(botocore_client):
+def _hook(botocore):
     global _instrumenter
-    _instrumenter = Instrumenter(botocore_client)
+    _instrumenter = Instrumenter(botocore)
     _instrumenter.install(
         serverlessSdk._is_dev_mode
         and not serverlessSdk._settings.disable_request_response_monitoring
     )
 
 
-def _undo_hook(botocore_client):
+def _undo_hook(botocore):
     global _instrumenter
     _instrumenter.uninstall()
     _instrumenter = None

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
@@ -8,6 +8,7 @@ from sls_sdk.lib.instrumentation.http import (
 )
 from sls_sdk.lib.instrumentation.wrapper import replace_method
 import re
+import importlib
 
 _instrumenter = None
 _import_hook = ImportHook("botocore")
@@ -21,9 +22,7 @@ class Instrumenter:
     target_method = "_make_api_call"
 
     def __init__(self, botocore):
-        import botocore.client
-
-        self._botocore_client = botocore.client
+        self._botocore_client = importlib.import_module("botocore.client")
 
     def install(self, should_monitor_request_response):
         self._should_monitor_request_response = should_monitor_request_response

--- a/python/packages/aws-lambda-sdk/tests/conftest.py
+++ b/python/packages/aws-lambda-sdk/tests/conftest.py
@@ -34,6 +34,8 @@ def _reset_sdk(
         "aiohttp",
         "requests",
         "flask",
+        "boto3",
+        "botocore",
         "serverless_aws_lambda_sdk",
     ]
     deleted_modules = []
@@ -61,7 +63,7 @@ def _reset_sdk(
 
     # make sure 3rd party dependencies are imported
     for module in deleted_modules + module_prefixes_to_delete:
-        if not module.startswith("serverless_"):
+        if not module.startswith("serverless_aws_lambda_sdk"):
             importlib.import_module(module)
 
     # finally, make sure the SDK is imported

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
@@ -739,7 +739,12 @@ def test_instrument_dynamodb(instrumenter, monkeypatch):
         def handler(event, context):
             import boto3
 
-            client = boto3.client("dynamodb", region_name="us-east-1")
+            client = boto3.client(
+                "dynamodb",
+                region_name="us-east-1",
+                aws_access_key_id="foo",
+                aws_secret_access_key="bar",
+            )
             stubber = Stubber(client)
             response = {
                 "ResponseMetadata": {
@@ -753,7 +758,12 @@ def test_instrument_dynamodb(instrumenter, monkeypatch):
             stubber.add_response("delete_table", response)
             stubber.activate()
 
-            dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+            dynamodb = boto3.resource(
+                "dynamodb",
+                region_name="us-east-1",
+                aws_access_key_id="foo",
+                aws_secret_access_key="bar",
+            )
             resource_stubber = Stubber(dynamodb.meta.client)
             resource_stubber.add_response("query", response)
             resource_stubber.activate()

--- a/python/packages/aws-lambda-sdk/tests/instrumentation/test_aws_sdk.py
+++ b/python/packages/aws-lambda-sdk/tests/instrumentation/test_aws_sdk.py
@@ -41,7 +41,12 @@ def test_aws_sdk_instrumentation_s3(instrumenter):
     # given
     import boto3
 
-    client = boto3.client("s3", region_name="us-east-1")
+    client = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     stubber = Stubber(client)
     stubber.add_response("create_bucket", {})
     stubber.activate()
@@ -69,7 +74,12 @@ def test_aws_sdk_instrumentation_in_dev_mode_s3(instrumenter_dev):
     # given
     import boto3
 
-    client = boto3.client("s3", region_name="us-east-1")
+    client = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     stubber = Stubber(client)
     response = {
         "ResponseMetadata": {
@@ -109,7 +119,12 @@ def test_aws_sdk_instrumentation_error(instrumenter):
     # given
     import boto3
 
-    client = boto3.client("s3", region_name="us-east-1")
+    client = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     stubber = Stubber(client)
     stubber.add_client_error(
         "head_object",
@@ -157,7 +172,12 @@ def test_aws_sdk_instrumentation_of_dynamodb(instrumenter, monkeypatch):
 
     import boto3
 
-    client = boto3.client("dynamodb", region_name="us-east-1")
+    client = boto3.client(
+        "dynamodb",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     stubber = Stubber(client)
     response = {
         "ResponseMetadata": {
@@ -201,7 +221,12 @@ def test_aws_sdk_instrumentation_of_dynamodb(instrumenter, monkeypatch):
         ExpressionAttributeValues={":country": {"S": "France"}},
     )
 
-    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    dynamodb = boto3.resource(
+        "dynamodb",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     resource_stubber = Stubber(dynamodb.meta.client)
     resource_stubber.add_response("query", response)
     resource_stubber.activate()
@@ -255,7 +280,12 @@ def test_aws_sdk_servicequotas_instrumentation(instrumenter):
     # given
     import boto3
 
-    client = boto3.client("service-quotas", region_name="us-east-1")
+    client = boto3.client(
+        "service-quotas",
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+    )
     stubber = Stubber(client)
     response = {
         "ResponseMetadata": {


### PR DESCRIPTION
### Description
* Related issues https://linear.app/serverless/issue/SC-606/python-sdk-very-large-extension-layer-size & https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead
* Related PR https://github.com/serverless/console/pull/731
* We were using wrapt when instrumenting 3rd party libraries, we only use a small functionality which is easy to implement and save some space and performance by not importing wrapt.

### Testing done
Unit/integration tested.