### PR TITLE
SDK: Fix AWS Lambda Powertools error log parsing

### DIFF
--- a/node/packages/sdk/lib/instrumentation/node-process-stdout-stderr.js
+++ b/node/packages/sdk/lib/instrumentation/node-process-stdout-stderr.js
@@ -19,12 +19,28 @@ module.exports.install = () => {
 
   nodeStdout.write = function (...args) {
     original.stdout.write.apply(this, args);
-    attemptParseStructuredLogAndCapture(args[0]);
+    try {
+      attemptParseStructuredLogAndCapture(args[0]);
+    } catch (error) {
+      process.nextTick(() => {
+        // Prevent crashes swalling by Node.js console
+        // see: https://github.com/nodejs/node/blob/3538e1bcde45eae60c6bdbedeb3f765dbb9714c2/lib/internal/console/constructor.js#L306-L310
+        throw error;
+      });
+    }
   };
 
   nodeStderr.write = function (...args) {
     original.stderr.write.apply(this, args);
-    attemptParseStructuredLogAndCapture(args[0]);
+    try {
+      attemptParseStructuredLogAndCapture(args[0]);
+    } catch (error) {
+      process.nextTick(() => {
+        // Prevent crashes swalling by Node.js console
+        // see: https://github.com/nodejs/node/blob/3538e1bcde45eae60c6bdbedeb3f765dbb9714c2/lib/internal/console/constructor.js#L306-L310
+        throw error;
+      });
+    }
   };
 
   uninstall = () => {

--- a/node/packages/sdk/lib/structured-log-to-event.js
+++ b/node/packages/sdk/lib/structured-log-to-event.js
@@ -79,13 +79,12 @@ const handleErrorLog = (logLineParsed) => {
   } else {
     // In this case we do best attempt at parsing.
     // AWS Lambda Powertools will fall in this category.
-    const [errKey, errObj] = Object.entries(logLineParsed).find(
+    const errorLineData = Object.entries(logLineParsed).find(
       ([, value]) => value && value.message && value.stack
     );
+    if (!errorLineData) return;
 
-    if (!errKey || !errObj) {
-      return;
-    }
+    const [errKey, errObj] = errorLineData;
     const tags = Object.fromEntries(
       Object.entries(logLineParsed)
         .filter(([key]) => ![...highCardinalityAttributes, errKey].includes(key))

--- a/node/packages/sdk/test/unit/index.test.js
+++ b/node/packages/sdk/test/unit/index.test.js
@@ -8,6 +8,7 @@ describe('index.test.js', () => {
   let serverlessSdk;
   let rootSpan;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       const TraceSpan = require('../../lib/trace-span');
       serverlessSdk = require('../../');
@@ -48,6 +49,11 @@ describe('index.test.js', () => {
   });
 
   it('should not crash on invalid .setTag input', () => {
-    serverlessSdk.setTag();
+    delete process.env.SLS_CRASH_ON_SDK_ERROR;
+    try {
+      serverlessSdk.setTag();
+    } finally {
+      process.env.SLS_CRASH_ON_SDK_ERROR = '1';
+    }
   });
 });

--- a/node/packages/sdk/test/unit/instrumentation/express-app.test.js
+++ b/node/packages/sdk/test/unit/instrumentation/express-app.test.js
@@ -5,6 +5,9 @@ const { expect } = require('chai');
 const requireUncached = require('ncjsm/require-uncached');
 
 describe('instrumentation/express-app.js', () => {
+  before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
+  });
   describe('Basic', () => {
     let instrumentExpressApp;
     let serverless;

--- a/node/packages/sdk/test/unit/lib/captured-event.test.js
+++ b/node/packages/sdk/test/unit/lib/captured-event.test.js
@@ -11,6 +11,7 @@ describe('lib/captured-event.test.js', () => {
   let Tags;
   let Long;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       Long = require('long');
       TraceSpan = require('../../../lib/trace-span');
@@ -103,15 +104,20 @@ describe('lib/captured-event.test.js', () => {
     });
 
     it('should not throw on invalid user input', () => {
-      // eslint-disable-next-line no-new
-      new CapturedEvent('test.custom', {
-        customTags: { 'fooo': {}, 'W$#&^@#&$': 'raz' },
-        customFingerprint: {},
-      });
-      // eslint-disable-next-line no-new
-      new CapturedEvent('test.custom', {
-        customFingerprint: {},
-      });
+      delete process.env.SLS_CRASH_ON_SDK_ERROR;
+      try {
+        // eslint-disable-next-line no-new
+        new CapturedEvent('test.custom', {
+          customTags: { 'fooo': {}, 'W$#&^@#&$': 'raz' },
+          customFingerprint: {},
+        });
+        // eslint-disable-next-line no-new
+        new CapturedEvent('test.custom', {
+          customFingerprint: {},
+        });
+      } finally {
+        process.env.SLS_CRASH_ON_SDK_ERROR = '1';
+      }
     });
   });
 });

--- a/node/packages/sdk/test/unit/lib/instrumentation/http.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/http.test.js
@@ -8,6 +8,9 @@ const requireUncached = require('ncjsm/require-uncached');
 const TEST_SERVER_PORT = 3177;
 
 describe('lib/instrumentation/http.js', () => {
+  before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
+  });
   describe('basic', () => {
     let serverlessSdk;
     let server;

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-console.test.js
@@ -8,6 +8,7 @@ describe('lib/instrumentation/node-console.js', () => {
   let serverlessSdk;
   let instrumentNodeConsole;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       serverlessSdk = require('../../../../');
       instrumentNodeConsole = require('../../../../lib/instrumentation/node-console');

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
@@ -41,6 +41,20 @@ describe('lib/instrumentation/node-process-stdout-stderr.js', () => {
       expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
       expect(capturedEvent._origin).to.equal('nodeConsole');
     });
+
+    it('should not instrument error string', () => {
+      let capturedEvent = null;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+      const logger = new PowertoolsLogger({
+        serviceName: 'test-app',
+        persistentLogAttributes: { testtag: 'test tag' },
+      });
+
+      logger.error('Test Error');
+      expect(capturedEvent).to.be.null;
+    });
+
     it('should instrument warning', () => {
       let capturedEvent;
       serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
@@ -12,6 +12,7 @@ describe('lib/instrumentation/node-process-stdout-stderr.js', () => {
   let serverlessSdk;
   let instrumentNodeConsole;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       serverlessSdk = require('../../../../');
       instrumentNodeConsole = require('../../../../lib/instrumentation/node-process-stdout-stderr');

--- a/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
+++ b/node/packages/sdk/test/unit/lib/instrumentation/node-process-stdout-stderr.test.js
@@ -23,137 +23,143 @@ describe('lib/instrumentation/node-process-stdout-stderr.js', () => {
     delete require('uni-global')('serverless/sdk/202212').serverlessSdk;
   });
 
-  it('should instrument `process.stderr.write` with powertools logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+  describe('AWS Lambda Powertools', () => {
+    it('should instrument error', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
 
-    const logger = new PowertoolsLogger({
-      serviceName: 'test-app',
-      persistentLogAttributes: { testtag: 'test tag' },
+      const logger = new PowertoolsLogger({
+        serviceName: 'test-app',
+        persistentLogAttributes: { testtag: 'test tag' },
+      });
+
+      logger.error('Test Error', new Error('My error'));
+      expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+      expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+      expect(capturedEvent.customTags.get('service')).to.equal('test-app');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
+    });
+    it('should instrument warning', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+      const logger = new PowertoolsLogger({
+        serviceName: 'test-app',
+        persistentLogAttributes: { testtag: 'test tag' },
+      });
+
+      logger.warn('Test Warning');
+      expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+      expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+      expect(capturedEvent.customTags.get('service')).to.equal('test-app');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
+    });
+  });
+  describe('Pino', () => {
+    it('should instrument error', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+      const parent = pino();
+
+      const logger = parent.child({ testtag: 'test tag' });
+
+      logger.error(new Error('My error'));
+      expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+      expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
     });
 
-    logger.error('Test Error', new Error('My error'));
-    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
-    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
-    expect(capturedEvent.customTags.get('service')).to.equal('test-app');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
+    it('should instrument warning', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+
+      const parent = pino();
+
+      const logger = parent.child({ testtag: 'test tag' });
+
+      logger.warn('Test Warning');
+      expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+      expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
+    });
   });
 
-  it('should instrument `process.stderr.write` with pino logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+  describe('Winston', () => {
+    it('should instrument error', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
 
-    const parent = pino();
+      const parent = winston.createLogger({
+        format: winston.format.json(),
+        transports: [new winston.transports.Console()],
+      });
 
-    const logger = parent.child({ testtag: 'test tag' });
+      const logger = parent.child({ testtag: 'test tag' });
 
-    logger.error(new Error('My error'));
-    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
-    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
-  });
-
-  it('should instrument `process.stderr.write` with winston logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
-
-    const parent = winston.createLogger({
-      format: winston.format.json(),
-      transports: [new winston.transports.Console()],
+      const error = new Error('My error');
+      error.name = 'WinstonError';
+      logger.error('winston error', error);
+      expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+      expect(capturedEvent.tags.get('error.message')).to.equal('winston error My error');
+      expect(capturedEvent.tags.get('error.name')).to.equal('WinstonError');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
     });
 
-    const logger = parent.child({ testtag: 'test tag' });
+    it('should instrument warning', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
 
-    const error = new Error('My error');
-    error.name = 'WinstonError';
-    logger.error('winston error', error);
-    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
-    expect(capturedEvent.tags.get('error.message')).to.equal('winston error My error');
-    expect(capturedEvent.tags.get('error.name')).to.equal('WinstonError');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
+      const parent = winston.createLogger({
+        format: winston.format.json(),
+        transports: [new winston.transports.Console()],
+      });
+
+      const logger = parent.child({ testtag: 'test tag' });
+
+      logger.warn('Test Warning');
+      expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+      expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
+    });
   });
 
-  it('should instrument `process.stderr.write` with bunyan logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+  describe('Bunyan', () => {
+    it('should instrument error', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
 
-    const parent = bunyan.createLogger({ name: 'bunyan-test' });
-    const logger = parent.child({ testtag: 'test tag' });
+      const parent = bunyan.createLogger({ name: 'bunyan-test' });
+      const logger = parent.child({ testtag: 'test tag' });
 
-    const error = new Error('My error');
-    error.name = 'BunyanError';
-    logger.error(error, 'bunyan error');
-    expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
-    expect(capturedEvent.tags.get('error.message')).to.equal('My error');
-    expect(capturedEvent.tags.get('error.name')).to.equal('BunyanError');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
-  });
-
-  it('should instrument `process.stdout.write` with powertools logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
-
-    const logger = new PowertoolsLogger({
-      serviceName: 'test-app',
-      persistentLogAttributes: { testtag: 'test tag' },
+      const error = new Error('My error');
+      error.name = 'BunyanError';
+      logger.error(error, 'bunyan error');
+      expect(capturedEvent.name).to.equal('telemetry.error.generated.v1');
+      expect(capturedEvent.tags.get('error.message')).to.equal('My error');
+      expect(capturedEvent.tags.get('error.name')).to.equal('BunyanError');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
     });
 
-    logger.warn('Test Warning');
-    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
-    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
-    expect(capturedEvent.customTags.get('service')).to.equal('test-app');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
-  });
+    it('should instrument warning', () => {
+      let capturedEvent;
+      serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
 
-  it('should instrument `process.stdout.write` with pino logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
+      const parent = bunyan.createLogger({ name: 'bunyan-test' });
+      const logger = parent.child({ testtag: 'test tag' });
 
-    const parent = pino();
-
-    const logger = parent.child({ testtag: 'test tag' });
-
-    logger.warn('Test Warning');
-    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
-    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
-  });
-
-  it('should instrument `process.stdout.write` with winston logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
-
-    const parent = winston.createLogger({
-      format: winston.format.json(),
-      transports: [new winston.transports.Console()],
+      logger.warn('Test Warning');
+      expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
+      expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
+      expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
+      expect(capturedEvent._origin).to.equal('nodeConsole');
     });
-
-    const logger = parent.child({ testtag: 'test tag' });
-
-    logger.warn('Test Warning');
-    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
-    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
-  });
-
-  it('should instrument `process.stdout.write` with bunyan logger', () => {
-    let capturedEvent;
-    serverlessSdk._eventEmitter.once('captured-event', (event) => (capturedEvent = event));
-
-    const parent = bunyan.createLogger({ name: 'bunyan-test' });
-    const logger = parent.child({ testtag: 'test tag' });
-
-    logger.warn('Test Warning');
-    expect(capturedEvent.name).to.equal('telemetry.warning.generated.v1');
-    expect(capturedEvent.tags.get('warning.message')).to.equal('Test Warning');
-    expect(capturedEvent.customTags.get('testtag')).to.equal('test tag');
-    expect(capturedEvent._origin).to.equal('nodeConsole');
   });
 });

--- a/node/packages/sdk/test/unit/lib/report-notice.test.js
+++ b/node/packages/sdk/test/unit/lib/report-notice.test.js
@@ -8,6 +8,7 @@ describe('lib/report-notice.test.js', () => {
   let serverlessSdk;
   let reportNotice;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       serverlessSdk = require('../../..');
       reportNotice = require('../../../lib/report-notice');

--- a/node/packages/sdk/test/unit/lib/report-warning.test.js
+++ b/node/packages/sdk/test/unit/lib/report-warning.test.js
@@ -8,6 +8,7 @@ describe('lib/report-warning.test.js', () => {
   let serverlessSdk;
   let reportWarning;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       serverlessSdk = require('../../..');
       reportWarning = require('../../../lib/report-warning');

--- a/node/packages/sdk/test/unit/lib/trace-span.test.js
+++ b/node/packages/sdk/test/unit/lib/trace-span.test.js
@@ -9,6 +9,7 @@ describe('lib/trace-span.test.js', () => {
   let TraceSpan;
   let Long;
   before(() => {
+    process.env.SLS_CRASH_ON_SDK_ERROR = '1';
     requireUncached(() => {
       Long = require('long');
       TraceSpan = require('../../../lib/trace-span');


### PR DESCRIPTION
When browsing internal error reports. I found following:

```
{
  "message": "undefined is not iterable (cannot read property Symbol(Symbol.iterator))",
  "name": "TypeError",
  "stacktrace": "at handleErrorLog (/opt/nodejs/node_modules/@serverless/sdk/index.js:3622:34)\nat module2.exports.attemptParseStructuredLogAndCapture (/opt/nodejs/node_modules/@serverless/sdk/index.js:3662:13)\nat nodeStdout.write (/opt/nodejs/node_modules/@serverless/sdk/index.js:3698:9)\nat Console.log (/var/task/src/triggers/handle-db-change.js:201027:23)\nat Console._write (/var/task/src/triggers/handle-db-change.js:198701:19)\nat doWrite (/var/task/src/triggers/handle-db-change.js:118934:139)\nat writeOrBuffer (/var/task/src/triggers/handle-db-change.js:118925:5)\nat Writable.write (/var/task/src/triggers/handle-db-change.js:118846:11)\nat DerivedLogger.ondata (/var/task/src/triggers/handle-db-change.js:117942:20)\nat DerivedLogger.emit (node:events:513:28)",
  "type": "ERROR_TYPE_CAUGHT_SDK_INTERNAL"
}
```

It appears there's a bug when processing an AWS Lambda Powertools error log which was written without passing the error instance.

This patch ensures it's handled gently