### PR TITLE
Add set_endpoint method to SDK

### DIFF
--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -87,6 +87,7 @@ class ServerlessSdk:
     _is_debug_mode: bool
     _is_dev_mode: bool
     _maximum_body_byte_length: int
+    _user_defined_endpoint: Optional[str] = None
 
     def __init__(self):
         self._is_initialized = False
@@ -174,6 +175,9 @@ class ServerlessSdk:
             self._custom_tags._set(name, value)
         except Exception as ex:
             report_error(ex, type="USER")
+
+    def set_endpoint(self, endpoint: str):
+        self._user_defined_endpoint = endpoint
 
 
 serverlessSdk: Final[ServerlessSdk] = ServerlessSdk()

--- a/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
+++ b/python/packages/sdk/sls_sdk/lib/instrumentation/flask.py
@@ -85,11 +85,12 @@ class Instrumenter:
         if not self._flask.request.endpoint:
             return
         try:
-            if self._flask.request.path:
+            endpoint = serverlessSdk._user_defined_endpoint or self._flask.request.path
+            if endpoint:
                 del serverlessSdk.trace_spans.root.tags["aws.lambda.http_router.path"]
                 serverlessSdk.trace_spans.root.tags[
                     "aws.lambda.http_router.path"
-                ] = self._flask.request.path
+                ] = endpoint
             span_name = ".".join(
                 [
                     "flask",


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1241/python-sdk-add-support-for-setendpoint
* Add `set_endpoint` SDK method to let users override `aws.lambda.http_router.path` tag

### Testing done
* Unit tested
* Integration tests are passing
