### PR TITLE
[Python base SDK] Import dependencies internally

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from contextlib import contextmanager
+import sys
+import os
+from typing import Dict
+from types import ModuleType
+
+_INTERNAL_MODULES: Dict[str, ModuleType] = dict()
+
+_LOCK = None
+
+if bool(os.environ.get("SLS_DEV_MODE_ORG_ID")):
+    import threading
+
+    _LOCK = threading.Lock()
+
+
+@contextmanager
+def internally_imported(
+    *top_level_module_names: str, internal_path: str = "/opt/python"
+):
+    def _import():
+        previously_cached_modules = sys.modules.copy()
+        original_sys_path = sys.path.copy()
+        sys.path.insert(
+            0, internal_path
+        )  # Ensure all imports are from the lambda layer
+        sys.path = list(
+            filter(lambda p: p != "/var/task", sys.path)
+        )  # Ensure no imports are from the lambda function (e.g. the user's code)
+
+        sys.modules.update(
+            _INTERNAL_MODULES
+        )  # Restore previous internal imports to sys.modules to make them visible
+
+        yield
+
+        sys.path = original_sys_path  # Rollback the path change
+
+        # Remove the internal modules from sys.modules
+        # to prevent them being imported by customer code
+        for module_name in sys.modules.copy():
+            if module_name not in previously_cached_modules and [
+                prefix
+                for prefix in top_level_module_names
+                if module_name == prefix or module_name.startswith(f"{prefix}.")
+            ]:
+                _INTERNAL_MODULES[module_name] = sys.modules[module_name]
+                del sys.modules[module_name]
+
+    if _LOCK:
+        with _LOCK:
+            return _import()
+    else:
+        return _import()

--- a/python/packages/sdk/sls_sdk/lib/name.py
+++ b/python/packages/sdk/sls_sdk/lib/name.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-
 from re import Pattern
+from .imports import internally_imported
 
-from js_regex import compile
+with internally_imported("js_regex"):
+    from js_regex import compile
+
 from typing_extensions import Final
-
 from ..exceptions import InvalidTraceSpanName
 
 

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -4,7 +4,11 @@ from datetime import datetime
 from math import inf, nan
 from re import Pattern
 from typing import Dict, List, Mapping, Tuple, Optional, Any
-from js_regex import compile
+from .imports import internally_imported
+
+with internally_imported("js_regex"):
+    from js_regex import compile
+
 from typing_extensions import Final, get_args
 from threading import Lock
 from .error import report as report_error

--- a/python/packages/sdk/tests/lib/test_imports.py
+++ b/python/packages/sdk/tests/lib/test_imports.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from sls_sdk.lib.imports import internally_imported
+import pytest
+from pathlib import Path
+import sys
+import os
+
+
+def test_internally_imported():
+    # given
+    path = str(Path(__file__).parent / "flask.py")
+    f = open(path, "w", encoding="utf-8")
+    f.write("VALUE = 1")
+    f.close()
+
+    value = 0
+
+    if "flask" in sys.modules:
+        del sys.modules["flask"]
+
+    # when
+    with internally_imported(
+        "flask", internal_path=str(Path(__file__).resolve().parent)
+    ):
+        import flask
+
+        os.remove(path)
+
+        value = flask.VALUE
+        with pytest.raises(Exception):
+            print(flask.Config)
+
+    import flask
+
+    # then
+    assert flask.Config is not None
+    assert value == 1
+
+    del sys.modules["flask"]


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-977/user-thetie-seeing-error-in-production-mode-with-python-sdk#comment-df0ca0e7
* Import SDK's external dependencies internally from the layer folder, so that customer code can import its own version separately without version conflicts.

### Testing done
Unit, integration, performance tested