### PR TITLE
AWS Lambda SDK: Fix handling of not responding handler

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -182,7 +182,7 @@ const clearRootSpan = () => {
   delete awsLambdaSpan.id;
   delete awsLambdaSpan.endTime;
   awsLambdaSpan.tags.reset();
-  awsLambdaSpan.subSpans.clear();
+  awsLambdaSpan._subSpans.clear();
   capturedEvents.length = 0;
   if (objHasOwnProperty.call(serverlessSdk, '_customTags')) serverlessSdk._customTags.clear();
 };

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/no-response-callback.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/no-response-callback.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.handler = () => {};

--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/no-response-thenable.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/no-response-thenable.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.handler = async () => new Promise(() => {});

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -2188,6 +2188,40 @@ describe('integration', function () {
       },
     ],
     [
+      'no-response-callback',
+      {
+        variants: new Map([
+          ['v12', { config: { configuration: { Runtime: 'nodejs12.x' } } }],
+          ['v14', { config: { configuration: { Runtime: 'nodejs14.x' } } }],
+          ['v16', { config: { configuration: { Runtime: 'nodejs16.x' } } }],
+          ['v18', { config: { configuration: { Runtime: 'nodejs18.x' } } }],
+        ]),
+        config: {
+          isCustomResponse: true,
+          capturedEvents: [
+            { name: 'telemetry.warning.generated.v1', type: 'WARNING_TYPE_SDK_USER' },
+          ],
+        },
+      },
+    ],
+    [
+      'no-response-thenable',
+      {
+        variants: new Map([
+          ['v12', { config: { configuration: { Runtime: 'nodejs12.x' } } }],
+          ['v14', { config: { configuration: { Runtime: 'nodejs14.x' } } }],
+          ['v16', { config: { configuration: { Runtime: 'nodejs16.x' } } }],
+          ['v18', { config: { configuration: { Runtime: 'nodejs18.x' } } }],
+        ]),
+        config: {
+          isCustomResponse: true,
+          capturedEvents: [
+            { name: 'telemetry.warning.generated.v1', type: 'WARNING_TYPE_SDK_USER' },
+          ],
+        },
+      },
+    ],
+    [
       'delayed-http-request',
       {
         variants: new Map([


### PR DESCRIPTION
In the Node.js function handler does not have to be resolved (its callback called or returned promise resolved) for the invocation to successfully end.

In case of the drained event loop, AWS runtime will wrap up the invocation without waiting for the explicitly provided result.

In our logs, I've observed failures that describe a situation where we have a trace with two `aws.lambda.invocation` spans and not properly cleared tags after the previous invocation. As I tested its unresolved handler and drained the event loop, which may introduce such situations.

This patch fixes the handling of such scenario and issues a warning for the user, describing that such a situation occurred (cc @skierkowski)