### PR TITLE
[Python Lambda SDK] Performance tests: Increase init latency threshold

### DIFF
--- a/node/test/python/aws-lambda-sdk/benchmark/performance.test.js
+++ b/node/test/python/aws-lambda-sdk/benchmark/performance.test.js
@@ -20,7 +20,7 @@ describe('performance', function () {
 
   // TODO: Reduce acceptable durations once improvements are made
   it('should introduce reasonable initialization overhead', () => {
-    expect(results.get('internal').results.initialization.total.median).to.be.below(400);
+    expect(results.get('internal').results.initialization.total.median).to.be.below(450);
   });
 
   it('should introduce reasonable first invocation overhead', () => {


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-593\#comment-f380a737
* 400ms seems too tight and tests occasionally fail, so increasing it to 450ms.

### Testing done
Ran the performance tests locally
```
    ✔ should introduce reasonable initialization overhead
    ✔ should introduce reasonable first invocation overhead
    ✔ should introduce reasonable following invocation overhead


  3 passing (1m)
```
