### PR TITLE
fix(Go SDK): do not panic if event options not provided

### DIFF
--- a/go/packages/slslambda/event.go
+++ b/go/packages/slslambda/event.go
@@ -38,7 +38,7 @@ type (
 )
 
 func marshalCustomTags(options *EventOptions) *string {
-	if options.CustomTags == nil || len(options.CustomTags) == 0 {
+	if options == nil || options.CustomTags == nil || len(options.CustomTags) == 0 {
 		return nil
 	}
 	b, err := json.Marshal(options.CustomTags)


### PR DESCRIPTION
When an uncaught error is captured no event options are provided (nil). It causes panic during payload marshalling which is recovered and doesn't break the function but SDK payload is not printed.