### PR TITLE
SDK: Restrict tag size

### DIFF
--- a/node/packages/sdk/lib/create-error-captured-event.js
+++ b/node/packages/sdk/lib/create-error-captured-event.js
@@ -6,6 +6,7 @@ const isError = require('type/error/is');
 const CapturedEvent = require('./captured-event');
 const resolveStackTraceString = require('./resolve-stack-trace-string');
 const resolveNonErrorName = require('./resolve-non-error-name');
+const limitTagValue = require('./limit-tag-value');
 
 const typeMap = new Map([
   ['unhandled', 1],
@@ -29,12 +30,13 @@ module.exports = (error, options = {}) => {
   const tags = { type: typeMap.get(type) };
   if (isError(error)) {
     tags.name = error.name;
-    tags.message = error.message;
+    tags.message = limitTagValue(error.message);
   } else {
     tags.name = options._name || resolveNonErrorName(error);
-    tags.message = typeof error === 'string' ? error : util.inspect(error);
+    tags.message = limitTagValue(typeof error === 'string' ? error : util.inspect(error));
   }
-  tags.stacktrace = options._stack || resolveStackTraceString(error);
+  tags.stacktrace = limitTagValue(options._stack || resolveStackTraceString(error));
+
   capturedEvent.tags.setMany(tags, { prefix: 'error' });
 
   if (

--- a/node/packages/sdk/lib/limit-tag-value.js
+++ b/node/packages/sdk/lib/limit-tag-value.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const MAX_VALUE_LENGTH = require('./max-tag-value-length');
+
+module.exports = (string) => {
+  const stringBuffer = Buffer.from(string);
+  if (stringBuffer.length <= MAX_VALUE_LENGTH) return string;
+  return stringBuffer.slice(0, MAX_VALUE_LENGTH).toString();
+};

--- a/node/packages/sdk/lib/max-tag-value-length.js
+++ b/node/packages/sdk/lib/max-tag-value-length.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 32766;

--- a/node/packages/sdk/lib/tags.js
+++ b/node/packages/sdk/lib/tags.js
@@ -10,7 +10,7 @@ const capitalize = require('ext/string_/capitalize');
 const ServerlessSdkError = require('./error');
 const reportError = require('./report-error');
 
-const isValidTagName = RegExp.prototype.test.bind(/^[a-zA-Z0-9_.-]+$/);
+const isValidTagName = RegExp.prototype.test.bind(/^[a-zA-Z0-9_.-]{1,256}$/);
 
 const ensureTagName = (() => {
   const errorCode = 'INVALID_TRACE_SPAN_TAG_NAME';

--- a/node/packages/sdk/test/unit/lib/limit-tag-value.test.js
+++ b/node/packages/sdk/test/unit/lib/limit-tag-value.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const maxTagValueLength = require('../../../lib/max-tag-value-length');
+const limitTagValue = require('../../../lib/limit-tag-value');
+
+describe('lib/limit-tag-value.test.js', () => {
+  it('should pass through strings below limit', () => {
+    expect(limitTagValue('foo')).to.equal('foo');
+    expect(limitTagValue('x'.repeat(maxTagValueLength)).length).to.equal(maxTagValueLength);
+  });
+
+  it('should trim strings exceeding the limit', () => {
+    expect(limitTagValue('x'.repeat(maxTagValueLength + 1)).length).to.equal(maxTagValueLength);
+  });
+});


### PR DESCRIPTION
Restrict tag name to max `256` characters and tag value to `32766` bytes.

Ensure `error.message` and `error.stacktrace` are truncated to fit the limit