### PR TITLE
[Python Lambda SDK] Import dependencies internally

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -612,6 +612,12 @@ describe('Python: integration', function () {
 
   const useCasesConfig = new Map([
     [
+      'internal_dependencies',
+      {
+        variants: new Map([['v3-10', { configuration: { Runtime: 'python3.10' } }]]),
+      },
+    ],
+    [
       'success',
       {
         variants: new Map([
@@ -1076,6 +1082,13 @@ describe('Python: integration', function () {
         `echo "raise Exception('This is a dummy module that should never get imported.')" > ${fixturesDirname}/sls_sdk/__init__.py`,
       ].join('\n')
     );
+    exec(
+      [
+        `mkdir -p ${fixturesDirname}/google`,
+        `touch ${fixturesDirname}/google/__init__.py`,
+        `echo "foo = 'bar'" > ${fixturesDirname}/google/protobuf.py`,
+      ].join('\n')
+    );
 
     pyProjectToml = toml.parse(
       await fsp.readFile(
@@ -1251,6 +1264,7 @@ describe('Python: integration', function () {
     await Promise.all([
       fsp.rmdir(`${fixturesDirname}/test_dependencies`, { recursive: true, force: true }),
       fsp.rmdir(`${fixturesDirname}/sls_sdk`, { recursive: true, force: true }),
+      fsp.rmdir(`${fixturesDirname}/google`, { recursive: true, force: true }),
     ]);
   });
 });

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -492,7 +492,7 @@ describe('Python: integration', function () {
                 FunctionName: urlEndpointLambdaName,
                 Handler: 'api_endpoint.handler',
                 Role: coreConfig.roleArn,
-                Runtime: 'python3.9',
+                Runtime: 'python3.10',
                 Code: {
                   ZipFile: resolveFileZipBuffer(path.resolve(fixturesDirname, 'api_endpoint.py')),
                 },
@@ -611,12 +611,7 @@ describe('Python: integration', function () {
   ]);
 
   const useCasesConfig = new Map([
-    [
-      'internal_dependencies',
-      {
-        variants: new Map([['v3-10', { configuration: { Runtime: 'python3.10' } }]]),
-      },
-    ],
+    ['internal_dependencies', {}],
     [
       'success',
       {
@@ -1111,7 +1106,7 @@ describe('Python: integration', function () {
       TracePayload,
       fixturesDirname,
       baseLambdaConfiguration: {
-        Runtime: 'python3.9',
+        Runtime: 'python3.10',
         Layers: [coreConfig.layerInternalArn],
         Environment: {
           Variables: {

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "serverless-sdk~=0.4.8",
+    "serverless-sdk~=0.4.9",
     "serverless-sdk-schema~=0.2.1",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
@@ -5,6 +5,7 @@ from .telemetry import send, close_connection
 from .sdk import serverlessSdk
 from .invocation_context import get as get_invocation_context
 from .payload_conversion import to_trace_payload
+from sls_sdk.lib.imports import internally_imported
 import builtins
 import logging
 
@@ -84,6 +85,7 @@ class DevModeThread(Thread):
         )  # used to buffer spans and captured events
         self._is_stopped = Event()  # used to stop the thread
 
+    @internally_imported("google")
     def _send_all(self):
         (
             spans,

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -1,5 +1,8 @@
-from serverless_sdk_schema import TracePayload, RequestResponse
-from google.protobuf import json_format
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported("google"):
+    from serverless_sdk_schema import TracePayload, RequestResponse
+    from google.protobuf import json_format
 
 
 def to_trace_payload(payload_dct: dict) -> TracePayload:

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
@@ -1,0 +1,7 @@
+import google.protobuf
+
+
+def handler(event, context) -> str:
+    if google.protobuf.foo != "bar":
+        raise Exception("google.protobuf.foo != 'bar'")
+    return "ok"


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-977/user-thetie-seeing-error-in-production-mode-with-python-sdk#comment-df0ca0e7
* Related PR https://github.com/serverless/console/pull/764
* Import SDK's external dependencies internally from the layer folder, so that customer code can import its own version separately without version conflicts.

### Testing done
* Integration test added that validates customer code can import an incompatible version of one of our dependencies.
* Unit, integration, performance tested