### PR TITLE
feat!: Group dev mode activity

### DIFF
--- a/go/packages/dev-mode/go.mod
+++ b/go/packages/dev-mode/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
-	go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.16
+	go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.31
 	go.uber.org/zap v1.23.0
 	google.golang.org/protobuf v1.28.1
 )

--- a/go/packages/dev-mode/go.sum
+++ b/go/packages/dev-mode/go.sum
@@ -82,6 +82,8 @@ go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.15 h1:UN+GACIOXx0WHAn
 go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.15/go.mod h1:6WY9HNTpyOtrLS29m5eTD1/XdrTSqnWDmLqwX3gaO0s=
 go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.16 h1:e5vwHA2LE+yrfQtfJoRcSVHUwHj7vVnypJbHIvvwwTY=
 go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.16/go.mod h1:6WY9HNTpyOtrLS29m5eTD1/XdrTSqnWDmLqwX3gaO0s=
+go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.31 h1:bvJwMR4GGmsSFHpx605xbXCI0z4l/TPSG3cHBe+s6yk=
+go.buf.build/protocolbuffers/go/serverless/sdk-schema v1.3.31/go.mod h1:6WY9HNTpyOtrLS29m5eTD1/XdrTSqnWDmLqwX3gaO0s=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=

--- a/go/packages/dev-mode/lib/logger.go
+++ b/go/packages/dev-mode/lib/logger.go
@@ -77,27 +77,11 @@ func ReportOverheadDuration(t time.Time) {
 	}
 }
 
-func ReportLog(logPayload string) {
+func ReportDevModePayload(logPayload string) {
 	_, ok := os.LookupEnv("SLS_DEBUG_EXTENSION")
 	_, toLogs := os.LookupEnv("SLS_TEST_EXTENSION_LOG")
 	if ok || toLogs {
-		BaseLogger.Printf("SERVERLESS_TELEMETRY.DL.%s", base64.StdEncoding.EncodeToString([]byte(logPayload)))
-	}
-}
-
-func ReportReqRes(logPayload string) {
-	_, ok := os.LookupEnv("SLS_DEBUG_EXTENSION")
-	_, toLogs := os.LookupEnv("SLS_TEST_EXTENSION_LOG")
-	if ok || toLogs {
-		BaseLogger.Printf("SERVERLESS_TELEMETRY.DR.%s", base64.StdEncoding.EncodeToString([]byte(logPayload)))
-	}
-}
-
-func ReportSpans(logPayload string) {
-	_, ok := os.LookupEnv("SLS_DEBUG_EXTENSION")
-	_, toLogs := os.LookupEnv("SLS_TEST_EXTENSION_LOG")
-	if ok || toLogs {
-		BaseLogger.Printf("SERVERLESS_TELEMETRY.DM.%s", base64.StdEncoding.EncodeToString([]byte(logPayload)))
+		BaseLogger.Printf("SERVERLESS_TELEMETRY.DMZ.%s", base64.StdEncoding.EncodeToString([]byte(logPayload)))
 	}
 }
 

--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/golang-collections/go-datastructures/queue"
+	schema "go.buf.build/protocolbuffers/go/serverless/sdk-schema/serverless/instrumentation/v1"
 	"go.uber.org/zap"
 )
 
@@ -82,8 +83,9 @@ func (e *Extension) ExternalExtension() {
 	var responseLog *agent.LogItem = nil
 
 	deferredLogs := []agent.LogItem{}
-
+	deferredActivity := []schema.DevModeTransportPayload{}
 	hasInternalExtension := lib.HasInternalExtension()
+	lastRequest := time.Now()
 
 	// Save the res payload from the SDK so we can send it out at runtime done so we can include the
 	// runtime_duration_ms & runtime_response_latency_ms that is included in the runtime done event
@@ -178,13 +180,22 @@ func (e *Extension) ExternalExtension() {
 			}
 
 			// Send to dev mode if we have requestId and traceId
-			agent.ForwardLogs(arr, requestId, AWS_ACCOUNT_ID, traceId)
+			aggregate := agent.AggregateActivity(arr, requestId, AWS_ACCOUNT_ID, traceId)
+			deferredActivity = append(deferredActivity, *aggregate)
+			// Check if lastRequest is more than 500 milliseconds ago
+			if time.Since(lastRequest).Milliseconds() > 500 && len(deferredActivity) > 0 {
+				lastRequest = time.Now()
+				agent.ForwardActivity(deferredActivity)
+				deferredActivity = nil
+			}
 		}
