### PR TITLE
fix: Execution should halt if api error is detected

### DIFF
--- a/go/packages/dev-mode/agent/forwarder.go
+++ b/go/packages/dev-mode/agent/forwarder.go
@@ -546,6 +546,7 @@ func ForwardActivity(payloads []schema.DevModeTransportPayload) (int, error) {
 				res, resErr := client.Do(req)
 				if resErr != nil {
 					lib.Error("API Call failed", resErr)
+					return 500, resErr
 				}
 				return res.StatusCode, resErr
 			}


### PR DESCRIPTION
## Description
I forgot to add a return here so once the error was logs (or not depending on the function configuration) we would try and access `res.StatusCode` causing a seg fault.

## Screenshot
<img width="804" alt="Screenshot 2023-06-28 at 3 28 12 PM" src="https://github.com/serverless/console/assets/1753824/94bb38bc-4fcc-4536-a698-6e690fc4e266">
