### PR TITLE
[Python Lambda SDK] Absolute imports should be made internal 

### DIFF
--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "serverless-sdk~=0.4.12",
+    "serverless-sdk~=0.5.0",
     "serverless-sdk-schema~=0.2.3",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-import os
-import logging
-from typing import Optional
+
 import sys
 import inspect
 from pathlib import Path
@@ -19,12 +17,19 @@ finally:
     if _path_modified:
         sys.path.pop(0)
 
-
+from .instrumentation import aws_sdk  # noqa E402
 from .trace_spans.aws_lambda import aws_lambda_span  # noqa E402
+
 from sls_sdk import ServerlessSdk, TraceSpans  # noqa E402
 from sls_sdk.lib.trace import TraceSpan  # noqa E402
 from sls_sdk.lib.captured_event import CapturedEvent  # noqa E402
-from .instrumentation import aws_sdk  # noqa E402
+
+from sls_sdk.lib.imports import internally_imported  # noqa E402
+
+with internally_imported():
+    from typing import Optional
+    import logging
+    import os
 
 # module metadata
 __name__ = "serverless-aws-lambda-sdk"

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
-import os
-import time
-import sys
-import copy
-import json
-from typing import List, Optional, Any, Set
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
-import random
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported():
+    import os
+    import time
+    import sys
+    import copy
+    import json
+    from typing import List, Optional, Any, Set
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+    import random
+
+    import base64
+    import gzip
+
 from sls_sdk.lib.timing import to_protobuf_epoch_timestamp
 from sls_sdk.lib.imports import internally_imported
+from sls_sdk.lib.trace import TraceSpan
+from sls_sdk.lib.captured_event import CapturedEvent
 from .lib.sdk import serverlessSdk
 from .lib.invocation_context import (
     set as set_invocation_context,
@@ -23,10 +33,6 @@ from .lib.event_tags import resolve as resolve_event_tags
 from .lib.response_tags import resolve as resolve_response_tags
 from .lib.api_events import is_api_event
 from .lib.captured_event import should_include as should_include_event_captured_event
-from sls_sdk.lib.trace import TraceSpan
-from sls_sdk.lib.captured_event import CapturedEvent
-import base64
-import gzip
 
 
 MAX_LOG_LINE_LENGTH = 256 * 1024
@@ -454,7 +460,7 @@ class Instrumenter:
             self.dev_mode.terminate()
             self.dev_mode = None
 
-    @internally_imported("google")
+    @internally_imported()
     def _close_trace(self, outcome: str, outcome_result: Optional[Any] = None):
         self.is_root_span_reset = False
         try:
@@ -517,7 +523,7 @@ class Instrumenter:
     def _handler(self, user_handler, event, context):
         request_start_time = time.perf_counter_ns()
         self.current_invocation_id += 1
-        with internally_imported("google"):
+        with internally_imported():
             try:
                 debug_log("Invocation: start")
                 set_invocation_context(context)

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/dev_mode.py
@@ -1,14 +1,17 @@
-import json
-from threading import Thread, Event, Lock
-import os
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported():
+    import json
+    from threading import Thread, Event, Lock
+    import os
+    import builtins
+    import logging
+
 from .telemetry import send, close_connection
 from .sdk import serverlessSdk
 from .invocation_context import get as get_invocation_context
 from .payload_conversion import to_trace_payload
-from sls_sdk.lib.imports import internally_imported
 from .captured_event import should_include as should_include_event_captured_event
-import builtins
-import logging
 
 _original_print = builtins.print
 
@@ -86,7 +89,7 @@ class DevModeThread(Thread):
         )  # used to buffer spans and captured events
         self._is_stopped = Event()  # used to stop the thread
 
-    @internally_imported("google")
+    @internally_imported()
     def _send_all(self):
         (
             spans,

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -1,6 +1,6 @@
 from sls_sdk.lib.imports import internally_imported
 
-with internally_imported("google"):
+with internally_imported():
     from serverless_sdk_schema import TracePayload, RequestResponse
     from google.protobuf import json_format
 

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/telemetry.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/telemetry.py
@@ -1,9 +1,12 @@
 from .sdk import serverlessSdk
 
 if serverlessSdk._is_dev_mode:
-    import time
-    import http.client
+    from sls_sdk.lib.imports import internally_imported
     from sls_sdk.lib.instrumentation.http import ignore_following_request
+
+    with internally_imported():
+        import time
+        import http.client
 
     _connection = None
 
@@ -44,7 +47,8 @@ if serverlessSdk._is_dev_mode:
                     "DEV_MODE_SERVER_REJECTION",
                 )
         except Exception as ex:
