### PR TITLE
AWS Lambda SDK: Fix handling of case where we wait for empty event loop

### DIFF
--- a/node/packages/aws-lambda-sdk/test/fixtures/lambdas/callback-postponed-exit.js
+++ b/node/packages/aws-lambda-sdk/test/fixtures/lambdas/callback-postponed-exit.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const http = require('http');
+const https = require('https');
+
+const TEST_SERVER_PORT = 3177;
+
+const getServer = () =>
+  http
+    .createServer((request, response) => {
+      request.on('data', () => {});
+      request.on('end', () => {
+        response.writeHead(200, {});
+        response.end('"ok"');
+      });
+    })
+    .listen(TEST_SERVER_PORT);
+
+module.exports.handler = (event, context, callback) => {
+  let url = event.url;
+  let server;
+  if (!url) {
+    server = getServer();
+    url = `http://localhost:${TEST_SERVER_PORT}/?foo=bar`;
+  }
+  callback(null, 'ok');
+  const request = url.startsWith('https') ? https.request : http.request;
+  request(url, { headers: { someHeader: 'bar' } }, (response) => {
+    let body = '';
+    response.on('data', (data) => {
+      body += data;
+    });
+    response.on('end', () => {
+      if (server) server.close();
+      console.log('Response', JSON.parse(body));
+    });
+  })
+    .end()
+    .on('error', (error) => {
+      if (server) server.close();
+      throw error;
+    });
+};

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -793,6 +793,35 @@ describe('integration', function () {
       },
     ],
     [
+      'callback-postponed-exit',
+      {
+        test: ({ invocationsData }) => {
+          for (const [
+            index,
+            {
+              trace: { spans },
+            },
+          ] of invocationsData.entries()) {
+            spans.shift();
+            if (!index) spans.shift();
+            const [invocationSpan, httpRequestSpan] = spans;
+
+            expect(httpRequestSpan.name).to.equal('node.http.request');
+            expect(httpRequestSpan.parentSpanId.toString()).to.equal(invocationSpan.id.toString());
+
+            const { tags } = httpRequestSpan;
+            expect(tags.http.method).to.equal('GET');
+            expect(tags.http.protocol).to.equal('HTTP/1.1');
+            expect(tags.http.host).to.equal('localhost:3177');
+            expect(tags.http.path).to.equal('/');
+            expect(tags.http.queryParameterNames).to.deep.equal(['foo']);
+            expect(tags.http.requestHeaderNames).to.deep.equal(['someHeader']);
+            expect(tags.http.statusCode.toString()).to.equal('200');
+          }
+        },
+      },
+    ],
+    [
       'esbuild-from-esm-callback',
       {
         variants: new Map([


### PR DESCRIPTION
When lambda is resolved via callback, by default AWS holds the resolution until the event loop drains. 

So far we didn't handle this properly (as it was not clear how it could be handled), now that we learned how AWS runtime internally detects the drain of event loop, we can fix the handling of this special case