### PR TITLE
SDK: Enable filters configuration for HTTP requests

### DIFF
--- a/node/packages/sdk/lib/instrumentation/http.js
+++ b/node/packages/sdk/lib/instrumentation/http.js
@@ -6,6 +6,8 @@ const reportError = require('../report-error');
 
 let shouldIgnoreFollowingRequest = false;
 
+const requestFilters = [];
+
 const urlToHttpOptions = (url) => {
   const options = {
     hostname:
@@ -179,7 +181,8 @@ const install = (protocol, httpModule) => {
       shouldIgnoreFollowingRequest ||
       options._slsIgnore ||
       (originalCb && typeof originalCb !== 'function') ||
-      serverlessSdk._isInTraceSpanBlackBox
+      serverlessSdk._isInTraceSpanBlackBox ||
+      requestFilters.some((filter) => !filter(options))
     ) {
       shouldIgnoreFollowingRequest = false;
       return originalRequest.apply(this, args);
@@ -277,5 +280,7 @@ module.exports.ignoreFollowingRequest = () => {
     shouldIgnoreFollowingRequest = false;
   });
 };
+
+module.exports.requestFilters = requestFilters;
 
 const serverlessSdk = require('../..');


### PR DESCRIPTION
To properly support response streaming, we need to ignore HTTP requests made internally by the AWS runtime (as in case of response streaming AWS runtime sends the data to AWS backend chunk by chunk with regular HTTP requests).

This generic filtering method, will let us configure specific HTTP request filter in context of the AWS Lambda SDK package

