### PR TITLE
AWS Lambda SDK: Support response streaming

### DIFF
--- a/node/packages/aws-lambda-sdk/index.js
+++ b/node/packages/aws-lambda-sdk/index.js
@@ -28,3 +28,10 @@ serverlessSdk._initializeExtension = (options) => {
   }
 };
 serverlessSdk._isDevMode = Boolean(process.env.SLS_DEV_MODE_ORG_ID);
+
+require('@serverless/sdk/lib/instrumentation/http').requestFilters.push((httpOptions) => {
+  if (typeof httpOptions.path !== 'string') return true;
+  // Do not attempt to trace Lambda Runtime API calls
+  // e.g. it's how AWS runtime handles internally response streaming
+  return !httpOptions.path.startsWith('/2018-06-01/runtime/');
+});

--- a/node/packages/aws-lambda-sdk/instrument/lib/resolve-response-tags.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/resolve-response-tags.js
@@ -7,6 +7,7 @@ const awsLambdaSpan = require('./sdk').traceSpans.awsLambda;
 
 module.exports = (response) => {
   if (isApiEvent()) {
+    if (awsLambdaSpan.tags.get('aws.lambda.response_mode' === 2)) return;
     let statusCode = response && response.statusCode;
     if (statusCode == null) {
       awsLambdaSpan.tags.set('aws.lambda.http.error_code', 'MISSING_STATUS_CODE');

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/.eslintrc.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/.eslintrc.js
@@ -20,4 +20,7 @@ module.exports = {
     'dashboard/s_function.js',
     'dashboard/serverless_sdk',
   ],
+  globals: {
+    awslambda: 'readonly',
+  },
 };

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/response-streaming.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/response-streaming.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
+  responseStream.write('"ok"');
+  responseStream.end();
+});


### PR DESCRIPTION
Fix handling of lambdas which are configured for response streaming, and also recognize response streaming