### PR TITLE
Make retries visible in tests

### DIFF
--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -988,6 +988,7 @@ describe('integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -1048,6 +1049,7 @@ describe('integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -1105,6 +1107,7 @@ describe('integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -1203,6 +1206,7 @@ describe('integration', function () {
                 });
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -1302,6 +1306,7 @@ describe('integration', function () {
             });
             if (response.status !== 200) {
               if (response.status === 404) {
+                log.debug('Retrying invocation of %s', testConfig.name);
                 await wait(1000);
                 return self(testConfig);
               }

--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -331,6 +331,7 @@ describe('Python: integration', function () {
     );
     if (response.status !== 200) {
       if (response.status === 404) {
+        log.debug('Retrying invocation of %s', testConfig.name);
         await wait(1000);
         return self(testConfig);
       }
@@ -739,6 +740,7 @@ describe('Python: integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -799,6 +801,7 @@ describe('Python: integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -856,6 +859,7 @@ describe('Python: integration', function () {
                 );
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }
@@ -954,6 +958,7 @@ describe('Python: integration', function () {
                 });
                 if (response.status !== 200) {
                   if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
                     await wait(1000);
                     return self(testConfig);
                   }


### PR DESCRIPTION
### Description
* Related issue https://github.com/serverless/console/pull/801#issuecomment-1593073275
* Add a debug log for when the API Gateway response is 404 and the request is retried

### Testing done
Ran the integration tests for python
