### PR TITLE
feat: Update WritePolicy to Enable CreateServiceLinkedRole for EventBridge

### DIFF
--- a/instrumentation/aws/iam-role-cfn-template.yaml
+++ b/instrumentation/aws/iam-role-cfn-template.yaml
@@ -1484,7 +1484,11 @@ Resources:
               # https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicyVersions.html
               - "iam:ListPolicyVersions"
               - "iam:DeleteRolePolicy"
+              # Grants permission to Create the Service Linked Roles that Serverless needs to operate. Each ServiceLinkedRole is defined in the resource block below
+              # https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateServiceLinkedRole.html
+              - "iam:CreateServiceLinkedRole"
             Resource:
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/apidestinations.events.amazonaws.com/AWSServiceRoleForAmazonEventBridgeApiDestinations
               - !Sub "${AWS::StackId}"
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/ServerlessRole"
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/ServerlessMonitoringRole"

--- a/instrumentation/aws/iam-role-cfn-template.yaml
+++ b/instrumentation/aws/iam-role-cfn-template.yaml
@@ -30,12 +30,6 @@ Resources:
         Ref: ExternalId
       Version:
         Ref: Version
-  APIDestinationsEventBridgeServiceLinkedRole:
-    Type: AWS::IAM::ServiceLinkedRole
-    DeletionPolicy: Retain
-    Properties:
-      AWSServiceName: apidestinations.events.amazonaws.com
-      Description: Enables access to the Secrets Manager Secrets created by AWS EventBridge
   ServerlessEventSubscriptionExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
Instead of explicitly attempting to create the ServiceLinkedRole for Eventbridge, which can causes errors in some cases, we will instead give the role permissions to create that ServiceLinkedRole when Console attempts to create the event subscriptions.