### PR TITLE
Fix response tag handling

### DIFF
--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/response_tags.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/response_tags.py
@@ -4,16 +4,29 @@ from .api_events import is_api_event
 aws_lambda_span = serverlessSdk.trace_spans.aws_lambda
 
 
+def _get_response_status_code(response):
+    status_code = None
+    if response and isinstance(response, dict):
+        status_code = response.get("statusCode")
+
+    if status_code is None:
+        return None
+
+    try:
+        return int(status_code)
+    except Exception:
+        return None
+
+
 def resolve(response):
     if not is_api_event():
         return
 
-    status_code = response and response.get("statusCode")
+    status_code = _get_response_status_code(response)
     if status_code is None:
         aws_lambda_span.tags.set("aws.lambda.http.error_code", "MISSING_STATUS_CODE")
         return
 
-    status_code = int(status_code)
     if status_code >= 100 and status_code < 600:
         aws_lambda_span.tags.set("aws.lambda.http.status_code", status_code)
     else:

--- a/python/packages/aws-lambda-sdk/tests/instrument/lib/test_response_tags.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/lib/test_response_tags.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+from unittest.mock import MagicMock, patch
+
+
+def test_non_api_event(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.response_tags import resolve
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    # when
+    with patch(
+        "serverless_aws_lambda_sdk.instrument.lib.response_tags.is_api_event"
+    ) as mock_is_api_event:
+        mock_is_api_event.return_value = False
+        resolve(None)
+
+    # then
+    mock_is_api_event.assert_called_once()
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.status_code"
+    )
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.error_code"
+    )
+
+
+def test_api_event_success(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.response_tags import resolve
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    status_code = 200
+
+    # when
+    with patch(
+        "serverless_aws_lambda_sdk.instrument.lib.response_tags.is_api_event"
+    ) as mock_is_api_event:
+        mock_is_api_event.return_value = True
+        resolve({"statusCode": str(status_code)})
+
+    # then
+    mock_is_api_event.assert_called_once()
+    assert (
+        serverlessSdk.trace_spans.aws_lambda.tags["aws.lambda.http.status_code"]
+        == status_code
+    )
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.error_code"
+    )
+
+
+def test_api_event_invalid_status_code(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.response_tags import resolve
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    status_code = 900
+
+    # when
+    with patch(
+        "serverless_aws_lambda_sdk.instrument.lib.response_tags.is_api_event"
+    ) as mock_is_api_event:
+        mock_is_api_event.return_value = True
+        resolve({"statusCode": str(status_code)})
+
+    # then
+    mock_is_api_event.assert_called_once()
+    assert (
+        serverlessSdk.trace_spans.aws_lambda.tags["aws.lambda.http.error_code"]
+        == "INVALID_STATUS_CODE"
+    )
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.status_code"
+    )
+
+
+def test_api_event_error(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.response_tags import resolve
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    status_code = 200
+
+    # when
+    with patch(
+        "serverless_aws_lambda_sdk.instrument.lib.response_tags.is_api_event"
+    ) as mock_is_api_event:
+        mock_is_api_event.return_value = True
+        resolve(str(status_code))
+
+    # then
+    mock_is_api_event.assert_called_once()
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.status_code"
+    )
+    assert not hasattr(
+        serverlessSdk.trace_spans.aws_lambda.tags, "aws.lambda.http.error_code"
+    )


### PR DESCRIPTION
### Description
* Fixes https://linear.app/serverless/issue/SC-1653/python-sdk-error-user-instrumented-functions-and-all-functions-started
* My only explanation is that somehow the customer is using AWS Lambda to implement an http API but failing to return a dictionary with "statusCode" field in it and we fail to properly surface the issue.
* This will fix the status code extraction logic to make sure it doesn't fail and instead just report that the status code is missing.

### Testing done
Unit tested