### PR TITLE
[Python Lambda SDK] Remove byte-code from layer

### DIFF
--- a/.github/workflows/python-integrate.yaml
+++ b/.github/workflows/python-integrate.yaml
@@ -207,6 +207,8 @@ jobs:
         run: |
           cd python/packages/aws-lambda-sdk
           python3 -m pip install . --target=dist
+          python3 -m pip install pyclean
+          python3 -m pyclean dist
           rm -rf dist/google/_upb
 
       - name: Install Node.js and npm

--- a/.github/workflows/python-publish-aws-lambda-sdk.yml
+++ b/.github/workflows/python-publish-aws-lambda-sdk.yml
@@ -44,6 +44,8 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           python3 -m pip install . --target=dist
+          python3 -m pip install pyclean
+          python3 -m pyclean dist
           rm -rf dist/google/_upb
 
       - name: Create lambda layer package


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-606/python-sdk-very-large-extension-layer-size
* When creating the lambda layer, remove the byte-code (`__pycache__/*.pyc` files)
* The removed files will be auto-generated by Python anyway, when the layer is mounted and gets imported.
* Bundle size is down to 330KB from 650KB on my dev environment
* The removal improves INIT time by around 30ms.

### Testing done
* Integration tested
* Performance tested