### PR TITLE
Fix pyproject-fmt version

### DIFF
--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd python/packages
 
-          python3 -m pip install tox pyproject-fmt
+          python3 -m pip install tox pyproject-fmt==0.10.0
 
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd python/packages
 
-          python3 -m pip install tox pyproject-fmt==0.10.0
+          python3 -m pip install tox pyproject-fmt
 
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -56,6 +56,9 @@ repository = "https://github.com/serverless/console"
 [tool.setuptools.dynamic]
 version = {file = "./serverless_aws_lambda_sdk/VERSION"}
 
+[tool.ruff]
+exclude = ["tests"]
+
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
@@ -70,6 +73,3 @@ exclude = [
 [[tool.mypy.overrides]]
 module = "wrapt"
 ignore_missing_imports = true
-
-[tool.ruff]
-exclude = ["tests"]


### PR DESCRIPTION
### Description
Noticed that a recent PR was failing due to pyproject.toml file formatting, since pyproject-fmt released a version that breaks for us. This PR fixes the version to `0.10.0` which is known to be working for our files.

### Testing done
Tested by running `python -m pyproject_fmt --indent 4 pyproject.toml` and verifying it does not suggest changes.