### PR TITLE
Draft: [Python base SDK] Absolute imports should be made internal

### DIFF
--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
-import sys
-from os import environ
-from typing import List, Optional
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
-from types import SimpleNamespace
+from .lib.imports import internally_imported
+
+with internally_imported():
+    import sys
+    from os import environ
+    from typing import List, Optional
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+    from types import SimpleNamespace
 
 from .base import Nanoseconds, SLS_ORG_ID, __version__, __name__
 from .lib import trace

--- a/python/packages/sdk/sls_sdk/base.py
+++ b/python/packages/sdk/sls_sdk/base.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import List, Union
-from pathlib import Path
-import sys
+from .lib.imports import internally_imported
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+with internally_imported():
+    from datetime import datetime
+    from typing import List, Union
+    from pathlib import Path
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
 
 SLS_ORG_ID: Final[str] = "SLS_ORG_ID"
 

--- a/python/packages/sdk/sls_sdk/lib/captured_event.py
+++ b/python/packages/sdk/sls_sdk/lib/captured_event.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
-from typing import List, Optional
-import time
-import json
-from backports.cached_property import cached_property  # available in Python >=3.8
-import sys
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from .imports import internally_imported
+
+with internally_imported():
+    from typing import List, Optional
+    import time
+    import json
+    from backports.cached_property import cached_property  # available in Python >=3.8
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+
 from .timing import to_protobuf_epoch_timestamp
 from .id import generate_id
 from .name import get_resource_name

--- a/python/packages/sdk/sls_sdk/lib/emitter.py
+++ b/python/packages/sdk/sls_sdk/lib/emitter.py
@@ -1,10 +1,13 @@
-import sys
-from typing import Callable
+from .imports import internally_imported
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+with internally_imported():
+    import sys
+    from typing import Callable
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 EVENT_TYPE = Literal["captured-event", "trace-span-close"]
 

--- a/python/packages/sdk/sls_sdk/lib/error.py
+++ b/python/packages/sdk/sls_sdk/lib/error.py
@@ -1,8 +1,10 @@
-import os
-from builtins import type as builtins_type
+from .imports import internally_imported
 from .stack_trace_string import resolve as resolve_stack_trace_string
 
-import logging
+with internally_imported():
+    import os
+    from builtins import type as builtins_type
+    import logging
 
 
 logger = logging.getLogger(__name__)

--- a/python/packages/sdk/sls_sdk/lib/error_captured_event.py
+++ b/python/packages/sdk/sls_sdk/lib/error_captured_event.py
@@ -1,7 +1,11 @@
-import logging
-import time
-from builtins import type as builtins_type
-from typing import Optional
+from .imports import internally_imported
+
+with internally_imported():
+    import logging
+    import time
+    from builtins import type as builtins_type
+    from typing import Optional
+
 from .tags import Tags
 from .captured_event import CapturedEvent
 from .stack_trace_string import resolve as resolve_stack_trace_string

--- a/python/packages/sdk/sls_sdk/lib/id.py
+++ b/python/packages/sdk/sls_sdk/lib/id.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import List
-from secrets import token_hex
-import sys
+from .imports import internally_imported
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+with internally_imported():
+    from typing import List
+    from secrets import token_hex
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
 
 from ..base import TraceId
 

--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -15,9 +15,7 @@ if bool(os.environ.get("SLS_DEV_MODE_ORG_ID")):
 
 
 @contextmanager
-def internally_imported(
-    *top_level_module_names: str, internal_path: str = "/opt/python"
-):
+def internally_imported(internal_path: str = "/opt/python"):
     def _import():
         previously_cached_modules = sys.modules.copy()
         original_sys_path = sys.path.copy()

--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 from contextlib import contextmanager
 import sys
 import os
-from typing import Dict
-from types import ModuleType
+from typing import Dict, Any
 
-_INTERNAL_MODULES: Dict[str, ModuleType] = dict()
+_INTERNAL_MODULES: Dict[str, Any] = dict()
 
 _LOCK = None
 

--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -33,18 +33,16 @@ def internally_imported(
             _INTERNAL_MODULES
         )  # Restore previous internal imports to sys.modules to make them visible
 
+        # At this point we yield control, so that our layer's modules can be imported
         yield
 
+        # At this point, modules were imported, so we need to undo the changes we made
         sys.path = original_sys_path  # Rollback the path change
 
         # Remove the internal modules from sys.modules
         # to prevent them being imported by customer code
         for module_name in sys.modules.copy():
