### PR TITLE
[Python SDK] Do not import typing extensions for new versions

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -5,7 +5,11 @@ import sys
 import copy
 import json
 from typing import List, Optional, Any
-from typing_extensions import Final
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 import random
 from sls_sdk.lib.timing import to_protobuf_epoch_timestamp
 from sls_sdk.lib.imports import internally_imported

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 import importlib
 from os import environ
 from typing import List
+import sys
 
-from typing_extensions import Final
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 __all__: Final[List[str]] = [
     "handler",

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
@@ -1,8 +1,12 @@
-from typing_extensions import Final
 import os
 import platform
 import logging
+import sys
 
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 from sls_sdk.lib.trace import TraceSpan
 from sls_sdk.lib.timing import _DIFF
 

--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 import sys
 from os import environ
 from typing import List, Optional
-from typing_extensions import Final
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 from types import SimpleNamespace
 
 from .base import Nanoseconds, SLS_ORG_ID, __version__, __name__

--- a/python/packages/sdk/sls_sdk/base.py
+++ b/python/packages/sdk/sls_sdk/base.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Union
 from pathlib import Path
-from typing_extensions import Final
+import sys
 
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 SLS_ORG_ID: Final[str] = "SLS_ORG_ID"
 

--- a/python/packages/sdk/sls_sdk/lib/captured_event.py
+++ b/python/packages/sdk/sls_sdk/lib/captured_event.py
@@ -3,7 +3,12 @@ from typing import List, Optional
 import time
 import json
 from backports.cached_property import cached_property  # available in Python >=3.8
-from typing_extensions import Final
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 from .timing import to_protobuf_epoch_timestamp
 from .id import generate_id
 from .name import get_resource_name

--- a/python/packages/sdk/sls_sdk/lib/emitter.py
+++ b/python/packages/sdk/sls_sdk/lib/emitter.py
@@ -1,5 +1,10 @@
+import sys
 from typing import Callable
-from typing_extensions import Literal
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 EVENT_TYPE = Literal["captured-event", "trace-span-close"]
 

--- a/python/packages/sdk/sls_sdk/lib/id.py
+++ b/python/packages/sdk/sls_sdk/lib/id.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import List
 from secrets import token_hex
-from typing_extensions import Final
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 from ..base import TraceId
 

--- a/python/packages/sdk/sls_sdk/lib/name.py
+++ b/python/packages/sdk/sls_sdk/lib/name.py
@@ -5,7 +5,12 @@ from .imports import internally_imported
 with internally_imported("js_regex"):
     from js_regex import compile
 
-from typing_extensions import Final
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 from ..exceptions import InvalidTraceSpanName
 
 

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -9,7 +9,12 @@ from .imports import internally_imported
 with internally_imported("js_regex"):
     from js_regex import compile
 
-from typing_extensions import Final, get_args
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Final, get_args
+else:
+    from typing_extensions import Final, get_args
 from threading import Lock
 from .error import report as report_error
 from ..base import TagType, ValidTags

--- a/python/packages/sdk/sls_sdk/lib/trace.py
+++ b/python/packages/sdk/sls_sdk/lib/trace.py
@@ -5,7 +5,13 @@ import threading
 from typing import List, Optional, Callable
 from contextvars import ContextVar
 from backports.cached_property import cached_property  # available in Python >=3.8
-from typing_extensions import Final
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
+
 import json
 from .instrumentation.import_hook import ImportHook
 from .timing import to_protobuf_epoch_timestamp


### PR DESCRIPTION
### Description
* Related issues
  * https://linear.app/serverless/issue/SC-593/python-sdk-big-latency-overhead
  * https://linear.app/serverless/issue/SC-977/user-thetie-seeing-error-in-production-mode-with-python-sdk
* Typing extensions module is only needed for Python v3.7 and below, this change makes sure we only import this module if it's necessary for the given runtime.

### Testing done
* Unit/Integration/Perf tested
* The init time is further reduced around 20ms.