### PR TITLE
fix: Ensure NODE_PATH always contains required paths

### DIFF
--- a/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
+++ b/node/packages/aws-lambda-sdk/internal-extension/wrapper.js
@@ -4,6 +4,14 @@
 
 'use strict';
 
+// We need to ensure the node path always contains the runtime path. If it does not
+// We fail to resolve our local import of `@serverless/sdk` in the `serverlessSdk` initialization at the root of this
+// package.
+if (process.env.NODE_PATH && !process.env.NODE_PATH.includes('/opt/nodejs/node_modules')) {
+  process.env.NODE_PATH += ':/opt/nodejs/node_modules';
+  require('module').Module._initPaths();
+}
+
 process.env._HANDLER = process.env._ORIGIN_HANDLER;
 delete process.env._ORIGIN_HANDLER;
 

--- a/node/packages/aws-lambda-sdk/test/integration/index.test.js
+++ b/node/packages/aws-lambda-sdk/test/integration/index.test.js
@@ -355,6 +355,21 @@ describe('integration', function () {
     }),
   };
 
+  const nodePathMutatedConfiguration = {
+    configuration: {
+      Environment: {
+        Variables: {
+          AWS_LAMBDA_EXEC_WRAPPER: '/opt/sls-sdk-node/exec-wrapper.sh',
+          SLS_ORG_ID: process.env.SLS_ORG_ID,
+          NODE_PATH: './:/opt/:/opt/node_modules:/opt/middleware/node_modules',
+        },
+      },
+    },
+    deferredConfiguration: () => ({
+      Layers: [coreConfig.layerInternalArn],
+    }),
+  };
+
   const resolveExpressInvoke = ({ pathname }, retryCount = 0) =>
     async function self(testConfig) {
       const startTime = process.hrtime.bigint();
@@ -640,6 +655,15 @@ describe('integration', function () {
           ['v14', { configuration: { Runtime: 'nodejs14.x' } }],
           ['v16', { configuration: { Runtime: 'nodejs16.x' } }],
           ['v18', { configuration: { Runtime: 'nodejs18.x' } }],
+          [
+            'mutated-node-path-v16',
+            {
+              configuration: {
+                ...nodePathMutatedConfiguration.configuration,
+                Runtime: 'nodejs16.x',
+              },
+            },
+          ],
           [
             'sampled',
             {


### PR DESCRIPTION
Resolves bug reported in [SC-1236](https://linear.app/serverless/issue/SC-1236/node-sdk-import-module-error-reported-by-user)

