### PR TITLE
Fix dev mode connection

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -264,10 +264,10 @@ class Instrumenter:
                 serverlessSdk.trace_spans.aws_lambda_invocation.close(end_time=end_time)
 
             self.aws_lambda.close(end_time=end_time)
+            self._flush_and_close_event_loop()
 
             if get_invocation_context():
                 self._report_trace(is_error_outcome)
-            self._flush_and_close_event_loop()
             self._clear_root_span()
 
             debug_log(

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/telemetry.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/telemetry.py
@@ -36,6 +36,7 @@ if serverlessSdk._is_dev_mode:
                 },
             )
             response = _connection.getresponse()
+            response.read()
             if response.status != 200:
                 serverlessSdk._report_warning(
                     "Cannot propagate telemetry, "

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/http_requester.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/http_requester.py
@@ -28,7 +28,8 @@ def make_http_request(host, path, use_ssl=False):
         else:
             conn = http.client.HTTPConnection(host)
         conn.request("GET", path, headers={"someHeader": "bar"})
-        conn.getresponse()
+        response = conn.getresponse()
+        response.read()
     finally:
         if conn:
             conn.close()


### PR DESCRIPTION
### Description
1. Related issue https://linear.app/serverless/issue/SC-1062/python-sdk-function-within-vpc-and-dev-mode-enabled-timesout-function#comment-6bac1208
2. Flush dev-mode requests before finalizing the trace to make sure all events are captured in the trace (the integration tests were not failing because of this, the dev-mode extension request errors were not included in the trace)
3. Fix the actual problem with how we use `http.client`, [as stated in the docs](https://docs.python.org/3/library/http.client.html#http.client.HTTPConnection.getresponse)
> Note that you must have read the whole response before you can send a new request to the server.

### Testing done
* Item 2 above made the integration tests fail and surface the issue. Item 3 provided the fix and now the integration tests are passing.
* Unfortunately, I couldn't reproduce the issue in unit tests, the test server is very basic and does not support streaming the response and thus the test still passes even if you don't read the response.