-            if module_name not in previously_cached_modules and [
-                prefix
-                for prefix in top_level_module_names
-                if module_name == prefix or module_name.startswith(f"{prefix}.")
-            ]:
+            if module_name not in previously_cached_modules:
                 _INTERNAL_MODULES[module_name] = sys.modules[module_name]
                 del sys.modules[module_name]
 

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
@@ -1,7 +1,12 @@
-import re
 from sls_sdk import serverlessSdk
+
+from ..imports import internally_imported
+
+with internally_imported():
+    import re
+    from functools import partial
+
 from ..error import report as report_error
-from functools import partial
 from .import_hook import ImportHook
 
 _instrumenter = None

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
-import time
-import contextvars
-import contextlib
-from urllib.parse import urlparse
-from urllib.parse import parse_qs
+
+import sls_sdk
+
+from ..imports import internally_imported
+
+with internally_imported():
+    import time
+    import contextvars
+    import contextlib
+    from urllib.parse import urlparse
+    from urllib.parse import parse_qs
+    import io
+    from typing import Iterable
+
 from ..error import report as report_error
 from .import_hook import ImportHook
-import sls_sdk
 from .wrapper import replace_method
-import io
-from typing import Iterable
+
 
 SDK = sls_sdk.serverlessSdk
 _IGNORE_FOLLOWING_REQUEST = contextvars.ContextVar("ignore", default=False)

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/import_hook.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/import_hook.py
@@ -1,5 +1,8 @@
-import sys
-from importlib.machinery import PathFinder, SourceFileLoader
+from ..imports import internally_imported
+
+with internally_imported():
+    import sys
+    from importlib.machinery import PathFinder, SourceFileLoader
 
 
 class CustomImporter:

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/logging.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/logging.py
@@ -1,5 +1,9 @@
 from logging import Logger
-import json
+
+from ..imports import internally_imported
+
+with internally_imported():
+    import json
 
 from ..error import report as report_error
 from ..error_captured_event import create as create_error_captured_event

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/wrapper.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/wrapper.py
@@ -1,4 +1,7 @@
-from functools import partial
+from ..imports import internally_imported
+
+with internally_imported():
+    from functools import partial
 
 
 class ReplacementMethod(object):

--- a/python/packages/sdk/sls_sdk/lib/name.py
+++ b/python/packages/sdk/sls_sdk/lib/name.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
-from re import Pattern
+
 from .imports import internally_imported
 
 with internally_imported():
+    from re import Pattern
     from js_regex import compile
+    import sys
 
-import sys
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
 from ..exceptions import InvalidTraceSpanName
 
 

--- a/python/packages/sdk/sls_sdk/lib/name.py
+++ b/python/packages/sdk/sls_sdk/lib/name.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from re import Pattern
 from .imports import internally_imported
 
-with internally_imported("js_regex"):
+with internally_imported():
     from js_regex import compile
 
 import sys

--- a/python/packages/sdk/sls_sdk/lib/notice.py
+++ b/python/packages/sdk/sls_sdk/lib/notice.py
@@ -1,5 +1,9 @@
-from typing import Optional
-import time
+from .imports import internally_imported
+
+with internally_imported():
+    from typing import Optional
+    import time
+
 from .trace import TraceSpan
 from .captured_event import CapturedEvent
 

--- a/python/packages/sdk/sls_sdk/lib/stack_trace_string.py
+++ b/python/packages/sdk/sls_sdk/lib/stack_trace_string.py
@@ -1,7 +1,10 @@
-import traceback
-import sys
-import inspect
-from typing import Optional, Any
+from .imports import internally_imported
+
+with internally_imported():
+    import traceback
+    import sys
+    import inspect
+    from typing import Optional, Any
 
 
 def resolve(error: Optional[Any] = None) -> str:

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
-import re
-from datetime import datetime
-import json
-from math import inf, nan
-from re import Pattern
-from typing import Dict, List, Mapping, Tuple, Optional, Any
+
 from .imports import internally_imported
-from .tag_value import MAX_VALUE_LENGTH
 
 with internally_imported():
+    import re
+    from datetime import datetime
+    import json
+    from math import inf, nan
+    from re import Pattern
+    from typing import Dict, List, Mapping, Tuple, Optional, Any
     from js_regex import compile
+    import sys
 
