### PR TITLE
Remove yarl dependency

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -1068,7 +1068,7 @@ describe('Python: integration', function () {
 
   before(async () => {
     exec(
-      `pip install pynamodb==5.5.0 aiohttp==3.8.4 serverless-wsgi==3.0.2 flask==2.2.3 --target="${fixturesDirname}/test_dependencies"`
+      `pip install pynamodb==5.5.0 yarl==1.8.2 aiohttp==3.8.4 serverless-wsgi==3.0.2 flask==2.2.3 --target="${fixturesDirname}/test_dependencies"`
     );
     exec(
       [

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "serverless-sdk~=0.4.7",
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
-    "yarl~=1.8.0",
 ]
 [project.optional-dependencies]
 tests = [
@@ -43,6 +42,7 @@ tests = [
     "ruff>=0.0.199",
     "serverless-wsgi>=3.0.2",
     "types-protobuf>=4.22.0.2",
+    "yarl~=1.8.0",
 ]
 [project.urls]
 changelog = "https://github.com/serverless/console/blob/main/python/packages/aws-lambda-sdk/CHANGELOG.md"


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-606/python-sdk-very-large-extension-layer-size#comment-18e1b26b
* Remove dependency on yarl, we do not need yarl directly, it's a transitive dependency of aiohttp which we don't depend on anymore

### Testing done
Integration/unit tested.