### PR TITLE
[Python base SDK] Improve linter config

### DIFF
--- a/python/packages/sdk/pyproject.toml
+++ b/python/packages/sdk/pyproject.toml
@@ -67,7 +67,3 @@ disable_error_code = "override,assignment,arg-type"
 exclude = [
     '^tests/',
 ]
-
-[tool.ruff]
-ignore = ["F401", "E722"]
-#fix = true

--- a/python/packages/sdk/sls_sdk/lib/error.py
+++ b/python/packages/sdk/sls_sdk/lib/error.py
@@ -45,6 +45,6 @@ def report(error, type: str = "INTERNAL"):
             type="handledSdkUser" if type == "USER" else "handledSdkInternal",
             origin="pythonLogging",
         )
-    except:
+    except:  # noqa: E722
         # ignore
         pass

--- a/python/packages/sdk/tests/lib/test_error.py
+++ b/python/packages/sdk/tests/lib/test_error.py
@@ -82,7 +82,7 @@ def test_error_with_custom_object(monkeypatch):
 
 def test_error_with_crash_exception(monkeypatch):
     # given
-    from sls_sdk.lib.error import report as report_error, logger
+    from sls_sdk.lib.error import report as report_error
 
     error = Exception("Something went wrong")
     monkeypatch.setenv("SLS_CRASH_ON_SDK_ERROR", "1")
@@ -95,7 +95,7 @@ def test_error_with_crash_exception(monkeypatch):
 
 def test_error_with_crash_custom_object(monkeypatch):
     # given
-    from sls_sdk.lib.error import report as report_error, logger
+    from sls_sdk.lib.error import report as report_error
 
     error = "Something went wrong"
     monkeypatch.setenv("SLS_CRASH_ON_SDK_ERROR", "1")

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -8,7 +8,7 @@ from . import get_params
 
 def test_can_import_serverless_sdk(reset_sdk):
     try:
-        from sls_sdk import serverlessSdk
+        from sls_sdk import serverlessSdk  # noqa: F401
 
     except ImportError as e:
         raise AssertionError("Cannot import `serverlessSdk`") from e
@@ -185,7 +185,7 @@ def test_sdk_set_tag_does_not_crash_on_invalid_input(reset_sdk, monkeypatch):
     failed = False
     try:
         sdk.set_tag(tag_name, tag_value)
-    except:
+    except Exception:
         failed = True
 
     # then


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-628/python-sdk-type-checking
* Do not ignore unused imports
* Ignore bare except block inline

### Testing done
CI/CD should validate