### PR TITLE
[Python SDK] Fix integration tests

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -1217,7 +1217,7 @@ describe('Python: integration', function () {
           expect(slsTags).to.deep.equal({
             orgId: process.env.SLS_ORG_ID,
             service: testConfig.configuration.FunctionName,
-            sdk: { name: pyProjectToml.project.name, version: sdkVersion },
+            sdk: { name: pyProjectToml.project.name, version: sdkVersion, runtime: 'python' },
           });
           expect(lambdaSpan.tags.aws.lambda).to.have.property('arch');
           expect(lambdaSpan.tags.aws.lambda.name).to.equal(testConfig.configuration.FunctionName);


### PR DESCRIPTION
### Description
* Related https://github.com/serverless/console/pull/766#issuecomment-1553236171
* I had an outdated node_modules directory and tests were passing, when I did an npm update I was able to reproduce the integration test failure: https://github.com/serverless/console/actions/runs/5012978662

### Testing done
Reproduced and fixed in integration tests ran locally