### PR TITLE
[Python Lambda SDK] Forbid unused imports

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -72,5 +72,4 @@ module = "wrapt"
 ignore_missing_imports = true
 
 [tool.ruff]
-ignore = ["F401", "E722"]
 exclude = ["tests"]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import os
 import logging
 from typing import Optional
-from typing_extensions import Final
 import sys
 import inspect
 from pathlib import Path

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec_wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/exec_wrapper.py
@@ -84,7 +84,7 @@ def _set_handler():
 def main():
     try:
         _set_handler()
-    except:
+    except:  # noqa: E722
         import traceback
 
         print(


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-628/python-sdk-type-checking
* Do not ignore unused imports
* Ignore bare except block inline

### Testing done
CI/CD should validate