### PR TITLE
[Python Lambda SDK] Trim down protobuf when bundling the layer

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -207,6 +207,7 @@ jobs:
         run: |
           cd python/packages/aws-lambda-sdk
           python3 -m pip install . --target=dist
+          rm -rf dist/google/_upb
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/.github/workflows/python-publish-aws-lambda-sdk.yml
+++ b/.github/workflows/python-publish-aws-lambda-sdk.yml
@@ -44,6 +44,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           python3 -m pip install . --target=dist
+          rm -rf dist/google/_upb
 
       - name: Create lambda layer package
         run: |


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-606/python-sdk-very-large-extension-layer-size#comment-18e1b26b
* Remove the unused C backend implementation from protobuf when bundling the layer. More information on the backends available in protobuf => https://github.com/protocolbuffers/protobuf/tree/main/python#implementation-backends
* This cuts down the size of the zipped layer archive around 200KB, resulting in a layer of size 650KB when bundled from my local machine

### Testing done
Integration tested to make sure removal of the binary does not break the SDK.