### PR TITLE
Do not report error on http body capture

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -26,6 +26,17 @@ def reset_ignore_following_request():
 _HTTP_SPAN = contextvars.ContextVar("http-span", default=None)
 
 
+def safe_call(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            return None
+
+    return wrapper
+
+
+@safe_call
 def _decode_body(body):
     if isinstance(body, bytes):
         return body.decode("utf-8")


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1012/python-sdk-customer-receiving-error-unicodedecodeerror
* Do not report an error in case we can't decode the http request/response body

### Testing done
* Reproduced in a unit test
* Integration tested
