### PR TITLE
fix: Updating error message on debug log

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -545,7 +545,7 @@ func ForwardActivity(payloads []schema.DevModeTransportPayload) (int, error) {
 				req.Header.Add("sls-token-type", "orgToken")
 				res, resErr := client.Do(req)
 				if resErr != nil {
-					lib.Error("API Call failed", res.StatusCode, res.Body, resErr)
+					lib.Error("API Call failed", resErr)
 				}
 				return res.StatusCode, resErr
 			}


### PR DESCRIPTION
## Description
There are cases where the dev mode extension would crash if it fails to send the payload to our backend. This PR adds general safety checks to the forwarder and it also removes the bad values from the debug log.