### PR TITLE
AWS Lambda SDK: Improve size of written telemetry log by gzipping it

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const zlib = require('zlib');
 const ensurePlainFunction = require('type/plain-function/ensure');
 const traceProto = require('@serverless/sdk-schema/dist/trace');
 const requestResponseProto = require('@serverless/sdk-schema/dist/request_response');
@@ -158,7 +159,7 @@ const reportTrace = ({ isErrorOutcome }) => {
   });
   const payloadBuffer = (serverlessSdk._lastTraceBuffer =
     traceProto.TracePayload.encode(payload).finish());
-  process._rawDebug(`SERVERLESS_TELEMETRY.T.${payloadBuffer.toString('base64')}`);
+  process._rawDebug(`SERVERLESS_TELEMETRY.TZ.${zlib.gzipSync(payloadBuffer).toString('base64')}`);
 };
 
 const resolveOutcomeEnumValue = (value) => {


### PR DESCRIPTION
An internal investigation showed that gzipped trace payloads take 40-60% less of space

@czubocha @Mmarzex I'll hold off merging it until I have confirmation that we support that on the backend side