### PR TITLE
Improve http status code inference

### DIFF
--- a/.github/workflows/python-validate.yml
+++ b/.github/workflows/python-validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd python/packages
 
-          python3 -m pip install tox pyproject-fmt
+          python3 -m pip install tox pyproject-fmt==0.13.1
 
           for directory in */; do
             if [ -f "$directory/pyproject.toml" ]; then

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/api_events.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/api_events.py
@@ -11,3 +11,9 @@ def is_api_event():
         "aws.lambda.url",
         "aws.elasticloadbalancing.http",
     ]
+
+
+def is_api_gateway_v2_event():
+    return (
+        aws_lambda_span.tags.get("aws.lambda.event_type") == "aws.apigatewayv2.http.v2"
+    )

--- a/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/response_tags.py
+++ b/python/packages/aws-lambda-sdk/serverless_aws_lambda_sdk/instrument/lib/response_tags.py
@@ -1,5 +1,5 @@
 from .sdk import serverlessSdk
-from .api_events import is_api_event
+from .api_events import is_api_event, is_api_gateway_v2_event
 
 aws_lambda_span = serverlessSdk.trace_spans.aws_lambda
 
@@ -10,7 +10,7 @@ def _get_response_status_code(response):
         status_code = response.get("statusCode")
 
     if status_code is None:
-        return None
+        return 200 if is_api_gateway_v2_event() else None
 
     try:
         return int(status_code)

--- a/python/packages/aws-lambda-sdk/tests/instrument/lib/test_api_events.py
+++ b/python/packages/aws-lambda-sdk/tests/instrument/lib/test_api_events.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+
+def test_is_api_event_returns_true(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.api_events import is_api_event
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    serverlessSdk.trace_spans.aws_lambda.tags[
+        "aws.lambda.event_type"
+    ] = "aws.apigateway.rest"
+
+    # when
+    result = is_api_event()
+
+    # then
+    assert result
+
+
+def test_is_api_event_returns_false(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.api_events import is_api_event
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    serverlessSdk.trace_spans.aws_lambda.tags["aws.lambda.event_type"] = "aws.sqs"
+
+    # when
+    result = is_api_event()
+
+    # then
+    assert not result
+
+
+def test_is_api_gateway_v2_event_returns_true(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.api_events import (
+        is_api_gateway_v2_event,
+    )
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    serverlessSdk.trace_spans.aws_lambda.tags[
+        "aws.lambda.event_type"
+    ] = "aws.apigatewayv2.http.v2"
+
+    # when
+    result = is_api_gateway_v2_event()
+
+    # then
+    assert result
+
+
+def test_is_api_gateway_v2_event_returns_false(reset_sdk):
+    # given
+    from serverless_aws_lambda_sdk.instrument.lib.api_events import (
+        is_api_gateway_v2_event,
+    )
+    from serverless_aws_lambda_sdk import serverlessSdk
+
+    serverlessSdk.trace_spans.aws_lambda.tags[
+        "aws.lambda.event_type"
+    ] = "aws.apigatewayv2.http.v1"
+
+    # when
+    result = is_api_gateway_v2_event()
+
+    # then
+    assert not result


### PR DESCRIPTION
### Description
* Related issues
  * https://linear.app/serverless/issue/SC-1688/reported-python-layer-issue#comment-09018e19
  * https://github.com/serverless/dashboard/issues/884
* Report `aws.lambda.http.status_code` tag to have `200` success code if `statusCode` is not present in the response and the request is from api gateway v2 integration.
* Fix `pyproject-fmt` (project configuration linter) to `0.13.1` as the new release broke our formatting.

### Testing done
Unit tested