### PR TITLE
Handle datetime json serialization

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -57,7 +57,7 @@ def _resolve_body_string(data, prefix):
                     f"{prefix}_BODY_BINARY",
                     serverlessSdk.trace_spans.aws_lambda,
                 )
-    stringified_body = json.dumps(data)
+    stringified_body = json.dumps(data, default=str)
     if len(stringified_body) > 1024 * 127:
         serverlessSdk._report_notice(
             "Large body excluded",

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/safe_stringify.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/safe_stringify.py
@@ -4,7 +4,7 @@ import serverless_aws_lambda_sdk
 
 def safe_stringify(value):
     try:
-        return json.dumps(value)
+        return json.dumps(value, default=str)
     except TypeError as ex:
         serverless_aws_lambda_sdk.serverlessSdk._report_warning(
             "Detected not serializable value in AWS SDK request:\n"

--- a/python/packages/aws-lambda-sdk/tests/lib/instrumentation/aws_sdk/test_safe_stringify.py
+++ b/python/packages/aws-lambda-sdk/tests/lib/instrumentation/aws_sdk/test_safe_stringify.py
@@ -1,6 +1,7 @@
 from serverless_aws_lambda_sdk.lib.instrumentation.aws_sdk.safe_stringify import (
     safe_stringify,
 )
+from datetime import datetime
 
 
 def test_safe_stringify_success():
@@ -16,10 +17,22 @@ def test_safe_stringify_success():
 
 def test_safe_stringify_failure():
     # given
-    input = {"foo": object()}
+    input = {object(): object()}
 
     # when
     result = safe_stringify(input)
 
     # then
     assert result is None
+
+
+def test_safe_stringify_with_datetime():
+    # given
+    now = datetime.now()
+    input = {"timestamp": now}
+
+    # when
+    result = safe_stringify(input)
+
+    # then
+    assert result == f'{{"timestamp": "{str(now)}"}}'


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1011/python-sdk-customer-receiving-warning-detected-not-serializable-value
* When json serializing, certain types like datetime are not json serializable. This ensures that the string representation of such types are used. For the case of datetime, string representation is ISO 8601 format, `YYYY-MM-DDTHH:MM:SS.ffffff`

### Testing done
* Reproduced in a unit test
* Integration tested