-		// Force send logs at end of loop
+		// Force send activity at end of loop
 		if len(deferredLogs) > 0 {
-			agent.ForwardLogs(deferredLogs, requestId, AWS_ACCOUNT_ID, traceId)
+			aggregate := agent.AggregateActivity(deferredLogs, requestId, AWS_ACCOUNT_ID, traceId)
+			deferredActivity = append(deferredActivity, *aggregate)
 		}
-
+		agent.ForwardActivity(deferredActivity)
+		deferredActivity = nil
 		initReport = nil
 		responseLog = nil
 	}

--- a/go/packages/dev-mode/main.go
+++ b/go/packages/dev-mode/main.go
@@ -182,8 +182,8 @@ func (e *Extension) ExternalExtension() {
 			// Send to dev mode if we have requestId and traceId
 			aggregate := agent.AggregateActivity(arr, requestId, AWS_ACCOUNT_ID, traceId)
 			deferredActivity = append(deferredActivity, *aggregate)
-			// Check if lastRequest is more than 500 milliseconds ago
-			if time.Since(lastRequest).Milliseconds() > 500 && len(deferredActivity) > 0 {
+			// Check if lastRequest is more than 100 milliseconds ago
+			if time.Since(lastRequest).Milliseconds() > 100 && len(deferredActivity) > 0 {
 				lastRequest = time.Now()
 				agent.ForwardActivity(deferredActivity)
 				deferredActivity = nil

--- a/go/packages/dev-mode/main_test.go
+++ b/go/packages/dev-mode/main_test.go
@@ -31,12 +31,13 @@ type ValidationLogMessage struct {
 }
 
 type ValidationResult struct {
-	Register  RegisterPayload `json:"register"`
-	RequestId string          `json:"requestId"`
-	Logs      []u.APIPayload  `json:"logs"`
-	ReqRes    []u.APIPayload  `json:"reqRes"`
-	Spans     []u.APIPayload  `json:"spans"`
-	NextCount int64           `json:"nextCount"`
+	Register        RegisterPayload `json:"register"`
+	RequestId       string          `json:"requestId"`
+	Logs            []u.APIPayload  `json:"logs"`
+	ReqRes          []u.APIPayload  `json:"reqRes"`
+	Spans           []u.APIPayload  `json:"spans"`
+	DevModePayloads []u.APIPayload  `json:"devModePayloads"`
+	NextCount       int64           `json:"nextCount"`
 }
 
 var port = 9001
@@ -284,12 +285,15 @@ func TestInvokeStartDoneTwice(t *testing.T) {
 		}
 	}
 
-	for _, reqResPayload := range validationData2.ReqRes {
+	for _, devModePayload := range validationData2.DevModePayloads {
 		// reqResStr, _ := base64.StdEncoding.DecodeString(string(reqResPayload.Payload))
-		var devModePayload schema.DevModePayload
-		err := proto.Unmarshal(reqResPayload.Payload, &devModePayload)
-		if err != nil || devModePayload.RequestId != requestId2 {
-			t.Errorf("Expected reqRes requestId %s Received %s", requestId2, devModePayload.RequestId)
+		var payload schema.DevModeTransportPayload
+		err := proto.Unmarshal(devModePayload.Payload, &payload)
+		if err != nil {
+			t.Errorf("Expected no marshaling error %v", err)
+		}
+		if payload.RequestId != requestId2 {
+			t.Errorf("Expected devModePayload requestId %s Received %s", requestId2, payload.RequestId)
 		}
 	}
 


### PR DESCRIPTION
## Description
I added three enhancements here.

1. traces, req/res, and logs will no longer make individual API calls and will share a single request depending on what data we have available
2. We will wait either 500ms or till the runtimeDone event is seen (whichever is first) before forwarding data to dev mode backend
3. Payloads will be gzipped

This will cut down on the number of requests a single lambda function can make when it is connected to dev mode and should prevent issues like we had seen yesterday.