### PR TITLE
Add create_span SDK method

### DIFF
--- a/python/packages/sdk/sls_sdk/__init__.py
+++ b/python/packages/sdk/sls_sdk/__init__.py
@@ -179,5 +179,8 @@ class ServerlessSdk:
     def set_endpoint(self, endpoint: str):
         self._user_defined_endpoint = endpoint
 
+    def create_span(self, name: str):
+        return self._create_trace_span(name)
+
 
 serverlessSdk: Final[ServerlessSdk] = ServerlessSdk()

--- a/python/packages/sdk/sls_sdk/lib/trace.py
+++ b/python/packages/sdk/sls_sdk/lib/trace.py
@@ -102,6 +102,13 @@ class TraceSpan:
     def __repr__(self):
         return self.__str__()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        if self.end_time is None:
+            self.close()
+
     @staticmethod
     def resolve_current_span() -> Optional[TraceSpan]:
         # Current span is resolved in the following order:

--- a/python/packages/sdk/tests/lib/test_trace_span.py
+++ b/python/packages/sdk/tests/lib/test_trace_span.py
@@ -64,17 +64,17 @@ def test_span_with_context_manager():
         assert span.end_time is None, "should be open"
 
     # when & then
-    with TraceSpan("foo") as _outer_span:
-        assert_open(_outer_span, "foo")
+    with TraceSpan("outer") as _outer_span:
+        assert_open(_outer_span, "outer")
         outer_span = _outer_span
 
-        with TraceSpan("bar") as _inner_span:
-            assert_open(_outer_span, "foo")
-            assert_open(_inner_span, "bar")
+        with TraceSpan("inner") as _inner_span:
+            assert_open(_outer_span, "outer")
+            assert_open(_inner_span, "inner")
             inner_span = _inner_span
 
         assert inner_span.end_time is not None, "inner span should be closed"
-        assert_open(_outer_span, "foo")
+        assert_open(_outer_span, "outer")
 
     assert outer_span.end_time is not None, "outer span should be closed"
 

--- a/python/packages/sdk/tests/lib/test_trace_span.py
+++ b/python/packages/sdk/tests/lib/test_trace_span.py
@@ -18,10 +18,12 @@ def test_root_span():
     root_span = TraceSpan("root")
 
     # then
-    assert type(root_span.trace_id) == str, "should automatically generate `trace_id`"
-    assert type(root_span.id) == str, "should automatically generate `id`"
-    assert (
-        type(root_span.start_time) == int
+    assert isinstance(
+        root_span.trace_id, str
+    ), "should automatically generate `trace_id`"
+    assert isinstance(root_span.id, str), "should automatically generate `id`"
+    assert isinstance(
+        root_span.start_time, int
     ), "should automatically generate `start_time`"
 
 
@@ -39,10 +41,10 @@ def test_sub_span():
     assert (
         child_span.trace_id == root_span.trace_id
     ), "should expose `trace_id` of a root span"
-    assert type(child_span.id) == str, "should automatically generate `id`"
+    assert isinstance(child_span.id, str), "should automatically generate `id`"
     assert child_span.id != root_span.id, "should have a unique `id`"
-    assert (
-        type(child_span.start_time) == int
+    assert isinstance(
+        child_span.start_time, int
     ), "should automatically generate `start_time`"
     assert (
         child_span.start_time != root_span.start_time

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -238,3 +238,38 @@ def test_initialize_extension(instrumented_sdk):
 
     # then
     instrumented_sdk._initialize_extension.assert_called_once_with("foo", bar="baz")
+
+
+def test_sdk_exposes_create_span(instrumented_sdk):
+    # given
+    span_name = "foo"
+
+    # when
+    span = instrumented_sdk.create_span(span_name)
+
+    # then
+    assert span.name == span_name
+    assert span.start_time is not None
+    assert span.end_time is None
+    assert span.spans == [span]
+
+    # when
+    span.close()
+
+    # then
+    assert span.end_time is not None
+
+
+def test_sdk_exposes_create_span_with_context_manager(instrumented_sdk):
+    # given
+    span_name = "foo"
+
+    # when
+    with instrumented_sdk.create_span(span_name) as span:
+        # then
+        assert span.name == span_name
+        assert span.start_time is not None
+        assert span.end_time is None
+        assert span.spans == [span]
+
+    assert span.end_time is not None

--- a/python/packages/sdk/tests/test_sdk.py
+++ b/python/packages/sdk/tests/test_sdk.py
@@ -273,3 +273,27 @@ def test_sdk_exposes_create_span_with_context_manager(instrumented_sdk):
         assert span.spans == [span]
 
     assert span.end_time is not None
+
+
+def test_sdk_exposes_create_span_with_context_manager_throwing_exception(
+    instrumented_sdk,
+):
+    # given
+    span_name = "foo"
+    exception = None
+
+    # when
+    try:
+        with instrumented_sdk.create_span(span_name) as span:
+            # then
+            assert span.name == span_name
+            assert span.start_time is not None
+            assert span.end_time is None
+            assert span.spans == [span]
+
+            raise Exception("My error")
+    except Exception as e:
+        exception = e
+
+    assert span.end_time is not None
+    assert exception is not None


### PR DESCRIPTION
### Description
* Related issue https://linear.app/serverless/issue/SC-596/python-sdk-add-support-for-custom-spans
* Add `create_span` method
* Make the `TraceSpan` a context manager and auto close the span

### Testing done
* Unit tested