-            import traceback
+            with internally_imported():
+                import traceback
 
             error = "".join(traceback.TracebackException.from_exception(ex).format())
             serverlessSdk._report_warning(

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrumentation/aws_sdk.py
@@ -1,3 +1,9 @@
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported():
+    import re
+    import importlib
+
 from ..lib.instrumentation.aws_sdk.safe_stringify import safe_stringify
 from ..lib.instrumentation.aws_sdk.service_mapper import get_mapper_for_service
 from sls_sdk import serverlessSdk
@@ -7,8 +13,6 @@ from sls_sdk.lib.instrumentation.http import (
     reset_ignore_following_request,
 )
 from sls_sdk.lib.instrumentation.wrapper import replace_method
-import re
-import importlib
 
 _instrumenter = None
 _import_hook = ImportHook("botocore")

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/internal_extension/wrapper.py
@@ -1,15 +1,8 @@
 from __future__ import annotations
 import importlib
 from os import environ
-from typing import List
-import sys
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
-
-__all__: Final[List[str]] = [
+__all__ = [
     "handler",
 ]
 

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/safe_stringify.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/safe_stringify.py
@@ -1,4 +1,8 @@
-import json
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported():
+    import json
+
 import serverless_aws_lambda_sdk
 
 

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/service_mapper.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/lib/instrumentation/aws_sdk/service_mapper.py
@@ -1,4 +1,7 @@
-from abc import ABC, abstractmethod
+from sls_sdk.lib.imports import internally_imported
+
+with internally_imported():
+    from abc import ABC, abstractmethod
 
 
 class ServiceMapper(ABC):

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/trace_spans/aws_lambda.py
@@ -1,12 +1,16 @@
-import os
-import platform
-import logging
-import sys
+from sls_sdk.lib.imports import internally_imported
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+with internally_imported():
+    import os
+    import platform
+    import logging
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+
 from sls_sdk.lib.trace import TraceSpan
 from sls_sdk.lib.timing import _DIFF
 

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
@@ -1,7 +1,18 @@
+# This file is used to test that the customer can shadow modules
+# by importing their own modules that has the same name.
+# See /node/test/python/aws-lambda-sdk/integration.test.js
+# to find out how these modules are injected.
+
 import google.protobuf
+import secrets
+import typing
+import contextvars
 
 
 def handler(event, context) -> str:
-    if google.protobuf.foo != "bar":
-        raise Exception("google.protobuf.foo != 'bar'")
+    if set([google.protobuf.foo, secrets.foo, typing.foo, contextvars.foo]) != set(
+        ["bar"]
+    ):
+        raise Exception("customer can not shadow modules")
+
     return "ok"

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/internal_dependencies.py
@@ -5,14 +5,10 @@
 
 import google.protobuf
 import secrets
-import typing
-import contextvars
 
 
 def handler(event, context) -> str:
-    if set([google.protobuf.foo, secrets.foo, typing.foo, contextvars.foo]) != set(
-        ["bar"]
-    ):
+    if set([google.protobuf.foo, secrets.foo]) != set(["bar"]):
         raise Exception("customer can not shadow modules")
 
     return "ok"

--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 import sys
 import os
-from typing import Dict, Any
 
-_INTERNAL_MODULES: Dict[str, Any] = dict()
+_INTERNAL_MODULES = dict()  # type: ignore
 
 _LOCK = None
 

--- a/python/packages/sdk/sls_sdk/lib/imports.py
+++ b/python/packages/sdk/sls_sdk/lib/imports.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 from contextlib import contextmanager
 import sys
 import os
+from typing import Dict, Any
 
-_INTERNAL_MODULES = dict()  # type: ignore
+_INTERNAL_MODULES: Dict[str, Any] = dict()
 
 _LOCK = None
 


### PR DESCRIPTION
This PR builds on https://github.com/serverless/console/pull/812 and should be reviewed after we release the other PR in a breaking change:

1. We should update the pyproject.toml to use the latest version
2. Review the PR and merge
3. Release a new version of the serverless-aws-lambda-sdk package

### Description
* Related issue https://linear.app/serverless/issue/SC-1200/issue-with-some-imports-in-python-sdk-initialization#comment-f0d95f19
* The absolute imports by our layer are arranged to be made internal and not visible to customer code. This will ensure our imports are not overwritten by customer code, for instance if customer has a "secrets" module we can still import the standard library "secrets" module and not customer's module.
* We should not import the sdk itself internally though, otherwise the customer's version would be different and we'd have two instances of the sdk hanging around
* Relative imports are not affected, as they point precisely to our layer code.
* This is a breaking change

### Testing done
* Unit tested
* Integration/performance tested
