### PR TITLE
Schema: Introduce `aws.lambda.response_mode` tag

### DIFF
--- a/proto/serverless/instrumentation/tags/v1/aws.proto
+++ b/proto/serverless/instrumentation/tags/v1/aws.proto
@@ -121,6 +121,18 @@ message AwsLambdaTags {
   // The Unix timestamp in milliseconds of the REPORT log event of the invocation.
   optional uint64 logs_end_time_unix = 21;
 
+  enum ResponseMode {
+    // Mode not confirmed
+    RESPONSE_MODE_UNSPECIFIED = 0;
+    // Regular buffered response
+    RESPONSE_MODE_BUFFERED = 1;
+    // Stream response
+    RESPONSE_MODE_RESPONSE_STREAM = 2;
+  }
+
+  // The event source for the invocation.
+  optional ResponseMode response_mode = 22;
+
   // Will be set if the function is handling a SQS event
   optional AwsSqsEventTags sqs = 100;
   // Will be set if the function is handling a SNS event


### PR DESCRIPTION
With response streaming, AWS introduced different lambda resolution mode.

This tag will let us track lambdas which work in this mode, it'll also be helpful to internal to recognize more we're in, as it requires adjustments to internal logic in related parts