### PR TITLE
Fix logging instrumentation

### DIFF
--- a/python/packages/sdk/tests/lib/instrumentation/test_logging.py
+++ b/python/packages/sdk/tests/lib/instrumentation/test_logging.py
@@ -40,6 +40,60 @@ def test_instrument_error_with_multiple_arguments(instrumented_logging, monkeypa
     mock.assert_called_once_with(error % args, origin="pythonLogging")
 
 
+def test_instrument_error_only_exception_as_argument(instrumented_logging, monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_error_captured_event",
+        mock,
+    )
+    ex = Exception("Something is wrong")
+
+    # when
+    logging.error(ex)
+
+    # then
+    mock.assert_called_once_with(ex, origin="pythonLogging")
+
+
+def test_instrument_error_integer_argument(instrumented_logging, monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_error_captured_event",
+        mock,
+    )
+
+    # when
+    logging.error(10)
+
+    # then
+    mock.assert_called_once_with("10", origin="pythonLogging")
+
+
+def test_instrument_error_invalid_usage(instrumented_logging, monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_error_captured_event",
+        mock,
+    )
+    error = None
+
+    # when
+    try:
+        logging.error(10, 10)
+    except TypeError as ex:
+        error = ex
+
+    # then
+    assert error
+    mock.assert_not_called()
+
+
 def test_instrument_warning(instrumented_logging, monkeypatch):
     # given
     mock = MagicMock()
@@ -114,3 +168,59 @@ def test_instrument_warning_recognize_sdk_error(instrumented_logging, monkeypatc
     # then
     mock.assert_not_called()
     mock_json.assert_called_once_with(data, indent=2)
+
+
+def test_instrument_warning_only_exception_as_argument(
+    instrumented_logging, monkeypatch
+):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_warning_captured_event",
+        mock,
+    )
+    ex = Exception("Something is wrong")
+
+    # when
+    logging.warning(ex)
+
+    # then
+    mock.assert_called_once_with(ex, origin="pythonLogging")
+
+
+def test_instrument_warning_integer_argument(instrumented_logging, monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_warning_captured_event",
+        mock,
+    )
+
+    # when
+    logging.warning(10)
+
+    # then
+    mock.assert_called_once_with("10", origin="pythonLogging")
+
+
+def test_instrument_warning_invalid_usage(instrumented_logging, monkeypatch):
+    # given
+    mock = MagicMock()
+    monkeypatch.setattr(
+        instrumented_logging,
+        "create_warning_captured_event",
+        mock,
+    )
+    error = None
+
+    # when
+    try:
+        logging.warning(10, 10)
+    except TypeError as ex:
+        error = ex
+
+    # then
+    assert error
+    mock.assert_not_called()


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1249/loggingwarning-cannot-handle-passing-an-exception
* Mimic the logic of `Logger.error` & `Logger.warning` in terms of the interpretation of the arguments. The crucial part that was not working is stringifying the first argument and using it as a formatter: https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L387
* Handle exceptions in the `warning` method as we do in `error`, passing it as is without stringifying it because it will get stringified in a different way within the `create_warning_captured_event` method.

### Testing done
Reproduced customer's exact issue and more in a unit test