-import sys
+    if sys.version_info >= (3, 8):
+        from typing import Final, get_args
+    else:
+        from typing_extensions import Final, get_args
+    from threading import Lock
 
-if sys.version_info >= (3, 8):
-    from typing import Final, get_args
-else:
-    from typing_extensions import Final, get_args
-from threading import Lock
+from .tag_value import MAX_VALUE_LENGTH
 from .error import report as report_error
 from ..base import TagType, ValidTags
 from ..exceptions import (

--- a/python/packages/sdk/sls_sdk/lib/tags.py
+++ b/python/packages/sdk/sls_sdk/lib/tags.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Mapping, Tuple, Optional, Any
 from .imports import internally_imported
 from .tag_value import MAX_VALUE_LENGTH
 
-with internally_imported("js_regex"):
+with internally_imported():
     from js_regex import compile
 
 import sys

--- a/python/packages/sdk/sls_sdk/lib/timing.py
+++ b/python/packages/sdk/sls_sdk/lib/timing.py
@@ -1,5 +1,8 @@
-import time
-from typing import Optional
+from .imports import internally_imported
+
+with internally_imported():
+    import time
+    from typing import Optional
 
 
 _DIFF = time.time_ns() - time.perf_counter_ns()

--- a/python/packages/sdk/sls_sdk/lib/trace.py
+++ b/python/packages/sdk/sls_sdk/lib/trace.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
-from collections.abc import Iterable
-import time
-import threading
-from typing import List, Optional, Callable
-from contextvars import ContextVar
-from backports.cached_property import cached_property  # available in Python >=3.8
-import sys
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from .imports import internally_imported
 
-import json
+with internally_imported():
+    from collections.abc import Iterable
+    import time
+    import threading
+    from typing import List, Optional, Callable
+    from contextvars import ContextVar
+    from backports.cached_property import cached_property  # available in Python >=3.8
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+
+    import json
+
 from .instrumentation.import_hook import ImportHook
 from .timing import to_protobuf_epoch_timestamp
 from ..base import Nanoseconds, TraceId

--- a/python/packages/sdk/sls_sdk/lib/warning.py
+++ b/python/packages/sdk/sls_sdk/lib/warning.py
@@ -1,5 +1,8 @@
 from .warning_captured_event import create as create_warning_captured_event
-import logging
+from .imports import internally_imported
+
+with internally_imported():
+    import logging
 
 
 logger = logging.getLogger(__name__)

--- a/python/packages/sdk/sls_sdk/lib/warning_captured_event.py
+++ b/python/packages/sdk/sls_sdk/lib/warning_captured_event.py
@@ -1,6 +1,10 @@
-import logging
-import time
-from typing import Optional
+from .imports import internally_imported
+
+with internally_imported():
+    import logging
+    import time
+    from typing import Optional
+
 from .tags import Tags
 from .captured_event import CapturedEvent
 from .stack_trace_string import resolve as resolve_stack_trace_string

--- a/python/packages/sdk/tests/lib/test_imports.py
+++ b/python/packages/sdk/tests/lib/test_imports.py
@@ -20,9 +20,7 @@ def test_internally_imported():
         del sys.modules["flask"]
 
     # when
-    with internally_imported(
-        "flask", internal_path=str(Path(__file__).resolve().parent)
-    ):
+    with internally_imported(internal_path=str(Path(__file__).resolve().parent)):
         import flask
 
         os.remove(path)


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1200/issue-with-some-imports-in-python-sdk-initialization#comment-f0d95f19
* The absolute imports by our layer are arranged to be made internal and not visible to customer code. This will ensure our imports are not overwritten by customer code, for instance if customer has a "secrets" module we can still import the standard library "secrets" module and not customer's module.
* We should not import the sdk itself internally though, otherwise the customer's version would be different and we'd have two instances of the sdk hanging around
* Relative imports are not affected, as they point precisely to our layer code.
* This is a breaking change

### Testing done
* Unit tested
* Integration/performance tested, against a modified serverless-aws-lambda-sdk module (because of breaking changes), to make sure the approach is sound

### Next
* We should release a breaking version of base SDK
* Same fixes to be applied on the serverless-aws-lambda-sdk package
* Unit tests and integration tests on serverless-aws-lambda-sdk should be enhanced to cover the module name clashes such as "secrets" and some more ("typing", "contextlib" etc.) 
* New version of the serverless-aws-lambda-sdk package to be released
