### PR TITLE
[Python Lambda SDK] Gzip telemetry payloads

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -19,6 +19,7 @@ from .lib.response_tags import resolve as resolve_response_tags
 from sls_sdk.lib.trace import TraceSpan
 from sls_sdk.lib.captured_event import CapturedEvent
 import base64
+import zlib
 
 
 def debug_log(msg):
@@ -218,8 +219,9 @@ class Instrumenter:
             else None,
         }
         payload = to_trace_payload(payload_dct)
+        compressed_payload = zlib.compress(payload.SerializeToString())
         print(
-            f"SERVERLESS_TELEMETRY.T.{base64.b64encode(payload.SerializeToString()).decode('utf-8')}"
+            f"SERVERLESS_TELEMETRY.TZ.{base64.b64encode(compressed_payload).decode('utf-8')}"
         )
 
     def _flush_and_close_event_loop(self):

--- a/python/packages/aws-lambda-sdk/tests/instrument/serialization.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/serialization.py
@@ -1,0 +1,10 @@
+import zlib
+from serverless_sdk_schema import TracePayload
+import base64
+
+
+TARGET_LOG_PREFIX = "SERVERLESS_TELEMETRY.TZ."
+
+
+def deserialize_trace(trace):
+    return TracePayload.FromString(zlib.decompress(base64.b64decode(trace)))

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_aws_lambda_events.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_aws_lambda_events.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 import pytest
 from .. import context
-from serverless_sdk_schema import TracePayload, RequestResponse
-import base64
-
-_TARGET_LOG_PREFIX = "SERVERLESS_TELEMETRY.T."
+from .serialization import TARGET_LOG_PREFIX, deserialize_trace
 
 
 @pytest.fixture()
