### PR TITLE
AWS Lambda SDK: Improve stream body reporting

### DIFF
--- a/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
@@ -3,7 +3,8 @@
 const util = require('util');
 
 const replacer = (key, value) => {
-  return typeof value === 'bigint' ? value.toString() : value;
+  if (typeof value === 'bigint') return value.toString();
+  return value;
 };
 
 module.exports = (value) => {

--- a/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
+++ b/node/packages/aws-lambda-sdk/lib/instrumentation/aws-sdk/safe-stringify.js
@@ -1,9 +1,14 @@
 'use strict';
 
 const util = require('util');
+const isObject = require('type/object/is');
+
+// Credit: https://github.com/sindresorhus/is-stream/blob/6913e344ab2dd63041bb7c03095876ce5a7e0a8b/index.js#L1-L5
+const isStream = (value) => isObject(value) && typeof value.pipe === 'function';
 
 const replacer = (key, value) => {
   if (typeof value === 'bigint') return value.toString();
+  if (isStream(value)) return '<stream>';
   return value;
 };
 


### PR DESCRIPTION
When browsing internally, reported warnings and errors. I observed the `Detected not serializable value in AWS SDK request` warning, which pointed out that the Node.js stream value was passed with the `Body` property to the payload.

This patch ensures that we gently handle such case