### PR TITLE
AWS Lambda SDK: Ensure to expose uncaught exceptions

### DIFF
--- a/node/packages/aws-lambda-sdk/instrument/index.js
+++ b/node/packages/aws-lambda-sdk/instrument/index.js
@@ -61,7 +61,7 @@ const resolveBodyString = (data, prefix) => {
   return stringifiedBody;
 };
 
-const reportRequest = async (event, context) => {
+const reportRequest = (event, context) => {
   const payload = (serverlessSdk._lastRequest = {
     slsTags: {
       orgId: serverlessSdk.orgId,
@@ -77,10 +77,10 @@ const reportRequest = async (event, context) => {
   });
   const payloadBuffer = (serverlessSdk._lastRequestBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());
-  await sendTelemetry('request-response', payloadBuffer);
+  return sendTelemetry('request-response', payloadBuffer);
 };
 
-const reportResponse = async (response, context, endTime) => {
+const reportResponse = (response, context, endTime) => {
   const responseString = resolveBodyString(response, 'OUTPUT');
   const payload = (serverlessSdk._lastResponse = {
     slsTags: {
@@ -97,7 +97,7 @@ const reportResponse = async (response, context, endTime) => {
   });
   const payloadBuffer = (serverlessSdk._lastResponseBuffer =
     requestResponseProto.RequestResponse.encode(payload).finish());
-  await sendTelemetry('request-response', payloadBuffer);
+  return sendTelemetry('request-response', payloadBuffer);
 };
 
 const gapsBetweenInvocations = [];


### PR DESCRIPTION
In parts of a logic where we process request and response, eventual uncaught exceptions (which in such case will be correctly handled and muted) are converted to unhandled rejections, which are not handled and exposed as lambda crashes to users.

This patch ensures those eventual exceptions land as uncaught exceptions.

It's discovered with latest report, where lambda was crashing for user in dev mode (source of the issue was already fixed with #822)