### PR TITLE
AWS Lambda SDK: Do not write dev mode specific events in trace payload

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
@@ -1,6 +1,21 @@
 'use strict';
 
+const serverlessSdk = require('./sdk');
+
+const devModeSpecificEventFingerprints = new Set([
+  'INPUT_BODY_BINARY',
+  'INPUT_BODY_TOO_LARGE',
+  'OUTPUT_BODY_BINARY',
+  'OUTPUT_BODY_TOO_LARGE',
+]);
+
 module.exports = (capturedEvent) => {
+  if (
+    !serverlessSdk._isDevMode &&
+    devModeSpecificEventFingerprints.has(capturedEvent.customFingerprint)
+  ) {
+    return false;
+  }
   switch (capturedEvent.name) {
     case 'telemetry.error.generated.v1':
       // Skip on errors logged via `console.error` in AWS Lambda runtime

--- a/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/filter-captured-event.js
@@ -1,7 +1,11 @@
 'use strict';
 
 module.exports = (capturedEvent) => {
-  // Skip on errors logged via `console.error` in AWS Lambda runtime
-  if (capturedEvent.name !== 'telemetry.error.generated.v1') return true;
-  return !capturedEvent.tags.get('error.stacktrace').split('\n')[0].includes('/var/runtime/');
+  switch (capturedEvent.name) {
+    case 'telemetry.error.generated.v1':
+      // Skip on errors logged via `console.error` in AWS Lambda runtime
+      return !capturedEvent.tags.get('error.stacktrace').split('\n')[0].includes('/var/runtime/');
+    default:
+      return true;
+  }
 };

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -369,7 +369,7 @@ describe('integration', function () {
         }
       );
       if (response.status !== 200) {
-        if (retryCount < 10 && response.status === 404) {
+        if (retryCount < 20 && response.status === 404) {
           log.warn(`API Gateway at POST ${pathname} not ready yet, retrying in 1s`);
           await wait(1000);
           return self(testConfig, ++retryCount);


### PR DESCRIPTION
We've agreed to not expose trace payload events which are specific to dev mode functionality