### PR TITLE
[Python SDK] Restrict tag size

### DIFF
--- a/python/packages/sdk/sls_sdk/base.py
+++ b/python/packages/sdk/sls_sdk/base.py
@@ -20,8 +20,7 @@ with open(Path(__file__).parent / "VERSION") as version_file:
 
 TraceId = str
 Nanoseconds = int
-DateStr = str
 
-TagType = Union[str, int, float, DateStr, bool, datetime]
+TagType = Union[str, int, float, bool, datetime]
 TagList = List[TagType]
 ValidTags = Union[TagType, TagList]

--- a/python/packages/sdk/sls_sdk/lib/error_captured_event.py
+++ b/python/packages/sdk/sls_sdk/lib/error_captured_event.py
@@ -5,6 +5,7 @@ from typing import Optional
 from .tags import Tags
 from .captured_event import CapturedEvent
 from .stack_trace_string import resolve as resolve_stack_trace_string
+from .tag_value import limit_tag_value
 
 
 logger = logging.getLogger(__name__)
@@ -23,8 +24,8 @@ def create(
     timestamp: Optional[int] = None,
     tags: Optional[Tags] = None,
     type: str = "handledUser",
-    name=None,
-    stack=None,
+    name: Optional[str] = None,
+    stack: Optional[str] = None,
     origin: Optional[str] = None,
     fingerprint: Optional[str] = None,
 ):
@@ -42,11 +43,11 @@ def create(
     }
     if isinstance(error, Exception):
         _tags["name"] = builtins_type(error).__name__
-        _tags["message"] = str(error)
     else:
         _tags["name"] = name or builtins_type(error).__name__
-        _tags["message"] = str(error)
-    _tags["stacktrace"] = stack or resolve_stack_trace_string(error)
+
+    _tags["message"] = limit_tag_value(str(error))
+    _tags["stacktrace"] = limit_tag_value(stack or resolve_stack_trace_string(error))
     captured_event.tags.update(_tags, prefix="error")
 
     # to avoid circular dependency, require inline

--- a/python/packages/sdk/sls_sdk/lib/tag_value.py
+++ b/python/packages/sdk/sls_sdk/lib/tag_value.py
@@ -1,0 +1,8 @@
+MAX_VALUE_LENGTH = 32766
+
+
+def limit_tag_value(value: str) -> str:
+    byte_array = value.encode(errors="ignore")
+    if len(byte_array) <= MAX_VALUE_LENGTH:
+        return value
+    return byte_array[:MAX_VALUE_LENGTH].decode(errors="ignore")

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -27,8 +27,7 @@ from ..exceptions import (
     SdkException,
 )
 
-# from https://github.com/serverless/console/blob/fe64a4f53529285e89a64f7d50ec9528a3c4ce57/node/packages/sdk/lib/tags.js#L12
-RE: Final[str] = r"^[a-zA-Z0-9_.-]+$"
+RE: Final[str] = r"^[a-zA-Z0-9_.-]{1,256}$"
 RE_C: Final[Pattern] = compile(RE)
 
 

--- a/python/packages/sdk/tests/lib/test_tag_value.py
+++ b/python/packages/sdk/tests/lib/test_tag_value.py
@@ -1,0 +1,23 @@
+from sls_sdk.lib.tag_value import limit_tag_value, MAX_VALUE_LENGTH
+
+
+def test_limit_tag_value_noop_for_short_values():
+    # given
+    value = "this should pass as is"
+
+    # when
+    result = limit_tag_value(value)
+
+    # then
+    assert result == value
+
+
+def test_limit_tag_value_truncates_long_values():
+    # given
+    value = "x" * (MAX_VALUE_LENGTH + 1)
+
+    # when
+    result = limit_tag_value(value)
+
+    # then
+    assert len(result) == MAX_VALUE_LENGTH

--- a/python/packages/sdk/tests/lib/test_tags.py
+++ b/python/packages/sdk/tests/lib/test_tags.py
@@ -242,12 +242,20 @@ def test_tags_invalid_names_and_values_bulk(tags: Tags, monkeypatch):
 
 
 def test_tags_invalid_names_and_values_bulk_internal_method_raises_exception(
-    tags: Tags, monkeypatch
+    tags: Tags,
 ):
     # given
-    mock = MagicMock()
-    monkeypatch.setattr(sls_sdk.lib.tags, "report_error", mock)
+    data = {name: "" for name in INVALID_NAMES}
 
     # when
     with pytest.raises(SdkException):
-        tags._update({name: "" for name in INVALID_NAMES})
+        tags._update(data)
+
+
+def test_tags_non_flat_list_raises_exception(tags: Tags):
+    # given
+    data = {"foo": ["bar", ["baz"]]}
+
+    # when
+    with pytest.raises(SdkException):
+        tags._update(data)


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1129/sdk-field-size-limits#comment-6fef104d
* Restrict tag name to max 256 characters and tag value to 32766 bytes
* Ensure `error.message` and `error.stacktrace` are truncated to fit the limit
* Fix handling of lists for tag values, make sure lists are flat

### Testing done
Unit & integration tested