@@ -80,11 +77,11 @@ def test_handle_api_gateway_rest_api_event(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.apigateway"
     assert lambda_tags.event_type == "aws.apigateway.rest"
@@ -183,11 +180,11 @@ def test_handle_api_gateway_v2_http_api_payload_v1_event(instrumenter, mocked_pr
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.apigateway"
     assert lambda_tags.event_type == "aws.apigatewayv2.http.v1"
@@ -259,11 +256,11 @@ def test_handle_api_gateway_v2_http_api_payload_v2_event(instrumenter, mocked_pr
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.apigateway"
     assert lambda_tags.event_type == "aws.apigatewayv2.http.v2"
@@ -334,11 +331,11 @@ def test_handle_function_url_payload_event(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.lambda"
     assert lambda_tags.event_type == "aws.lambda.url"
@@ -411,11 +408,11 @@ def test_handle_sqs_event(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.sqs"
     assert lambda_tags.event_type == "aws.sqs"
@@ -478,11 +475,11 @@ def test_handle_sns_event(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     lambda_tags = trace_payload.spans[0].tags.aws.__getattribute__("lambda")
     assert lambda_tags.event_source == "aws.sns"
     assert lambda_tags.event_type == "aws.sns"

--- a/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/test_instrument.py
@@ -10,13 +10,10 @@ from .test_assertions import (
     assert_hexadecimal,
 )
 from serverless_sdk_schema import TracePayload, RequestResponse
-import base64
 from werkzeug.wrappers import Request, Response
 from pytest_httpserver import HTTPServer
 from botocore.stub import Stubber
-
-
-_TARGET_LOG_PREFIX = "SERVERLESS_TELEMETRY.T."
+from .serialization import TARGET_LOG_PREFIX, deserialize_trace
 
 
 @pytest.fixture()
@@ -70,11 +67,11 @@ def test_instrument_lambda_success(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -112,8 +109,8 @@ def test_instrument_subsequent_calls(instrumenter):
         first = [
             x[0][0]
             for x in mocked_print.call_args_list
-            if x[0][0].startswith(_TARGET_LOG_PREFIX)
-        ][0].replace(_TARGET_LOG_PREFIX, "")
+            if x[0][0].startswith(TARGET_LOG_PREFIX)
+        ][0].replace(TARGET_LOG_PREFIX, "")
     assert generator_call_count == 1
     assert handler_call_count == 1
 
@@ -123,13 +120,13 @@ def test_instrument_subsequent_calls(instrumenter):
         second = [
             x[0][0]
             for x in mocked_print.call_args_list
-            if x[0][0].startswith(_TARGET_LOG_PREFIX)
-        ][0].replace(_TARGET_LOG_PREFIX, "")
+            if x[0][0].startswith(TARGET_LOG_PREFIX)
+        ][0].replace(TARGET_LOG_PREFIX, "")
     assert generator_call_count == 1
     assert handler_call_count == 2
 
     # then
-    first_trace_payload = TracePayload.FromString(base64.b64decode(first))
+    first_trace_payload = deserialize_trace(first)
     assert_trace_payload(
         first_trace_payload,
         [
@@ -140,7 +137,7 @@ def test_instrument_subsequent_calls(instrumenter):
         1,
     )
 
-    second_trace_payload = TracePayload.FromString(base64.b64decode(second))
+    second_trace_payload = deserialize_trace(second)
 
     assert [s.name for s in first_trace_payload.spans] == [
         "aws.lambda",
@@ -171,11 +168,11 @@ def test_instrument_lambda_unhandled_error(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -199,11 +196,11 @@ def test_instrument_lambda_handled_error(instrumenter, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -261,11 +258,11 @@ def test_instrument_lambda_sdk(instrumenter):
             serialized = [
                 x[0][0]
                 for x in mocked_print.call_args_list
-                if x[0][0].startswith(_TARGET_LOG_PREFIX)
-            ][0].replace(_TARGET_LOG_PREFIX, "")
+                if x[0][0].startswith(TARGET_LOG_PREFIX)
+            ][0].replace(TARGET_LOG_PREFIX, "")
 
         # then
-        trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+        trace_payload = deserialize_trace(serialized)
         if asserted_spans:
             assert_trace_payload(
                 trace_payload,
@@ -348,11 +345,11 @@ def test_instrument_sdk_sampled_out(
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -386,11 +383,11 @@ def test_instrument_lambda_success_dev_mode_without_server(
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -452,11 +449,11 @@ def test_instrument_lambda_success_dev_mode_with_server(
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -502,11 +499,11 @@ def test_instrument_lambda_success_dev_mode_with_server(
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -564,11 +561,11 @@ def test_instrument_lambda_http_requests(reset_sdk_debug_mode, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -604,11 +601,11 @@ def test_instrument_lambda_aiohttp_requests(reset_sdk_debug_mode, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -636,11 +633,11 @@ def test_instrument_lambda_aiohttp_requests(reset_sdk_debug_mode, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -711,11 +708,11 @@ def test_instrument_flask(reset_sdk_debug_mode, mocked_print):
     serialized = [
         x[0][0]
         for x in mocked_print.call_args_list
-        if x[0][0].startswith(_TARGET_LOG_PREFIX)
-    ][0].replace(_TARGET_LOG_PREFIX, "")
+        if x[0][0].startswith(TARGET_LOG_PREFIX)
+    ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [
@@ -823,11 +820,11 @@ def test_instrument_dynamodb(instrumenter, monkeypatch):
         serialized = [
             x[0][0]
             for x in mocked_print.call_args_list
-            if x[0][0].startswith(_TARGET_LOG_PREFIX)
-        ][0].replace(_TARGET_LOG_PREFIX, "")
+            if x[0][0].startswith(TARGET_LOG_PREFIX)
+        ][0].replace(TARGET_LOG_PREFIX, "")
 
     # then
-    trace_payload = TracePayload.FromString(base64.b64decode(serialized))
+    trace_payload = deserialize_trace(serialized)
     assert_trace_payload(
         trace_payload,
         [


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1014/python-sdk-gzip-telemetry-payloads
* Gzip the telemetry response before logging it
* Performance-wise it introduces a negligible latency
  * import of "zlib" takes around 1ms on my local machine
  * zipping took around 0.1ms for a payload of length 2KB, reduced the payload to size 1KB
  * zipping took around 0.3ms for a larger payload of 24KB, reduced the payload to size 4KB

### Testing done
Unit/integration/performance tested