### PR TITLE
AWS Lambda SDK: Fix handling of side effect of unexpected express configuration

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/lib/resolve-event-tags.js
+++ b/node/packages/aws-lambda-sdk/instrument/lib/resolve-event-tags.js
@@ -201,6 +201,9 @@ module.exports = (event) => {
       },
       { prefix: 'aws.lambda.http' }
     );
+    // It's possible that express instrumentation already set this tag
+    // it's sign of unexpected configuration, which we ignore
+    awsLambdaSpan.tags.delete('aws.lambda.http_router.path');
     awsLambdaSpan.tags.set('aws.lambda.http_router.path', requestContext.resourcePath);
     return;
   }


### PR DESCRIPTION
There are reports of `aws.lambda.http_router.path` being set prior invocation starts.

It signals that express middlewares were run at initialisation phase (not specifically to handle event input). It's unexpected to us, yet we need to handle it gently (ignore it)