### PR TITLE
feat: Added a new transport payload for dev mode

### DIFF
--- a/proto/serverless/instrumentation/v1/dev_mode.proto
+++ b/proto/serverless/instrumentation/v1/dev_mode.proto
@@ -4,6 +4,7 @@ package serverless.instrumentation.v1;
 
 import "serverless/instrumentation/v1/trace.proto";
 import "serverless/instrumentation/v1/request_response.proto";
+import "serverless/instrumentation/v1/log.proto";
 
 option go_package = ".;protoc";
 
@@ -26,6 +27,24 @@ message DevModePayload {
     // The req or response data from the instrumented lambda function
     RequestResponse request_response = 5;
   }
+}
+
+// DevMode Transport Payload that will be used to aggregate reqRes, traces, and logs
+// into a single payload that will be packaged and sent to our DevMode ingest.
+message DevModeTransportPayload {
+  // The AWS Account ID where this payload originated from
+  string account_id = 1;
+  // The AWS Region where this payload originated from
+  string region = 2;
+  // The lambda request id where this payload originated from
+  string request_id = 3;
+
+  // The request/response data from the instrumented lambda function
+  repeated RequestResponse request_response = 4;
+  // The set of lambda traces that were generated via an internal extension
+  repeated TracePayload traces = 5;
+  // The logs generated via the telemetry API
+  repeated LogPayload logs = 7;
 }
 
 // Lambda Telemetry API data. This data is only available for lambda functions that


### PR DESCRIPTION
## Description
I am adding a new dev mode transport payload so that we can send a batch of all types of dev mode activity in a single payload.

> Note: I didn't modify the original `DevModePayload` because this new transport payload will be use for a different purpose than the original dev mode payload was designed for. I will deprecate the `DevModePayload` once this work is complete and deployed to customer lambda functions.