### PR TITLE
Python lambda sdk set endpoint

### DIFF
--- a/node/test/python/aws-lambda-sdk/integration.test.js
+++ b/node/test/python/aws-lambda-sdk/integration.test.js
@@ -991,6 +991,338 @@ describe('Python: integration', function () {
       },
     ],
     [
+      'sdk_set_endpoint',
+      {
+        variants: new Map([
+          [
+            'rest-api',
+            {
+              hooks: {
+                afterCreate: async (testConfig) => {
+                  const restApiId = (testConfig.restApiId = (
+                    await awsRequest(APIGateway, 'createRestApi', {
+                      name: testConfig.configuration.FunctionName,
+                    })
+                  ).id);
+                  const deferredAddPermission = awsRequest(Lambda, 'addPermission', {
+                    FunctionName: testConfig.configuration.FunctionName,
+                    Principal: '*',
+                    Action: 'lambda:InvokeFunction',
+                    SourceArn: `arn:aws:execute-api:${process.env.AWS_REGION}:${coreConfig.accountId}:${restApiId}/*/*`,
+                    StatementId: 'rest-api',
+                  });
+                  const rootResourceId = (
+                    await awsRequest(APIGateway, 'getResources', {
+                      restApiId,
+                    })
+                  ).items[0].id;
+                  const interimResourceId = (
+                    await awsRequest(APIGateway, 'createResource', {
+                      restApiId,
+                      parentId: rootResourceId,
+                      pathPart: 'some-path',
+                    })
+                  ).id;
+                  const resourceId = (
+                    await awsRequest(APIGateway, 'createResource', {
+                      restApiId,
+                      parentId: interimResourceId,
+                      pathPart: '{param}',
+                    })
+                  ).id;
+                  await awsRequest(APIGateway, 'putMethod', {
+                    restApiId,
+                    resourceId,
+                    httpMethod: 'POST',
+                    authorizationType: 'NONE',
+                    requestParameters: { 'method.request.path.param': true },
+                  });
+                  await awsRequest(APIGateway, 'putIntegration', {
+                    restApiId,
+                    resourceId,
+                    httpMethod: 'POST',
+                    integrationHttpMethod: 'POST',
+                    type: 'AWS_PROXY',
+                    uri: `arn:aws:apigateway:${process.env.AWS_REGION}:lambda:path/2015-03-31/functions/${testConfig.functionArn}/invocations`,
+                  });
+                  await awsRequest(APIGateway, 'createDeployment', {
+                    restApiId,
+                    stageName: 'test',
+                  });
+                  await deferredAddPermission;
+                },
+                beforeDelete: async (testConfig) => {
+                  await awsRequest(APIGateway, 'deleteRestApi', {
+                    restApiId: testConfig.restApiId,
+                  });
+                },
+              },
+              invoke: async function self(testConfig) {
+                const startTime = process.hrtime.bigint();
+                const response = await fetch(
+                  `https://${testConfig.restApiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test/some-path/some-param`,
+                  {
+                    method: 'POST',
+                    body: JSON.stringify({ some: 'content' }),
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                  }
+                );
+                if (response.status !== 200) {
+                  if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
+                    await wait(1000);
+                    return self(testConfig);
+                  }
+                  throw new Error(`Unexpected response status: ${response.status}`);
+                }
+                const payload = { raw: await response.text() };
+                const duration = Math.round(Number(process.hrtime.bigint() - startTime) / 1000000);
+                log.debug('invoke response payload %s', payload.raw);
+                return { duration, payload };
+              },
+              test: ({ invocationsData, testConfig }) => {
+                for (const { trace } of invocationsData) {
+                  const { tags } = trace.spans[0];
+
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigateway.rest');
+
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.restApiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('test');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test/some-path/some-param');
+                  expect(tags.aws.lambda.apiGateway.request.pathParameterNames).to.deep.equal([
+                    'param',
+                  ]);
+
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
+
+                  expect(tags.aws.lambda.httpRouter.path).to.equal('/test/set/endpoint');
+                }
+              },
+            },
+          ],
+          [
+            'http-api-v1',
+            {
+              hooks: {
+                afterCreate: getCreateHttpApi('1.0'),
+                beforeDelete: async (testConfig) => {
+                  await awsRequest(ApiGatewayV2, 'deleteApi', { ApiId: testConfig.apiId });
+                },
+              },
+              invoke: async function self(testConfig) {
+                const startTime = process.hrtime.bigint();
+                const response = await fetch(
+                  `https://${testConfig.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test`,
+                  {
+                    method: 'POST',
+                    body: JSON.stringify({ some: 'content' }),
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                  }
+                );
+                if (response.status !== 200) {
+                  if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
+                    await wait(1000);
+                    return self(testConfig);
+                  }
+                  throw new Error(`Unexpected response status: ${response.status}`);
+                }
+                const payload = { raw: await response.text() };
+                const duration = Math.round(Number(process.hrtime.bigint() - startTime) / 1000000);
+                log.debug('invoke response payload %s', payload.raw);
+                return { duration, payload };
+              },
+              test: ({ invocationsData, testConfig }) => {
+                for (const { trace } of invocationsData) {
+                  const { tags } = trace.spans[0];
+
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigatewayv2.http.v1');
+
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.apiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('$default');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test');
+
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
+
+                  expect(tags.aws.lambda.httpRouter.path).to.equal('/test/set/endpoint');
+                }
+              },
+            },
+          ],
+          [
+            'http-api-v2',
+            {
+              hooks: {
+                afterCreate: getCreateHttpApi('2.0'),
+                beforeDelete: async (testConfig) => {
+                  await awsRequest(ApiGatewayV2, 'deleteApi', { ApiId: testConfig.apiId });
+                },
+              },
+              invoke: async function self(testConfig) {
+                const startTime = process.hrtime.bigint();
+                const response = await fetch(
+                  `https://${testConfig.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/test`,
+                  {
+                    method: 'POST',
+                    body: JSON.stringify({ some: 'content' }),
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                  }
+                );
+                if (response.status !== 200) {
+                  if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
+                    await wait(1000);
+                    return self(testConfig);
+                  }
+                  throw new Error(`Unexpected response status: ${response.status}`);
+                }
+                const payload = { raw: await response.text() };
+                const duration = Math.round(Number(process.hrtime.bigint() - startTime) / 1000000);
+                log.debug('invoke response payload %s', payload.raw);
+                return { duration, payload };
+              },
+              test: ({ invocationsData, testConfig }) => {
+                for (const { trace } of invocationsData) {
+                  const { tags } = trace.spans[0];
+
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.apigateway');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.apigatewayv2.http.v2');
+
+                  expect(tags.aws.lambda.apiGateway).to.have.property('accountId');
+                  expect(tags.aws.lambda.apiGateway.apiId).to.equal(testConfig.apiId);
+                  expect(tags.aws.lambda.apiGateway.apiStage).to.equal('$default');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('id');
+                  expect(tags.aws.lambda.apiGateway.request).to.have.property('timeEpoch');
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test');
+
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
+
+                  expect(tags.aws.lambda.httpRouter.path).to.equal('/test/set/endpoint');
+                }
+              },
+            },
+          ],
+          [
+            'function-url',
+            {
+              hooks: {
+                afterCreate: async function self(testConfig) {
+                  await awsRequest(Lambda, 'createAlias', {
+                    FunctionName: testConfig.configuration.FunctionName,
+                    FunctionVersion: '$LATEST',
+                    Name: 'url',
+                  });
+                  const deferredFunctionUrl = (async () => {
+                    try {
+                      return (
+                        await awsRequest(Lambda, 'createFunctionUrlConfig', {
+                          AuthType: 'NONE',
+                          FunctionName: testConfig.configuration.FunctionName,
+                          Qualifier: 'url',
+                        })
+                      ).FunctionUrl;
+                    } catch (error) {
+                      if (
+                        error.message.includes('FunctionUrlConfig exists for this Lambda function')
+                      ) {
+                        return (
+                          await awsRequest(Lambda, 'getFunctionUrlConfig', {
+                            FunctionName: testConfig.configuration.FunctionName,
+                            Qualifier: 'url',
+                          })
+                        ).FunctionUrl;
+                      }
+                      throw error;
+                    }
+                  })();
+                  await Promise.all([
+                    deferredFunctionUrl,
+                    awsRequest(Lambda, 'addPermission', {
+                      FunctionName: testConfig.configuration.FunctionName,
+                      Qualifier: 'url',
+                      FunctionUrlAuthType: 'NONE',
+                      Principal: '*',
+                      Action: 'lambda:InvokeFunctionUrl',
+                      StatementId: 'public-function-url',
+                    }),
+                  ]);
+                  testConfig.functionUrl = await deferredFunctionUrl;
+                },
+                beforeDelete: async (testConfig) => {
+                  await awsRequest(Lambda, 'deleteFunctionUrlConfig', {
+                    FunctionName: testConfig.configuration.FunctionName,
+                    Qualifier: 'url',
+                  });
+                },
+              },
+              invoke: async function self(testConfig) {
+                const startTime = process.hrtime.bigint();
+                const response = await fetch(`${testConfig.functionUrl}/test?foo=bar`, {
+                  method: 'POST',
+                  body: JSON.stringify({ some: 'content' }),
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                });
+                if (response.status !== 200) {
+                  if (response.status === 404) {
+                    log.debug('Retrying invocation of %s', testConfig.name);
+                    await wait(1000);
+                    return self(testConfig);
+                  }
+                  throw new Error(`Unexpected response status: ${response.status}`);
+                }
+                const payload = { raw: await response.text() };
+                const duration = Math.round(Number(process.hrtime.bigint() - startTime) / 1000000);
+                log.debug('invoke response payload %s', payload.raw);
+                return { duration, payload };
+              },
+              test: ({ invocationsData }) => {
+                for (const { trace } of invocationsData) {
+                  const { tags } = trace.spans[0];
+
+                  expect(tags.aws.lambda.eventSource).to.equal('aws.lambda');
+                  expect(tags.aws.lambda.eventType).to.equal('aws.lambda.url');
+
+                  expect(tags.aws.lambda.http).to.have.property('host');
+                  expect(tags.aws.lambda.http).to.have.property('requestHeaderNames');
+                  expect(tags.aws.lambda.http.method).to.equal('POST');
+                  expect(tags.aws.lambda.http.path).to.equal('/test');
+
+                  expect(tags.aws.lambda.http.statusCode.toString()).to.equal('200');
+
+                  expect(tags.aws.lambda.httpRouter.path).to.equal('/test/set/endpoint');
+                }
+              },
+            },
+          ],
+        ]),
+      },
+    ],
+    [
       'sdk',
       {
         variants: new Map([

--- a/python/packages/aws-lambda-sdk/pyproject.toml
+++ b/python/packages/aws-lambda-sdk/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "serverless-sdk~=0.5.2",
+    "serverless-sdk~=0.5.4",
     "serverless-sdk-schema~=0.2.3",
     "typing-extensions~=4.5", # included in Python 3.8 - 3.11
 ]

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/__init__.py
@@ -496,6 +496,12 @@ class Instrumenter:
             if serverlessSdk.trace_spans.aws_lambda_invocation:
                 serverlessSdk.trace_spans.aws_lambda_invocation.close(end_time=end_time)
 
+            if serverlessSdk._user_defined_endpoint:
+                del self.aws_lambda.tags["aws.lambda.http_router.path"]
+                self.aws_lambda.tags[
+                    "aws.lambda.http_router.path"
+                ] = serverlessSdk._user_defined_endpoint
+
             self.aws_lambda.close(end_time=end_time)
             self._flush_and_close_event_loop()
 

--- a/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk_set_endpoint.py
+++ b/python/packages/aws-lambda-sdk/tests/fixtures/lambdas/sdk_set_endpoint.py
@@ -1,0 +1,10 @@
+import json
+from serverless_sdk import serverlessSdk as sdk
+
+
+def handler(event, context) -> str:
+    sdk.set_endpoint("/test/set/endpoint")
+    return {
+        "statusCode": 200,
+        "body": json.dumps("ok"),
+    }


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-1241/python-sdk-add-support-for-setendpoint
* Override `aws.lambda.http_router.path` tag with user defined value
* Upgrade to latest base SDK version

### Testing done
Integration tested