### PR TITLE
[Python Base SDK] Fix response body monitoring

### DIFF
--- a/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/http.py
@@ -127,10 +127,10 @@ class NativeAIOHTTPInstrumenter(BaseInstrumenter):
         self._original_init = None
 
     async def _capture_response_body(self, trace_span, response):
-        # TODO: Turned off temporarily, until we have response body observation fixed
-        return
         # response is a aiohttp.ClientResponse object
-        if not self.should_monitor_request_response:
+        if not self.should_monitor_request_response or not hasattr(
+            response.content, "unread_data"
+        ):
             return
         if (
             response.content_length
@@ -144,6 +144,7 @@ class NativeAIOHTTPInstrumenter(BaseInstrumenter):
             return
         try:
             response_body = await response.read()
+            response.content.unread_data(response_body)
             if response_body:
                 trace_span.output = _decode_body(response_body)
         except Exception as ex:
@@ -319,8 +320,6 @@ class NativeHTTPInstrumenter(BaseInstrumenter):
         return _func
 
     def _capture_response_body(self, trace_span, response):
-        # TODO: Turned off temporarily, until we have response body observation fixed
-        return
         if not self.should_monitor_request_response:
             return
         if response.length > SDK._maximum_body_byte_length:
@@ -422,8 +421,6 @@ class URLLib3Instrumenter(BaseInstrumenter):
                 trace_span.close()
 
     def _capture_response_body(self, trace_span, response):
-        # TODO: Turned off temporarily, until we have response body observation fixed
-        return
         if not self.should_monitor_request_response:
             return
 

--- a/python/packages/sdk/tests/lib/instrumentation/test_http.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_http.py
@@ -24,13 +24,12 @@ def _assert_request_response_body(sdk, request_body, response_body):
         or (len(request_body) > 1024 * 127 and sdk.trace_spans.root.input is None)
         or sdk.trace_spans.root.input == request_body.decode("utf-8")
     )
-    # TODO: Uncomment after response body observation is fixed
-    # assert (
-    #     not sdk._is_dev_mode
-    #     or (response_body is None and sdk.trace_spans.root.output is None)
-    #     or (len(response_body) > 1024 * 127 and sdk.trace_spans.root.output is None)
-    #     or sdk.trace_spans.root.output == response_body.decode("utf-8")
-    # )
+    assert (
+        not sdk._is_dev_mode
+        or (response_body is None and sdk.trace_spans.root.output is None)
+        or (len(response_body) > 1024 * 127 and sdk.trace_spans.root.output is None)
+        or sdk.trace_spans.root.output == response_body.decode("utf-8")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1204/python-sdk-users-seeing-errors-since-last-update
* Reenable response body monitoring in dev-mode
* For aiohttp instrumentation, if response body monitoring is enabled, we were consuming the response for reporting but then the customer was unable to consume it again as the stream was finished. This fix "unreads" the response data, so that customer can reread it.

#### What Was Happening?
* Note that this is a very specific case in which the transient dependency `aiobotocore` library accesses the internals of `aiohttp` instead of relying its public `read` method which we were already using. If `aiobotocore` also used `read`, it would successfully read the response many times because that `read` method caches the response body. However, since `aiobotocore` accesses the underlying stream directly, once we read the stream for response body reporting, it can't reread it through the underlying stream.
* The fix rewinds the underlying stream to its initial position by unreading the data.

### Testing done
Unit and integration tested (integration tests for this specific case will be added in a separate PR for the lambda SDK).