### PR TITLE
[Python Lambda SDK] Fix internal imports

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -452,6 +452,7 @@ describe('Python: integration', function () {
   };
 
   const httpTestConfig = new Map([
+    ['dev-mode', devModeConfiguration],
     [
       'http',
       {
@@ -1002,6 +1003,15 @@ describe('Python: integration', function () {
       },
     ],
     [
+      'aiobotocore_requester',
+      {
+        variants: new Map([
+          ['dev-mode', devModeConfiguration],
+          ['v3-10', { configuration: { Runtime: 'python3.10' } }],
+        ]),
+      },
+    ],
+    [
       'dashboard/s_hello',
       {
         variants: new Map([
@@ -1079,7 +1089,7 @@ describe('Python: integration', function () {
 
   before(async () => {
     exec(
-      `pip install pynamodb==5.5.0 yarl==1.8.2 aiohttp==3.8.4 serverless-wsgi==3.0.2 flask==2.2.3 --target="${fixturesDirname}/test_dependencies"`
+      `pip install pynamodb==5.5.0 yarl==1.8.2 aiohttp==3.8.4 serverless-wsgi==3.0.2 flask==2.2.3 aiobotocore==2.5.1 --target="${fixturesDirname}/test_dependencies"`
     );
     exec(
       [

--- a/node/test/utils/normalize-events.js
+++ b/node/test/utils/normalize-events.js
@@ -30,11 +30,11 @@ module.exports = (events) =>
               throw new Error(`Unexpected warning type: ${tags.warning.type}`);
           }
         case 'telemetry.notice.generated.v1':
-          switch (tags.warning.type) {
+          switch (tags.notice.type) {
             case 1:
               return 'NOTICE_TYPE_SDK_INTERNAL';
             default:
-              throw new Error(`Unexpected notice type: ${tags.warning.type}`);
+              throw new Error(`Unexpected notice type: ${tags.notice.type}`);
           }
         default:
           throw new Error(`Unexpected event name: ${name}`);

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -23,14 +23,15 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "serverless-sdk~=0.5.1",
+    "serverless-sdk~=0.5.2",
     "serverless-sdk-schema~=0.2.3",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]
 [project.optional-dependencies]
 tests = [
+    "aiobotocore>=2.5.1",
     "black>=22.12",
-    "boto3>=1.16.112",
+    "boto3>=1.25.1",
     "flask>=2.2.3",
     "importlib_metadata>=5.2", # included in Python >=3.8
     "mypy>=1.2",

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/payload_conversion.py
@@ -5,6 +5,11 @@ with internally_imported():
     from google.protobuf import json_format
 
 
+@internally_imported()
+def serialize_to_string(trace: TracePayload) -> str:
+    return trace.SerializeToString()
+
+
 def to_trace_payload(payload_dct: dict) -> TracePayload:
     spans = payload_dct["spans"]
     events = payload_dct["events"]

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiobotocore_requester.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiobotocore_requester.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import asyncio
+from botocore.client import Config
+from botocore import UNSIGNED
+
+
+async def get_s3_object():
+    bucket = "cloudformation-examples-us-east-1"
+    key = "cloudformation_graphic.png"
+
+    from aiobotocore.session import get_session
+
+    session = get_session()
+    async with session.create_client(
+        "s3",
+        region_name="us-east-1",
+        config=Config(signature_version=UNSIGNED),
+    ) as client:
+        resp = await client.get_object(Bucket=bucket, Key=key)
+        body = await resp["Body"].read()
+        if not len(body) > 0:
+            raise Exception("Unable to read data from the response")
+
+
+def handler(event, context) -> str:
+    sys.path.append(str(Path(__file__).parent / "test_dependencies"))
+    asyncio.run(get_s3_object())
+    sys.path.pop()
+    return "ok"
+
+
+if __name__ == "__main__":
+    handler({}, None)

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiohttp_requester.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/aiohttp_requester.py
@@ -28,7 +28,9 @@ def make_http_request(url):
     async def _request():
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers={"someHeader": "bar"}) as resp:
-                await resp.text()
+                body = await resp.text()
+                if not body:
+                    raise Exception("Could not read response body.")
 
     asyncio.run(_request())
     sys.path.pop()

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/http_requester.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/http_requester.py
@@ -29,7 +29,9 @@ def make_http_request(host, path, use_ssl=False):
             conn = http.client.HTTPConnection(host)
         conn.request("GET", path, headers={"someHeader": "bar"})
         response = conn.getresponse()
-        response.read()
+        body = response.read()
+        if not body:
+            raise Exception("Could not read response body.")
     finally:
         if conn:
             conn.close()


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1204/python-sdk-users-seeing-errors-since-last-update#comment-22495198
* Builds up on https://github.com/serverless/console/pull/830 and should be rebased/reviewed after that PR is in
* Add integration tests for validating customer's use case that involves interaction with `aiobotocore`.
* Fix notice event validation in integration tests
* Fix internal event object name to make sure we don't shadow the attribute from `threading` module (`_is_stopped` is an internal attribute in `Thread` objects)
* Improve internal imports by minimizing the scope, so that the lock is not held for long times.

### Testing done
Unit & integration tested.