### PR TITLE
fix: Write payloads using gzip

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -25,7 +25,7 @@ from .lib.api_events import is_api_event
 from sls_sdk.lib.trace import TraceSpan
 from sls_sdk.lib.captured_event import CapturedEvent
 import base64
-import zlib
+import gzip
 
 
 def debug_log(msg):
@@ -255,7 +255,7 @@ class Instrumenter:
             else None,
         }
         payload = to_trace_payload(payload_dct)
-        compressed_payload = zlib.compress(payload.SerializeToString())
+        compressed_payload = gzip.compress(payload.SerializeToString())
         print(
             f"SERVERLESS_TELEMETRY.TZ.{base64.b64encode(compressed_payload).decode('utf-8')}"
         )

--- a/python/packages/aws-lambda-sdk/tests/instrument/serialization.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/serialization.py
@@ -1,4 +1,4 @@
-import zlib
+import gzip
 from serverless_sdk_schema import TracePayload
 import base64
 
@@ -7,4 +7,4 @@ TARGET_LOG_PREFIX = "SERVERLESS_TELEMETRY.TZ."
 
 
 def deserialize_trace(trace):
-    return TracePayload.FromString(zlib.decompress(base64.b64decode(trace)))
+    return TracePayload.FromString(gzip.decompress(base64.b64decode(trace)))


### PR DESCRIPTION
To match the Node SDK and what ingest expects for compressed payloads.